### PR TITLE
Kubelet node labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- your excellent addition. (Hat-tip, @self 👒)
+- kubelet_node_labels worker group option allows setting --node-labels= in kubelet. (Hat-tip, @bshelton229 👒)
 
 ### Changed
 

--- a/data.tf
+++ b/data.tf
@@ -94,5 +94,6 @@ data template_file userdata {
     max_pod_count       = "${lookup(local.max_pod_per_node, lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type")))}"
     pre_userdata        = "${lookup(var.worker_groups[count.index], "pre_userdata",lookup(var.workers_group_defaults, "pre_userdata"))}"
     additional_userdata = "${lookup(var.worker_groups[count.index], "additional_userdata",lookup(var.workers_group_defaults, "additional_userdata"))}"
+    kubelet_node_labels = "${lookup(var.worker_groups[count.index], "kubelet_node_labels",lookup(var.workers_group_defaults, "kubelet_node_labels"))}"
   }
 }

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -13,7 +13,7 @@ echo "${cluster_auth_base64}" | base64 -d >$CA_CERTIFICATE_FILE_PATH
 KUBELET_NODE_LABELS=${kubelet_node_labels}
 if [[ $KUBELET_NODE_LABELS != "" ]]; then sed -i '/INTERNAL_IP/a \ \ --node-labels='"$KUBELET_NODE_LABELS"'\ \\' /etc/systemd/system/kubelet.service; fi
 
-# Authenticatoin
+# Authentication
 INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
 sed -i s,MASTER_ENDPOINT,${endpoint},g /var/lib/kubelet/kubeconfig
 sed -i s,CLUSTER_NAME,${cluster_name},g /var/lib/kubelet/kubeconfig

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -9,6 +9,10 @@ CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
 mkdir -p $CA_CERTIFICATE_DIRECTORY
 echo "${cluster_auth_base64}" | base64 -d >$CA_CERTIFICATE_FILE_PATH
 
+# Set kubelet --node-labels if kubelet_node_labels were set
+KUBELET_NODE_LABELS=${kubelet_node_labels}
+if [[ $KUBELET_NODE_LABELS != "" ]]; then sed -i '/INTERNAL_IP/a \ \ --node-labels='"$KUBELET_NODE_LABELS"'\ \\' /etc/systemd/system/kubelet.service; fi
+
 # Authenticatoin
 INTERNAL_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
 sed -i s,MASTER_ENDPOINT,${endpoint},g /var/lib/kubelet/kubeconfig

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,7 @@ variable "workers_group_defaults" {
     additional_userdata  = ""            # userdata to append to the default userdata.
     ebs_optimized        = true          # sets whether to use ebs optimization on supported types.
     public_ip            = false         # Associate a public ip address with a worker
+    kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-lables= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
   }
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Hello, thank you so much for creating this module. It's been invaluable for learning how EKS works. Being able to pass node labels to kubelet in a worker configuration option seemed like a nice interface over us doing this in `pre_userdata`.

Tested by passing this:

```
  worker_groups = [
    {
      name                = "default"
      instance_type       = "t2.small"
      kubelet_node_labels = "node-role.kubernetes.io/node="
    },
    {
      name                = "btest"
      instance_type       = "t2.small"
      kubelet_node_labels = "node-role.kubernetes.io/btest="
    },
    {
      name          = "no-role-passed"
      instance_type = "t2.small"
    },
  ]
```

Which created the expected nodes:

```
NAME                                        STATUS    ROLES     AGE       VERSION
ip-10-10-110-4.us-west-2.compute.internal   Ready     node      55m       v1.10.3
ip-10-10-54-81.us-west-2.compute.internal   Ready     <none>    45m       v1.10.3
ip-10-10-98-2.us-west-2.compute.internal    Ready     btest     51m       v1.10.3
```

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
