### PR TITLE
WIP: Tighter security group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ Full contributing [guidelines are covered here](https://github.com/terraform-aws
 Testing and using this repo requires a minimum set of IAM permissions. Test permissions
 are listed in the [eks_test_fixture README](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/eks_test_fixture/README.md).
 
+## Security group
+
+According to [AWS documentation on EKS security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html), you can set up the security group for worker nodes and control plane according to the minimum requirements or the recommended way.
+
+The module try to accommodate all possible settings that you might wish to have. Even including the ability to set additional security group onto the node and plane instances.
+
+*Since you will be running applications on these worker node, you will want to set additional security group(s) on them to grant the access for those application**
+
+In particular, you can control whether the worker node has egress connection everywhere or not, which port range is allowed for communication between control plane and worker node.
+
+The default setting of the module follow the recommended set up as per AWS guide, but you can always switch to other settings. As mentioned earlier, you can even add more security groups onto the instances to customize things even more according to your needs.
+
+These are done via the following variables
+`worker_node_allow_all_egress` (default `true`)
+`cp_to_wn_from_port` (default `1025`)
+`cp_to_wn_to_port` (default `65355`)
+
+Please note that if we follow **only the minimum rules for worker node**, they will only be able to communicate with the control plane on TCP:443.
+
 ## Change log
 
 The [changelog](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/CHANGELOG.md) captures all important release notes.
@@ -91,9 +110,13 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_ingress_cidrs | The CIDRs from which we can execute kubectl commands. | list | - | yes |
 | cluster_name | Name of the EKS cluster. | string | - | yes |
 | cluster_version | Kubernetes version to use for the cluster. | string | `1.10` | no |
+| cp_to_wn_from_port | The From port for the rules connecting our control plane to worker node | string | `1025` | no |
+| cp_to_wn_to_port | The to port for the rules connecting our control plane to worker node | string | `65535` | no |
 | subnets | A list of subnets to associate with the cluster's underlying instances. | list | - | yes |
 | tags | A map of tags to add to all resources | string | `<map>` | no |
 | vpc_id | VPC id where the cluster and other resources will be deployed. | string | - | yes |
+| worker_node_allow_all_egress | Specify whether you wish to allow worker node egress everwhere on all ports | string | `true` | no |
+| workers_additional_sgs | A list of security group IDs which we want to set onto the worker nodes instances | list | `<list>` | no |
 | workers_ami_id | AMI ID for the eks workers. | string | - | yes |
 | workers_asg_desired_capacity | description | string | `1` | no |
 | workers_asg_max_size | description | string | `3` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -31,6 +31,16 @@ resource "aws_security_group_rule" "cluster_egress_internet" {
   type              = "egress"
 }
 
+resource "aws_security_group_rule" "cluster_egress_worker_node" {
+  description              = "Allow control plane to connect to worker node on selected port"
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.cluster.id}"
+  source_security_group_id = "${aws_security_group.workers.id}"
+  from_port                = "${var.cp_to_wn_from_port}"
+  to_port                  = "${var.cp_to_wn_to_port}"
+  type                     = "egress"
+}
+
 resource "aws_security_group_rule" "cluster_https_worker_ingress" {
   description              = "Allow pods to communicate with the cluster API Server."
   protocol                 = "tcp"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 /**
 # terraform-aws-eks
 
-* A terraform module to create a managed Kubernetes cluster on AWS EKS. Available 
+* A terraform module to create a managed Kubernetes cluster on AWS EKS. Available
 * through the [Terraform registry](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws).
 * Inspired by and adapted from [this doc](https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html)
 * and its [source code](https://github.com/terraform-providers/terraform-provider-aws/tree/master/examples/eks-getting-started).
@@ -71,6 +71,25 @@ To test your kubectl connection manually, see the [eks_test_fixture README](http
 
 * Testing and using this repo requires a minimum set of IAM permissions. Test permissions
 * are listed in the [eks_test_fixture README](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/eks_test_fixture/README.md).
+
+## Security group
+
+According to [AWS documentation on EKS security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html), you can set up the security group for worker nodes and control plane according to the minimum requirements or the recommended way.
+
+The module try to accommodate all possible settings that you might wish to have. Even including the ability to set additional security group onto the node and plane instances.
+
+**Since you will be running applications on these worker node, you will want to set additional security group(s) on them to grant the access for those application**
+
+In particular, you can control whether the worker node has egress connection everywhere or not, which port range is allowed for communication between control plane and worker node.
+
+The default setting of the module follow the recommended set up as per AWS guide, but you can always switch to other settings. As mentioned earlier, you can even add more security groups onto the instances to customize things even more according to your needs.
+
+These are done via the following variables
+* `worker_node_allow_all_egress` (default `true`)
+* `cp_to_wn_from_port` (default `1025`)
+* `cp_to_wn_to_port` (default `65355`)
+
+Please note that if we follow **only the minimum rules for worker node**, they will only be able to communicate with the control plane on TCP:443.
 
 * ## Change log
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,24 @@ variable "workers_instance_type" {
   description = "Size of the workers instances."
   default     = "m4.large"
 }
+
+variable "workers_additional_sgs" {
+  description = "A list of security group IDs which we want to set onto the worker nodes instances"
+  type        = "list"
+  default     = []
+}
+
+variable worker_node_allow_all_egress {
+  description = "Specify whether you wish to allow worker node egress everwhere on all ports"
+  default     = true
+}
+
+variable "cp_to_wn_from_port" {
+  description = "The From port for the rules connecting our control plane to worker node"
+  default     = 1025
+}
+
+variable "cp_to_wn_to_port" {
+  description = "The to port for the rules connecting our control plane to worker node"
+  default     = 65535
+}


### PR DESCRIPTION
# Improvement on security group

## Description

As per [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html), you can set up the Security groups for the control plane and worker node to have either minimum rules, or have more access according to _recommendation_ (ie. more relaxed rules and our instances more access).

I added 3 more variables to let the user specify which scenario they would want to use:

* `worker_node_allow_all_egress` (default `true`)
* `cp_to_wn_from_port` (default `1025`)
* `cp_to_wn_to_port` (default `65355`)

The default values of these correspond to the recommended case by AWS, but for any users who wish to set up a strict set of rules, they can provide different values to those variables, such as

* `worker_node_allow_all_egress = false`
* `cp_to_wn_from_port = 10250`
* `cp_to_wn_from_port = 10250`

Beside this, we also added the ability to provide a list of custom security groups that we would like to set onto the worker node. That will allow users to use other Terraform modules to set up the groups in the way that they like and then assign them onto the instance.

Since it's possible that user can set `worker_node_allow_all_egress = false`, we have to add one more security group rule resource to allow worker node egress to allow communication within the worker nodes themselves.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Any breaking changes are noted in the description above
