### PR TITLE
Making kubeconfig file path and generated config unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume ["-r", "MyEksRole"] | string | `<list>` | no |
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | string | `<map>` | no |
-| kubeconfig_context_name | Name of the kubeconfig context. | string | `aws` | no |
-| kubeconfig_user_name | Name of the kubeconfig user. | string | `aws` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | string | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume ["-r", "MyEksRole"] | string | `<list>` | no |
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | string | `<map>` | no |
+| kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | string | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |

--- a/data.tf
+++ b/data.tf
@@ -49,6 +49,7 @@ data "template_file" "kubeconfig" {
 
   vars {
     cluster_name                      = "${var.cluster_name}"
+    kubeconfig_name                   = "${local.kubeconfig_name}"
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"

--- a/data.tf
+++ b/data.tf
@@ -52,8 +52,6 @@ data "template_file" "kubeconfig" {
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    context_name                      = "${var.kubeconfig_context_name}"
-    user_name                         = "${var.kubeconfig_user_name}"
     aws_authenticator_command         = "${var.kubeconfig_aws_authenticator_command}"
     aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : "" }"
     aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,6 +1,6 @@
 resource "local_file" "kubeconfig" {
   content  = "${data.template_file.kubeconfig.rendered}"
-  filename = "${var.config_output_path}/kubeconfig"
+  filename = "${var.config_output_path}/kubeconfig_eks_${data.aws_region.current.name}_${var.cluster_name}"
   count    = "${var.configure_kubectl_session ? 1 : 0}"
 }
 

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,18 +1,18 @@
 resource "local_file" "kubeconfig" {
   content  = "${data.template_file.kubeconfig.rendered}"
-  filename = "${var.config_output_path}/kubeconfig_eks_${data.aws_region.current.name}_${var.cluster_name}"
+  filename = "${var.config_output_path}/kubeconfig_${var.cluster_name}"
   count    = "${var.configure_kubectl_session ? 1 : 0}"
 }
 
 resource "local_file" "config_map_aws_auth" {
   content  = "${data.template_file.config_map_aws_auth.rendered}"
-  filename = "${var.config_output_path}/config-map-aws-auth.yaml"
+  filename = "${var.config_output_path}/config-map-aws-auth_${var.cluster_name}.yaml"
   count    = "${var.configure_kubectl_session ? 1 : 0}"
 }
 
 resource "null_resource" "configure_kubectl" {
   provisioner "local-exec" {
-    command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth.yaml --kubeconfig ${var.config_output_path}/kubeconfig"
+    command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth_${var.cluster_name}.yaml --kubeconfig ${var.config_output_path}/kubeconfig_${var.cluster_name}"
   }
 
   triggers {

--- a/local.tf
+++ b/local.tf
@@ -9,6 +9,8 @@ locals {
   workstation_external_cidr = "${chomp(data.http.workstation_external_ip.body)}/32"
   workstation_cidr          = "${coalesce(var.workstation_cidr, local.workstation_external_cidr)}"
 
+  kubeconfig_name = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
+
   # Mapping from the node type that we selected and the max number of pods that it can run
   # Taken from https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml
   max_pod_per_node = {

--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -6,18 +6,18 @@ clusters:
 - cluster:
     server: ${endpoint}
     certificate-authority-data: ${cluster_auth_base64}
-  name: eks_${region}_${cluster_name}
+  name: ${kubeconfig_name}
 
 contexts:
 - context:
-    cluster: eks_${region}_${cluster_name}
-    user: eks_${region}_${cluster_name}
-  name: eks_${region}_${cluster_name}
+    cluster: ${kubeconfig_name}
+    user: ${kubeconfig_name}
+  name: ${kubeconfig_name}
 
-current-context: eks_${region}_${cluster_name}
+current-context: ${kubeconfig_name}
 
 users:
-- name: eks_${region}_${cluster_name}
+- name: ${kubeconfig_name}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1

--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -6,17 +6,18 @@ clusters:
 - cluster:
     server: ${endpoint}
     certificate-authority-data: ${cluster_auth_base64}
-  name: ${cluster_name}
+  name: eks_${region}_${cluster_name}
 
 contexts:
 - context:
-    cluster: ${cluster_name}
-    user: ${user_name}
-  name: ${context_name}
-current-context: ${context_name}
+    cluster: eks_${region}_${cluster_name}
+    user: eks_${region}_${cluster_name}
+  name: eks_${region}_${cluster_name}
+
+current-context: eks_${region}_${cluster_name}
 
 users:
-- name: ${user_name}
+- name: eks_${region}_${cluster_name}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1

--- a/variables.tf
+++ b/variables.tf
@@ -79,16 +79,6 @@ variable "worker_sg_ingress_from_port" {
   default     = "1025"
 }
 
-variable "kubeconfig_context_name" {
-  description = "Name of the kubeconfig context."
-  default     = "aws"
-}
-
-variable "kubeconfig_user_name" {
-  description = "Name of the kubeconfig user."
-  default     = "aws"
-}
-
 variable "kubeconfig_aws_authenticator_command" {
   description = "Command to use to to fetch AWS EKS credentials"
   default     = "heptio-authenticator-aws"

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,8 @@ variable "kubeconfig_aws_authenticator_env_variables" {
   description = "Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = \"eks\"}"
   default     = {}
 }
+
+variable "kubeconfig_name" {
+  description = "Override the default name used for items kubeconfig"
+  default     = ""
+}


### PR DESCRIPTION
Here I am addressing 2 problems:
1. The strings used in the generated `kubeconfig` file are non-informative and non-unique. This makes merging with existing config a pain and when more than a single EKS cluster is managed by TF, manual changes are required.
2. The path of the generated `kubeconfig` file is not unique. This also makes managing multiple clusters in TF impossible as they will write to the same file. Having multiple clusters in TF is very likely as in place version upgrades of EKS are currently not supported so upgrading to a new version of k8s will mean running 2 clusters side by side for some amount of time.

Both of these have been discussed in https://github.com/terraform-aws-modules/terraform-aws-eks/pull/49 and https://github.com/terraform-aws-modules/terraform-aws-eks/issues/33.

In regards to formatting, I've copied what Google Kubernetes Engine does since their platform is much more mature than EKS and also I think it is sensible formatting. It allows for multiple clusters of the same name but in different regions by including the region in the name.

Here's an example from my kubeconfig containing 1 EKS cluster and 2 GKE clusters:

```
$ kubectl config get-contexts
CURRENT   NAME                                                    CLUSTER                                                 AUTHINFO                                            NAMESPACE
*         eks_us-east-1_cluster_1                                 eks_us-east-1_cluster_1                                 eks_us-east-1_cluster_1
          gke_my-project-live_europe-west1-d_live-cluster         gke_my-project-live_europe-west1-d_live-cluster         gke_my-project-live_europe-west1-d_live-cluster
          gke_my-project-staging_europe-west1-d_staging-cluster   gke_my-project-staging_europe-west1-d_staging-cluster   gke_my-project-staging_europe-west1-d_staging-cluster
```

To get merged config from different files, I ran this command:

```
KUBECONFIG=~/.kube/config:terraform/kubeconfig/kubeconfig_eks_us-east-1_cluster_1 kubectl config view --flatten > mergedkub && mv mergedkub ~/.kube/config
```