### PR TITLE
Don't call out to fetch the current ip address if it isn't needed.

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,7 @@
 data "aws_region" "current" {}
 
 data "http" "workstation_external_ip" {
+  count = "${var.workstation_cidr == "" ? 1 : 0}"
   url = "https://ipv4.icanhazip.com"
 }
 

--- a/data.tf
+++ b/data.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 data "http" "workstation_external_ip" {
   count = "${var.workstation_cidr == "" ? 1 : 0}"
-  url = "https://ipv4.icanhazip.com"
+  url   = "https://ipv4.icanhazip.com"
 }
 
 data "aws_iam_policy_document" "workers_assume_role_policy" {

--- a/local.tf
+++ b/local.tf
@@ -5,9 +5,9 @@ locals {
   # to workaround terraform not supporting short circut evaluation
   cluster_security_group_id = "${coalesce(join("", aws_security_group.cluster.*.id), var.cluster_security_group_id)}"
 
-  worker_security_group_id  = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
-  workstation_cidr          = "${coalesce(var.workstation_cidr, format("%s/32", chomp(join("", data.http.workstation_external_ip.*.body))))}"
-  kubeconfig_name           = "${coalesce(var.kubeconfig_name, "eks_${var.cluster_name}")}"
+  worker_security_group_id = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
+  workstation_cidr         = "${coalesce(var.workstation_cidr, format("%s/32", chomp(join("", data.http.workstation_external_ip.*.body))))}"
+  kubeconfig_name          = "${coalesce(var.kubeconfig_name, "eks_${var.cluster_name}")}"
 
   # Mapping from the node type that we selected and the max number of pods that it can run
   # Taken from https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml

--- a/local.tf
+++ b/local.tf
@@ -6,9 +6,8 @@ locals {
   cluster_security_group_id = "${coalesce(join("", aws_security_group.cluster.*.id), var.cluster_security_group_id)}"
 
   worker_security_group_id  = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
-  workstation_external_cidr = "${chomp(data.http.workstation_external_ip.body)}/32"
-  workstation_cidr          = "${coalesce(var.workstation_cidr, local.workstation_external_cidr)}"
-  kubeconfig_name           = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
+  workstation_cidr          = "${coalesce(var.workstation_cidr, format("%s/32", chomp(join("", data.http.workstation_external_ip.*.body))))}"
+  kubeconfig_name           = "${coalesce(var.kubeconfig_name, "eks_${var.cluster_name}")}"
 
   # Mapping from the node type that we selected and the max number of pods that it can run
   # Taken from https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml


### PR DESCRIPTION
# PR o'clock

## Description

If we specify a workstation_cidr block don't go out and fetch your current external ip address for the "default" value. This breaks systems if they don't have a route out to "https://ipv4.icanhazip.com"

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
