### PR TITLE
Fix typo in IAM policy for testing

### DIFF
--- a/examples/eks_test_fixture/README.md
+++ b/examples/eks_test_fixture/README.md
@@ -67,7 +67,7 @@ The following IAM policy is the minimum needed to execute the module from the te
         "ec2:DetachNetworkInterface",
         "ec2:DetachVolume",
         "ec2:Disassociate*",
-        "ModifySubnetAttribute",
+        "ec2:ModifySubnetAttribute",
         "ec2:ModifyVpcAttribute",
         "ec2:ModifyVpcEndpoint",
         "ec2:ReleaseAddress",


### PR DESCRIPTION

# PR o'clock

## Description

Fixed missing service type in the IAM policy for testing.

Using this policy (before fixing) resulted with the error:
`MalformedPolicyDocument: Actions/Conditions must be prefaced by a vendor, e.g., i
am, sdb, ec2, etc.`

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
