### PR TITLE
Fix error when using IPv6

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 data "http" "workstation_external_ip" {
-  url = "http://ipv4.icanhazip.com"
+  url = "https://ipv4.icanhazip.com"
 }
 
 data "aws_iam_policy_document" "workers_assume_role_policy" {

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 data "http" "workstation_external_ip" {
-  url = "http://icanhazip.com"
+  url = "http://ipv4.icanhazip.com"
 }
 
 data "aws_iam_policy_document" "workers_assume_role_policy" {


### PR DESCRIPTION
# PR o'clock

## Description

Fix error when using IPv6.

e.g.
(My IPv6 address is masked.)

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

data.http.workstation_external_ip: Refreshing state...
data.aws_region.current: Refreshing state...
data.aws_iam_policy_document.cluster_assume_role_policy: Refreshing state...
data.aws_iam_policy_document.workers_assume_role_policy: Refreshing state...
data.aws_ami.eks_worker: Refreshing state...

------------------------------------------------------------------------

Error: Error running plan: 1 error(s) occurred:

* module.eks.aws_security_group_rule.cluster_https_cidr_ingress: "cidr_blocks.0" must contain a valid network CIDR, got "xxxx:xxxx:xxxx:xxxx:xxxx:xxx:xxxx:xxxx/32"
```

To avoid the error above, use `http://ipv4.icanhazip.com`.

It also makes it safer using https.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
