### PR TITLE
Add a mechanism to lookup the AMI from current region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## [v0.1.1] - 2018-06-07
+## [v0.1.2] - 2018-06-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v0.1.1] - 2018-06-07
+
+### Added
+
+- A way to detect AMI according to region while still allow user to overwrite it
+
 ## [v0.1.0] - 2018-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ module "eks" {
   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
   tags                  = "${map("Environment", "test")}"
   vpc_id                = "vpc-abcde012"
-  workers_ami_id        = "ami-123456"
   cluster_ingress_cidrs = ["24.18.23.91/32"]
 }
 ```
@@ -66,6 +65,14 @@ Report issues/questions/feature requests on in the [issues](https://github.com/t
 
 Full contributing [guidelines are covered here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/CONTRIBUTING.md).
 
+## AMI
+
+According to [AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html), we should use the EKS-optimized AMI. Unfortunately, the AMI is being rolled out quite slowly. So, we have a variable that set up the mapping between the region in which you are rolling out EKS with the AMI that we will be using for the instance.
+
+If you wish to use your own AMI, you can do so by overwriting this `mapping` action with the variable `workers_ami_id`. Otherwise, we will simply map from the region to the AMI via the map (no pun intended) in variable `workers_ami_mapping`.
+
+Please note that the maintainer of this module will try to keep the list as always up-to-date, but if for some reason you think it's out of date, please feel free to provide the correct value via that variable, and the module will look up correctly.
+
 ## IAM Permissions
 
 Testing and using this repo requires a minimum set of IAM permissions. Test permissions
@@ -94,7 +101,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | subnets | A list of subnets to associate with the cluster's underlying instances. | list | - | yes |
 | tags | A map of tags to add to all resources | string | `<map>` | no |
 | vpc_id | VPC id where the cluster and other resources will be deployed. | string | - | yes |
-| workers_ami_id | AMI ID for the eks workers. | string | - | yes |
+| workers_ami_id | AMI ID for the eks workers. | string | `` | no |
+| workers_ami_mapping | Mapping from the region to the [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html) | map | `<map>` | no |
 | workers_asg_desired_capacity | description | string | `1` | no |
 | workers_asg_max_size | description | string | `3` | no |
 | workers_asg_min_size | description | string | `1` | no |

--- a/local.tf
+++ b/local.tf
@@ -127,4 +127,7 @@ users:
         - "-i"
         - "${var.cluster_name}"
 KUBECONFIG
+
+  # A mechanism to detect the AMI that we wish to use
+  worker_instance_ami = "${length(var.workers_ami_mapping) > 0? var.workers_ami_id : lookup(var.eks_ami_mapping, data.aws_region.current.name)}"
 }

--- a/local.tf
+++ b/local.tf
@@ -129,5 +129,5 @@ users:
 KUBECONFIG
 
   # A mechanism to detect the AMI that we wish to use
-  worker_instance_ami = "${length(var.workers_ami_mapping) > 0? var.workers_ami_id : lookup(var.eks_ami_mapping, data.aws_region.current.name)}"
+  worker_instance_ami = "${length(var.workers_ami_mapping) > 0? var.workers_ami_id : lookup(var.workers_ami_mapping, data.aws_region.current.name)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,6 @@
 *   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
 *   tags                  = "${map("Environment", "test")}"
 *   vpc_id                = "vpc-abcde012"
-*   workers_ami_id        = "ami-123456"
 *   cluster_ingress_cidrs = ["24.18.23.91/32"]
 * }
 * ```
@@ -66,6 +65,15 @@ To test your kubectl connection manually, see the [eks_test_fixture README](http
 * Report issues/questions/feature requests on in the [issues](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/new) section.
 
 * Full contributing [guidelines are covered here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/CONTRIBUTING.md).
+
+## AMI
+
+
+According to [AWS guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html), we should use the EKS-optimized AMI. Unfortunately, the AMI is being rolled out quite slowly. So, we have a variable that set up the mapping between the region in which you are rolling out EKS with the AMI that we will be using for the instance.
+
+If you wish to use your own AMI, you can do so by overwriting this `mapping` action with the variable `workers_ami_id`. Otherwise, we will simply map from the region to the AMI via the map (no pun intended) in variable `workers_ami_mapping`.
+
+Please note that the maintainer of this module will try to keep the list as always up-to-date, but if for some reason you think it's out of date, please feel free to provide the correct value via that variable, and the module will look up correctly.
 
 * ## IAM Permissions
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "vpc_id" {
 
 variable "workers_ami_id" {
   description = "AMI ID for the eks workers."
+  default     = ""
 }
 
 variable "workers_asg_desired_capacity" {
@@ -48,4 +49,14 @@ variable "workers_asg_min_size" {
 variable "workers_instance_type" {
   description = "Size of the workers instances."
   default     = "m4.large"
+}
+
+variable "workers_ami_mapping" {
+  description = "Mapping from the region to the [EKS optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)"
+  type        = "map"
+
+  default = {
+    us-east-1 = "ami-dea4d5a1"
+    us-west-2 = "ami-73a6e20b"
+  }
 }

--- a/workers.tf
+++ b/workers.tf
@@ -19,7 +19,7 @@ resource "aws_launch_configuration" "workers" {
   associate_public_ip_address = true
   name_prefix                 = "${var.cluster_name}"
   iam_instance_profile        = "${aws_iam_instance_profile.workers.name}"
-  image_id                    = "${var.workers_ami_id}"
+  image_id                    = "${local.worker_instance_ami}"
   instance_type               = "${var.workers_instance_type}"
   security_groups             = ["${aws_security_group.workers.id}"]
   user_data_base64            = "${base64encode(local.workers_userdata)}"


### PR DESCRIPTION
# 2018-06-07 9:45 EST

## Description

I added a feature to support using EKS optimized AMI by looking that up automatically using a variable which user can overwrite. Also, user can specify directly what AMI the user wants rather than having to use the mapping.

This added the benefit of forcing users to use this module only in EKS supported regions for now (`us-east-1` and `us-west-2`

I tested this using an AWS account and everything seemed to work as expected.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Any breaking changes are noted in the description above
