### PR TITLE
Updating heptio-authenticator-aws to aws-iam-authenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ kubeconfig
 config-map-aws-auth.yaml
 eks-admin-cluster-role-binding.yaml
 eks-admin-service-account.yaml
+.idea/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read the [AWS docs on EKS to get connected to the k8s dashboard](https://docs.aw
 * You want to create an EKS cluster and an autoscaling group of workers for the cluster.
 * You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
 * You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources.
-* If using the default variable value (`true`) for `configure_kubectl_session`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`heptio-authenticator-aws`](https://github.com/heptio/authenticator#4-set-up-kubectl-to-use-heptio-authenticator-for-aws-tokens) are installed and on your shell's PATH.
+* If using the default variable value (`true`) for `configure_kubectl_session`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
 
 ## Usage example
 
@@ -100,7 +100,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. | string | `./` | no |
 | configure_kubectl_session | Configure the current session's kubectl to use the instantiated EKS cluster. | string | `true` | no |
 | kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume ["-r", "MyEksRole"] | string | `<list>` | no |
-| kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `heptio-authenticator-aws` | no |
+| kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials | string | `aws-iam-authenticator` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator i.e. { AWS_PROFILE = "eks"} | string | `<map>` | no |
 | kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 ** You want to create an EKS cluster and an autoscaling group of workers for the cluster.
 ** You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
 ** You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources.
-** If using the default variable value (`true`) for `configure_kubectl_session`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`heptio-authenticator-aws`](https://github.com/heptio/authenticator#4-set-up-kubectl-to-use-heptio-authenticator-for-aws-tokens) are installed and on your shell's PATH.
+** If using the default variable value (`true`) for `configure_kubectl_session`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
 
 * ## Usage example
 

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "worker_sg_ingress_from_port" {
 
 variable "kubeconfig_aws_authenticator_command" {
   description = "Command to use to to fetch AWS EKS credentials"
-  default     = "heptio-authenticator-aws"
+  default     = "aws-iam-authenticator"
 }
 
 variable "kubeconfig_aws_authenticator_additional_args" {


### PR DESCRIPTION
Updating heptio-authenticator-aws to aws-iam-authenticator since the heptio project was moved and renamed.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
