### PR TITLE
adding capability to use non-default aws profile

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -51,6 +51,7 @@ data template_file kubeconfig {
     cluster_name        = "${var.cluster_name}"
     endpoint            = "${aws_eks_cluster.this.endpoint}"
     region              = "${data.aws_region.current.name}"
+    aws_profile         = "${var.aws_profile}"
     cluster_auth_base64 = "${aws_eks_cluster.this.certificate_authority.0.data}"
   }
 }

--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -25,3 +25,6 @@ users:
         - "token"
         - "-i"
         - "${cluster_name}"
+      env:
+        - name: AWS_PROFILE
+          value: ${aws_profile}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "aws_profile" {
+  description = "Name of the AWS profile to use in the generated kubeconfig."
+  default     = "default"
+  type        = "string"
+}
+
 variable "cluster_name" {
   description = "Name of the EKS cluster. Also used as a prefix in names of related resources."
 }


### PR DESCRIPTION
# PR o'clock

## Description

Fixes #39

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Any breaking changes are noted in the description above
