### PR TITLE
Bump module version in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A full example leveraging other community modules is contained in the [examples/
 ```hcl
 module "eks" {
   source                = "terraform-aws-modules/eks/aws"
-  version               = "0.1.0"
   cluster_name          = "test-eks-cluster"
   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
   tags                  = "${map("Environment", "test")}"


### PR DESCRIPTION
# PR o'clock

## Description

Copy/pasting the example is not working out of the box. It might take some time to notice the version difference.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Any breaking changes are noted in the description above
