### PR TITLE
Add IAM role output

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig                         | kubectl config file contents for this EKS cluster.                                                                                                              |
 | worker_security_group_id           | Security group ID attached to the EKS workers.                                                                                                                  |
 | workers_asg_arns                   | IDs of the autoscaling groups containing workers.                                                                                                               |
+| worker_iam_role_name               | IAM role name attached to EKS workers.                                                                                                                          |

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,3 +48,8 @@ output "worker_security_group_id" {
   description = "Security group ID attached to the EKS workers."
   value       = "${local.worker_security_group_id}"
 }
+
+output "worker_iam_role_name" {
+  description = "IAM role name attached to EKS workers"
+  value       = "${aws_iam_role.workers.name}"
+}


### PR DESCRIPTION
# PR o'clock

## Description

Added output for IAM role name that is automatically created for all workers within AutoScallingGoup.
That would allow granting additional permissions for the worker nodes, like using S3 buckets etc.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [X] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
