### PR TITLE
Fully manage aws-auth configmap file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ kubeconfig
 config-map-aws-auth.yaml
 eks-admin-cluster-role-binding.yaml
 eks-admin-service-account.yaml
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [[v1.4.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.3.0...v1.4.0)] - 2018-07-12]
+
+### Added
+
+- New variables `map_accounts`, `map_roles` and `map_users` in order to manage additional entries in the `aws-auth` configmap. (by @max-rocket-internet)
+
 ## [[v1.3.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.2.0...v1.3.0)] - 2018-07-??]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Generate them like so:
 
 ```bash
 go get github.com/segmentio/terraform-docs
-terraform-docs md ./ | cat -s > README.md
+terraform-docs md ./ | cat -s | ghead -n -1 > README.md
 ```
 
 ## Contributing
@@ -98,11 +98,11 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
 | config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. | string | `./` | no |
-| configure_kubectl_session | Configure the current session's kubectl to use the instantiated EKS cluster. | string | `true` | no |
-| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume ["-r", "MyEksRole"] | string | `<list>` | no |
+| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume ["-r", "MyEksRole"] | list | `<list>` | no |
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
-| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | string | `<map>` | no |
-| kubeconfig_name | Override the default name used for items kubeconfig | string | `` | no |
+| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | map | `<map>` | no |
+| kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
+| manage_aws_auth | Whether to write and apply the aws-auth configmap file | string | `true` | no |
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -99,11 +99,13 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
 | config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. | string | `./` | no |
 | configure_kubectl_session | Configure the current session's kubectl to use the instantiated EKS cluster. | string | `true` | no |
-| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. ["-r", "MyEksRole"] | list | `<list>` | no |
-| kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials. | string | `heptio-authenticator-aws` | no |
-| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"} | map | `<map>` | no |
-| kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
-| manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
+| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume ["-r", "MyEksRole"] | string | `<list>` | no |
+| kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
+| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | string | `<map>` | no |
+| kubeconfig_name | Override the default name used for items kubeconfig | string | `` | no |
+| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. | list | `<list>` | no |
+| map_roles | Additional IAM roles to add to the aws-auth configmap. | list | `<list>` | no |
+| map_users | Additional IAM users to add to the aws-auth configmap. | list | `<list>` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
@@ -128,3 +130,4 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_iam_role_name | IAM role name attached to EKS workers |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
+

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Generate them like so:
 
 ```bash
 go get github.com/segmentio/terraform-docs
-terraform-docs md ./ | cat -s | ghead -n -1 > README.md
+terraform-docs md ./ | cat -s > README.md
 ```
 
 ## Contributing
@@ -103,9 +103,9 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | string | `<map>` | no |
 | kubeconfig_name | Override the default name used for items kubeconfig | string | `` | no |
-| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. | list | `<list>` | no |
-| map_roles | Additional IAM roles to add to the aws-auth configmap. | list | `<list>` | no |
-| map_users | Additional IAM users to add to the aws-auth configmap. | list | `<list>` | no |
+| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
@@ -130,4 +130,3 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_iam_role_name | IAM role name attached to EKS workers |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
-

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | map | `<map>` | no |
 | kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
-| manage_aws_auth | Whether to write and apply the aws-auth configmap file | string | `true` | no |
+| manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
@@ -114,7 +114,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
 | workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `<map>` | no |
 | workstation_cidr | Override the default ingress rule that allows communication with the EKS cluster API. If not given, will use current IP/32. | string | `` | no |
-| write_kubeconfig | Whether to write a kubeconfig file containing the cluster configuration | string | `true` | no |
+| write_kubeconfig | Whether to write a kubeconfig file containing the cluster configuration. | string | `true` | no |
 
 ## Outputs
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -1,17 +1,60 @@
 resource "local_file" "config_map_aws_auth" {
   content  = "${data.template_file.config_map_aws_auth.rendered}"
   filename = "${var.config_output_path}/config-map-aws-auth.yaml"
-  count    = "${var.manage_aws_auth ? 1 : 0}"
+  count    = "${var.configure_kubectl_session ? 1 : 0}"
 }
 
