### PR TITLE
Optionally define worker subnets

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,7 @@ variable "workers_group_defaults" {
     ebs_optimized        = true          # sets whether to use ebs optimization on supported types.
     public_ip            = false         # Associate a public ip address with a worker
     kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-lables= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
+    subnets              = ""            # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
   }
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -4,7 +4,7 @@ resource "aws_autoscaling_group" "workers" {
   max_size             = "${lookup(var.worker_groups[count.index], "asg_max_size",lookup(var.workers_group_defaults, "asg_max_size"))}"
   min_size             = "${lookup(var.worker_groups[count.index], "asg_min_size",lookup(var.workers_group_defaults, "asg_min_size"))}"
   launch_configuration = "${element(aws_launch_configuration.workers.*.id, count.index)}"
-  vpc_zone_identifier  = ["${var.subnets}"]
+  vpc_zone_identifier  = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), join(",", var.subnets)))}"]
   count                = "${length(var.worker_groups)}"
 
   tags = ["${concat(


### PR DESCRIPTION
# PR o'clock

## Description

Adds a `subnets` option to `worker_groups`. The primary use-case is to address #15 . This will allow the eks cluster to be passed both private and public subnets while the workers only run in the private subnets.

Thanks!

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
