### PR TITLE
Adding configuration for public ip association, name_prefix in worker launch config

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,7 @@ variable "workers_group_defaults" {
     instance_type        = "m4.large"    # Size of the workers instances.
     additional_userdata  = ""            # userdata to append to the default userdata.
     ebs_optimized        = true          # sets whether to use ebs optimization on supported types.
+    public_ip            = false         # Associate a public ip address with a worker
   }
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -17,8 +17,8 @@ resource "aws_autoscaling_group" "workers" {
 }
 
 resource "aws_launch_configuration" "workers" {
-  name                        = "${var.cluster_name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
-  associate_public_ip_address = true
+  name_prefix                 = "${var.cluster_name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
+  associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(var.workers_group_defaults, "public_ip"))}"
   security_groups             = ["${local.worker_security_group_id}"]
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", data.aws_ami.eks_worker.id)}"


### PR DESCRIPTION
# PR o'clock

## Description

This PR makes to tweaks to worker launch configuration:
1. Changes name to name_prefix so Terraform can reattach modified launch configuration to autoscaling group
2. Adds configurable public IP attachment and defines default behavior to false.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
