### PR TITLE
Add option to run worker nodes in a subset of eks subnets (e.g. only …

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A full example leveraging other community modules is contained in the [examples/
 ```hcl
 module "eks" {
   source                = "terraform-aws-modules/eks/aws"
-  version               = "0.1.0"
+  version               = "1.0.0"
   cluster_name          = "test-eks-cluster"
   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
   tags                  = "${map("Environment", "test")}"
@@ -100,6 +100,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config_output_path        | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory.                                                                     | string |   `./`   |    no    |
 | configure_kubectl_session | Configure the current session's kubectl to use the instantiated EKS cluster.                                                                                                                                             | string |  `true`  |    no    |
 | subnets                   | A list of subnets to place the EKS cluster and workers within.                                                                                                                                                           |  list  |    -     |   yes    |
+| worker_subnets            | A list of subnets to place the EKS workers within. If empty then subnets variable will be used instead to place workers within.  |  list  |    []    |    no    |
 | tags                      | A map of tags to add to all resources.                                                                                                                                                                                   | string | `<map>`  |    no    |
 | vpc_id                    | VPC where the cluster and workers will be deployed.                                                                                                                                                                      | string |    -     |   yes    |
 | worker_groups             | A list of maps defining worker group configurations. See workers_group_defaults for valid keys.                                                                                                                          |  list  | `<list>` |    no    |

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -48,10 +48,11 @@ module "vpc" {
 }
 
 module "eks" {
-  source        = "../.."
-  cluster_name  = "${local.cluster_name}"
-  subnets       = "${module.vpc.public_subnets}"
-  tags          = "${local.tags}"
-  vpc_id        = "${module.vpc.vpc_id}"
-  worker_groups = "${local.worker_groups}"
+  source         = "../.."
+  cluster_name   = "${local.cluster_name}"
+  subnets        = ["${module.vpc.public_subnets}", "${module.vpc.private_subnets}"]
+  worker_subnets = "${module.vpc.private_subnets}"
+  tags           = "${local.tags}"
+  vpc_id         = "${module.vpc.vpc_id}"
+  worker_groups  = "${local.worker_groups}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,9 @@ variable "worker_security_group_id" {
   description = "If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster."
   default     = ""
 }
+
+variable "worker_subnets" {
+  description = "A list of subnets to place the EKS workers within. If empty then subnets variable will be used instead to place workers within."
+  type        = "list"
+  default     = []
+}

--- a/workers.tf
+++ b/workers.tf
@@ -4,7 +4,7 @@ resource "aws_autoscaling_group" "workers" {
   max_size             = "${lookup(var.worker_groups[count.index], "asg_max_size",lookup(var.workers_group_defaults, "asg_max_size"))}"
   min_size             = "${lookup(var.worker_groups[count.index], "asg_min_size",lookup(var.workers_group_defaults, "asg_min_size"))}"
   launch_configuration = "${element(aws_launch_configuration.workers.*.id, count.index)}"
-  vpc_zone_identifier  = ["${var.subnets}"]
+  vpc_zone_identifier  = ["${coalescelist(var.worker_subnets,var.subnets)}"]
   count                = "${length(var.worker_groups)}"
 
   tags = ["${concat(


### PR DESCRIPTION
…run workers in private subnets)

# PR o'clock

## Description

resolves #15 

The reason for this PR is to allow you to specify both private and public subnets when creating your eks cluster, but to only specify private subnets to create your worker nodes within (this is recommended in [this](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) AWS document).

The new variable added to achieve this is `worker_subnets`, it is an optional variable, current functionality will be unaffected if you do not use it. Below is an example of how using the new variable looks:
```
module "eks" {
  source       = "terraform-aws-modules/eks/aws"
  version        = "1.0.0"
  cluster_name   = "eks-test-1"
  subnets        = ["${module.vpc.public_subnets}", "${module.vpc.private_subnets}"]
  worker_subnets = ["${module.vpc.private_subnets}"]
  tags           = "${map("Managed", "terraform")}"
  vpc_id         = "${module.vpc.vpc_id}"
}
```

### Checklist

- [x ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above

I have not ran the test-kitchen tests as I am not currently able to, however I have created an eks cluster using this branch.