### PR TITLE
Removing kube-proxy restart according to the new worker guide

### DIFF
--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  version = ">= 1.22.0"
+  version = ">= 1.24.0"
   region  = "${var.region}"
 }
 

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -24,7 +24,7 @@ sed -i s,CLIENT_CA_FILE,$CA_CERTIFICATE_FILE_PATH,g /etc/systemd/system/kubelet.
 
 # start services
 systemctl daemon-reload
-systemctl restart kubelet kube-proxy
+systemctl restart kubelet
 
 # Allow user supplied userdata code
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

This PR is intended to fix issues https://github.com/terraform-aws-modules/terraform-aws-eks/issues/24 and https://github.com/terraform-aws-modules/terraform-aws-eks/issues/24, also bumps AWS provider to the newest version (because why not).

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
