### PR TITLE
Worker iam role arn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - kubelet_node_labels worker group option allows setting --node-labels= in kubelet. (Hat-tip, @bshelton229 👒)
+- `worker_iam_role_arn` added to outputs. Sweet, @hatemosphere 🔥
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -126,5 +126,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | worker_iam_role_name | IAM role name attached to EKS workers |
+| worker_iam_role_arn | IAM role ID attached to EKS workers |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,3 +53,8 @@ output "worker_iam_role_name" {
   description = "IAM role name attached to EKS workers"
   value       = "${aws_iam_role.workers.name}"
 }
+
+output "worker_iam_role_arn" {
+  description = "IAM role ID attached to EKS workers"
+  value       = "${aws_iam_role.workers.arn}"
+}


### PR DESCRIPTION
# PR o'clock

## Description

Just a small, but useful addition that will allow using worker's IAM role in policy documents (having only role name in outputs is apparently not enough in some cases)

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