-resource "null_resource" "update_config_map_aws_auth" {
+resource "null_resource" "configure_kubectl" {
   provisioner "local-exec" {
     command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth.yaml --kubeconfig ${var.config_output_path}/kubeconfig"
   }
 
   triggers {
     config_map_rendered = "${data.template_file.config_map_aws_auth.rendered}"
+    kubeconfig_rendered = "${data.template_file.kubeconfig.rendered}"
   }
 
-  count = "${var.manage_aws_auth ? 1 : 0}"
+  count = "${var.configure_kubectl_session ? 1 : 0}"
+}
+
+data "template_file" "config_map_aws_auth" {
+  template = "${file("${path.module}/templates/config-map-aws-auth.yaml.tpl")}"
+
+  vars {
+    worker_role_arn = "${aws_iam_role.workers.arn}"
+    map_users       = "${join("", data.template_file.map_users.*.rendered)}"
+    map_roles       = "${join("", data.template_file.map_roles.*.rendered)}"
+    map_accounts    = "${join("", data.template_file.map_accounts.*.rendered)}"
+  }
+}
+
+data "template_file" "map_users" {
+  count    = "${length(var.map_users)}"
+  template = "${file("${path.module}/templates/config-map-aws-auth-map_users.yaml.tpl")}"
+
+  vars {
+    user_arn = "${lookup(var.map_users[count.index], "user_arn")}"
+    username = "${lookup(var.map_users[count.index], "username")}"
+    group    = "${lookup(var.map_users[count.index], "group")}"
+  }
+}
+
+data "template_file" "map_roles" {
+  count    = "${length(var.map_roles)}"
+  template = "${file("${path.module}/templates/config-map-aws-auth-map_roles.yaml.tpl")}"
+
+  vars {
+    role_arn = "${lookup(var.map_roles[count.index], "role_arn")}"
+    username = "${lookup(var.map_roles[count.index], "username")}"
+    group    = "${lookup(var.map_roles[count.index], "group")}"
+  }
+}
+
+data "template_file" "map_accounts" {
+  count    = "${length(var.map_accounts)}"
+  template = "${file("${path.module}/templates/config-map-aws-auth-map_accounts.yaml.tpl")}"
+
+  vars {
+    account_number = "${element(var.map_accounts, count.index)}"
+  }
 }

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -1,12 +1,12 @@
 resource "local_file" "config_map_aws_auth" {
   content  = "${data.template_file.config_map_aws_auth.rendered}"
-  filename = "${var.config_output_path}/config-map-aws-auth.yaml"
+  filename = "${var.config_output_path}/config-map-aws-auth_${var.cluster_name}.yaml"
   count    = "${var.configure_kubectl_session ? 1 : 0}"
 }
 
 resource "null_resource" "configure_kubectl" {
   provisioner "local-exec" {
-    command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth.yaml --kubeconfig ${var.config_output_path}/kubeconfig"
+    command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth_${var.cluster_name}.yaml --kubeconfig ${var.config_output_path}/kubeconfig_${var.cluster_name}"
   }
 
   triggers {

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -1,17 +1,16 @@
 resource "local_file" "config_map_aws_auth" {
   content  = "${data.template_file.config_map_aws_auth.rendered}"
   filename = "${var.config_output_path}/config-map-aws-auth_${var.cluster_name}.yaml"
-  count    = "${var.configure_kubectl_session ? 1 : 0}"
+  count    = "${var.manage_aws_auth ? 1 : 0}"
 }
 
-resource "null_resource" "configure_kubectl" {
+resource "null_resource" "update_config_map_aws_auth" {
   provisioner "local-exec" {
     command = "kubectl apply -f ${var.config_output_path}/config-map-aws-auth_${var.cluster_name}.yaml --kubeconfig ${var.config_output_path}/kubeconfig_${var.cluster_name}"
   }
 
   triggers {
     config_map_rendered = "${data.template_file.config_map_aws_auth.rendered}"
-    kubeconfig_rendered = "${data.template_file.kubeconfig.rendered}"
   }
 
   count = "${var.configure_kubectl_session ? 1 : 0}"

--- a/data.tf
+++ b/data.tf
@@ -73,14 +73,6 @@ EOF
   }
 }
 
-data "template_file" "config_map_aws_auth" {
-  template = "${file("${path.module}/templates/config-map-aws-auth.yaml.tpl")}"
-
-  vars {
-    role_arn = "${aws_iam_role.workers.arn}"
-  }
-}
-
 data "template_file" "userdata" {
   template = "${file("${path.module}/templates/userdata.sh.tpl")}"
   count    = "${length(var.worker_groups)}"

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -70,4 +70,7 @@ module "eks" {
   tags          = "${local.tags}"
   vpc_id        = "${module.vpc.vpc_id}"
   worker_groups = "${local.worker_groups}"
+  map_roles     = "${var.map_roles}"
+  map_users     = "${var.map_users}"
+  map_accounts  = "${var.map_accounts}"
 }

--- a/examples/eks_test_fixture/variables.tf
+++ b/examples/eks_test_fixture/variables.tf
@@ -1,3 +1,41 @@
 variable "region" {
   default = "us-west-2"
 }
+
+variable "map_accounts" {
+  description = "Additional AWS account numbers to add to the aws-auth configmap."
+  type        = "list"
+  default     = [
+    "777777777777",
+    "888888888888"
+  ]
+}
+
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type        = "list"
+  default     = [
+    {
+      role_arn = "arn:aws:iam::66666666666:role/role1"
+      username = "role1"
+      group = "system:masters"
+    }
+  ]
+}
+
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type        = "list"
+  default     = [
+    {
+      user_arn = "arn:aws:iam::66666666666:user/user1"
+      username = "user1"
+      group  = "system:masters"
+    },
+    {
+      user_arn = "arn:aws:iam::66666666666:user/user2"
+      username = "user2"
+      group  = "system:masters"
+    }
+  ]
+}

--- a/examples/eks_test_fixture/variables.tf
+++ b/examples/eks_test_fixture/variables.tf
@@ -5,37 +5,40 @@ variable "region" {
 variable "map_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap."
   type        = "list"
-  default     = [
+
+  default = [
     "777777777777",
-    "888888888888"
+    "888888888888",
   ]
 }
 
 variable "map_roles" {
   description = "Additional IAM roles to add to the aws-auth configmap."
   type        = "list"
-  default     = [
+
+  default = [
     {
       role_arn = "arn:aws:iam::66666666666:role/role1"
       username = "role1"
-      group = "system:masters"
-    }
+      group    = "system:masters"
+    },
   ]
 }
 
 variable "map_users" {
   description = "Additional IAM users to add to the aws-auth configmap."
   type        = "list"
-  default     = [
+
+  default = [
     {
       user_arn = "arn:aws:iam::66666666666:user/user1"
       username = "user1"
-      group  = "system:masters"
+      group    = "system:masters"
     },
     {
       user_arn = "arn:aws:iam::66666666666:user/user2"
       username = "user2"
-      group  = "system:masters"
-    }
+      group    = "system:masters"
+    },
   ]
 }

--- a/templates/config-map-aws-auth-map_accounts.yaml.tpl
+++ b/templates/config-map-aws-auth-map_accounts.yaml.tpl
@@ -1,0 +1,1 @@
+    - "${account_number}"

--- a/templates/config-map-aws-auth-map_roles.yaml.tpl
+++ b/templates/config-map-aws-auth-map_roles.yaml.tpl
@@ -1,0 +1,4 @@
+    - rolearn: ${role_arn}
+      username: ${username}
+      groups:
+        - ${group}

--- a/templates/config-map-aws-auth-map_users.yaml.tpl
+++ b/templates/config-map-aws-auth-map_users.yaml.tpl
@@ -1,0 +1,4 @@
+    - userarn: ${user_arn}
+      username: ${username}
+      groups:
+        - ${group}

--- a/templates/config-map-aws-auth.yaml.tpl
+++ b/templates/config-map-aws-auth.yaml.tpl
@@ -5,8 +5,13 @@ metadata:
   namespace: kube-system
 data:
   mapRoles: |
-    - rolearn: ${role_arn}
+    - rolearn: ${worker_role_arn}
       username: system:node:{{EC2PrivateDNSName}}
       groups:
         - system:bootstrappers
         - system:nodes
+${map_roles}
+  mapUsers: |
+${map_users}
+  mapAccounts: |
+${map_accounts}

--- a/variables.tf
+++ b/variables.tf
@@ -33,19 +33,19 @@ variable "manage_aws_auth" {
 }
 
 variable "map_accounts" {
-  description = "Additional AWS account numbers to add to the aws-auth configmap."
+  description = "Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format."
   type        = "list"
   default     = []
 }
 
 variable "map_roles" {
-  description = "Additional IAM roles to add to the aws-auth configmap."
+  description = "Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format."
   type        = "list"
   default     = []
 }
 
 variable "map_users" {
-  description = "Additional IAM users to add to the aws-auth configmap."
+  description = "Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format."
   type        = "list"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,24 @@ variable "manage_aws_auth" {
   default     = true
 }
 
+variable "map_accounts" {
+  description = "Additional AWS account numbers to add to the aws-auth configmap"
+  type        = "list"
+  default     = []
+}
+
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap"
+  type        = "list"
+  default     = []
+}
+
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap"
+  type        = "list"
+  default     = []
+}
+
 variable "subnets" {
   description = "A list of subnets to place the EKS cluster and workers within."
   type        = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -23,12 +23,12 @@ variable "config_output_path" {
 }
 
 variable "write_kubeconfig" {
-  description = "Whether to write a kubeconfig file containing the cluster configuration"
+  description = "Whether to write a kubeconfig file containing the cluster configuration."
   default     = true
 }
 
 variable "manage_aws_auth" {
-  description = "Whether to write and apply the aws-auth configmap file"
+  description = "Whether to write and apply the aws-auth configmap file."
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,19 +33,19 @@ variable "manage_aws_auth" {
 }
 
 variable "map_accounts" {
-  description = "Additional AWS account numbers to add to the aws-auth configmap"
+  description = "Additional AWS account numbers to add to the aws-auth configmap."
   type        = "list"
   default     = []
 }
 
 variable "map_roles" {
-  description = "Additional IAM roles to add to the aws-auth configmap"
+  description = "Additional IAM roles to add to the aws-auth configmap."
   type        = "list"
   default     = []
 }
 
 variable "map_users" {
-  description = "Additional IAM users to add to the aws-auth configmap"
+  description = "Additional IAM users to add to the aws-auth configmap."
   type        = "list"
   default     = []
 }


### PR DESCRIPTION
Related issue: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/50

The problem: Any users, roles or accounts that need access to the EKS cluster must have the relevant entries in the `aws-auth` configmap inside k8s. Currently this module only puts the ARN of the worker group in there, thus forcing people to manage this file manually, which is a pain.

Limitations:

1. It's a bit of a mess due to needing to loop over values in a template. Not sure if the new template syntax in [0.12](https://www.hashicorp.com/blog/terraform-0-1-2-preview) will help. Let me know if there's a better way to do this!

2. We can't have multiple groups per user or role due to this error: `lookup() may only be used with flat maps, this map contains elements of type list in`. No big deal I think at this stage.

3. We can't have interpolation in the items being passed to the module as it breaks the count option. Details [here](https://github.com/hashicorp/terraform/issues/10857). Annoying but also not a big deal.

Example configuration:

```hcl
module "cluster_1" {
  source                    = "git@github.com:terraform-aws-modules/terraform-aws-eks.git?ref=v1.4.0"
  cluster_name              = "cluster_1"
  subnets                   = ["${aws_subnet.public.*.id}"]
  vpc_id                    = "${aws_vpc.eks.id}"

  worker_groups = [
    {
      instance_type = "t2.medium"
      key_name      = "default"
    }
  ]

  map_roles = [
     {
       role_arn = "${aws_iam_role.k8s_users.arn}"
       username = "k8s_users"
       group = "system:masters"
     }
   ]

   map_users = [
     {
       user_arn = "arn:aws:iam::66666666666:user/user.name"
       username = "user.name"
       group  = "system:masters"
     }
   ]

   map_accounts = [
     "666666666666",
     "999999999999"
   ]
}
```