### PR TITLE
kubectl now configurable by the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - files rendered from dedicated templates to separate out raw code and config from `hcl`
 - `workers_ami_id` is now made optional. If not specified, the module will source the latest AWS supported EKS AMI instead.
 - added ability to specify extra userdata code to execute after the second to configure and start kube services.
+- When `configure_kubectl_session` is set to true the current shell will be configured to talk to the kubernetes cluster using config files output from the module.
 
 ## [[v0.1.1](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v0.1.0...v0.1.1)] - 2018-06-07]
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ module "eks" {
   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
   tags                  = "${map("Environment", "test")}"
   vpc_id                = "vpc-abcde012"
-  workers_ami_id        = "ami-123456"
   cluster_ingress_cidrs = ["24.18.23.91/32"]
 }
 ```
@@ -92,6 +91,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_ingress_cidrs | The CIDRs from which we can execute kubectl commands. | list | - | yes |
 | cluster_name | Name of the EKS cluster which is also used as a prefix in names of related resources. | string | - | yes |
 | cluster_version | Kubernetes version to use for the cluster. | string | `1.10` | no |
+| config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. | string | `./` | no |
+| configure_kubectl_session | Configure the current session's kubectl to use the instantiated cluster. | string | `false` | no |
 | subnets | A list of subnets to associate with the cluster's underlying instances. | list | - | yes |
 | tags | A map of tags to add to all resources. | string | `<map>` | no |
 | vpc_id | VPC id where the cluster and other resources will be deployed. | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ module "eks" {
 }
 ```
 
+## Dependencies
+
+The `configure_kubectl_session` variable requires that both `[kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl)
+(>=1.10) and [`heptio-authenticator-aws`](https://github.com/heptio/authenticator#4-set-up-kubectl-to-use-heptio-authenticator-for-aws-tokens)
+are installed and on your shell's PATH.
+
 ## Testing
 
 This module has been packaged with [awspec](https://github.com/k1LoW/awspec) tests through [kitchen](https://kitchen.ci/) and [kitchen-terraform](https://newcontext-oss.github.io/kitchen-terraform/). To run them:

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -36,16 +36,6 @@ resource "random_string" "suffix" {
   special = false
 }
 
-resource "local_file" "kubeconfig" {
-  content  = "${module.eks.kubeconfig}"
-  filename = "${path.module}/kubeconfig"
-}
-
-resource "local_file" "config-map-aws-auth" {
-  content  = "${module.eks.config_map_aws_auth}"
-  filename = "${path.module}/config-map-aws-auth.yaml"
-}
-
 module "vpc" {
   source             = "terraform-aws-modules/vpc/aws"
   version            = "1.14.0"
@@ -60,12 +50,13 @@ module "vpc" {
 }
 
 module "eks" {
-  source                = "../.."
-  cluster_name          = "${local.cluster_name}"
-  subnets               = "${module.vpc.public_subnets}"
-  tags                  = "${local.tags}"
-  vpc_id                = "${module.vpc.vpc_id}"
-  cluster_ingress_cidrs = ["${local.workstation_external_cidr}"]
-  workers_instance_type = "t2.small"
-  additional_userdata   = "echo hello world"
+  source                    = "../.."
+  cluster_name              = "${local.cluster_name}"
+  subnets                   = "${module.vpc.public_subnets}"
+  tags                      = "${local.tags}"
+  vpc_id                    = "${module.vpc.vpc_id}"
+  cluster_ingress_cidrs     = ["${local.workstation_external_cidr}"]
+  workers_instance_type     = "t2.small"
+  additional_userdata       = "echo hello world"
+  configure_kubectl_session = true
 }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,6 @@
 *   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
 *   tags                  = "${map("Environment", "test")}"
 *   vpc_id                = "vpc-abcde012"
-*   workers_ami_id        = "ami-123456"
 *   cluster_ingress_cidrs = ["24.18.23.91/32"]
 * }
 * ```
@@ -88,3 +87,28 @@ To test your kubectl connection manually, see the [eks_test_fixture README](http
 
 provider "null" {}
 provider "template" {}
+
+resource "local_file" "kubeconfig" {
+  content  = "${data.template_file.kubeconfig.rendered}"
+  filename = "${var.config_output_path}/kubeconfig"
+  count    = "${var.configure_kubectl_session ? 1 : 0}"
+}
+
+resource "local_file" "config_map_aws_auth" {
+  content  = "${data.template_file.config_map_aws_auth.rendered}"
+  filename = "${var.config_output_path}/config-map-aws-auth.yaml"
+  count    = "${var.configure_kubectl_session ? 1 : 0}"
+}
+
+resource "null_resource" "configure_kubectl" {
+  provisioner "local-exec" {
+    command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth.yaml --kubeconfig ${var.config_output_path}/kubeconfig"
+  }
+
+  triggers {
+    config_map_rendered = "${data.template_file.config_map_aws_auth.rendered}"
+    kubeconfig_rendered = "${data.template_file.kubeconfig.rendered}"
+  }
+
+  count = "${var.configure_kubectl_session ? 1 : 0}"
+}

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,12 @@
 * }
 * ```
 
+* ## Dependencies
+
+* The `configure_kubectl_session` variable requires that both `[kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl)
+(>=1.10) and [`heptio-authenticator-aws`](https://github.com/heptio/authenticator#4-set-up-kubectl-to-use-heptio-authenticator-for-aws-tokens)
+are installed and on your shell's PATH.
+
 * ## Testing
 
 * This module has been packaged with [awspec](https://github.com/k1LoW/awspec) tests through [kitchen](https://kitchen.ci/) and [kitchen-terraform](https://newcontext-oss.github.io/kitchen-terraform/). To run them:

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,16 @@ variable "cluster_version" {
   default     = "1.10"
 }
 
+variable "config_output_path" {
+  description = "Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory."
+  default     = "./"
+}
+
+variable "configure_kubectl_session" {
+  description = "Configure the current session's kubectl to use the instantiated cluster."
+  default     = false
+}
+
 variable "subnets" {
   description = "A list of subnets to associate with the cluster's underlying instances."
   type        = "list"


### PR DESCRIPTION
# PR o'clock

## Description

As a consumer of the module, I want to have kubectl configured to use the cluster automatically.

Variables have been added to support outputting of config files and automatic configuration of kubectl for thecurrent shell session.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Any breaking changes are noted in the description above
