### PR TITLE
Use static not computed worker group count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- manage eks workers' root volume size and type
-- `workers_asg_names` added to outputs.
+- manage eks workers' root volume size and type.
+- `workers_asg_names` added to outputs. (kudos to @laverya)
+- New top level variable `worker_group_count` added to replace the use of `length(var.worker_groups)`. This allows using computed values as part of worker group configs. (complaints to @laverya)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
+| worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |

--- a/data.tf
+++ b/data.tf
@@ -75,7 +75,7 @@ EOF
 
 data "template_file" "userdata" {
   template = "${file("${path.module}/templates/userdata.sh.tpl")}"
-  count    = "${length(var.worker_groups)}"
+  count    = "${var.worker_group_count}"
 
   vars {
     region              = "${data.aws_region.current.name}"

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -37,7 +37,8 @@ locals {
 
   worker_groups = "${list(
                   map("instance_type","t2.small",
-                      "additional_userdata","echo foo bar"
+                      "additional_userdata","echo foo bar",
+                      "subnets", "${join(",", module.vpc.private_subnets)}",
                       ),
   )}"
   tags = "${map("Environment", "test",
@@ -68,7 +69,7 @@ module "vpc" {
 module "eks" {
   source             = "../.."
   cluster_name       = "${local.cluster_name}"
-  subnets            = "${module.vpc.public_subnets}"
+  subnets            = ["${module.vpc.public_subnets}", "${module.vpc.private_subnets}"]
   tags               = "${local.tags}"
   vpc_id             = "${module.vpc.vpc_id}"
   worker_groups      = "${local.worker_groups}"

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -24,12 +24,14 @@ locals {
   #                       "asg_min_size", "2",
   #                       "instance_type", "m4.xlarge",
   #                       "name", "worker_group_a",
+  #                       "subnets", "${join(",", module.vpc.private_subnets)}",
   #                   ),
   #                   map("asg_desired_capacity", "1",
   #                       "asg_max_size", "5",
   #                       "asg_min_size", "1",
   #                       "instance_type", "m4.2xlarge",
   #                       "name", "worker_group_b",
+  #                       "subnets", "${join(",", module.vpc.private_subnets)}",
   #                   ),
   # )}"
 
@@ -64,13 +66,14 @@ module "vpc" {
 }
 
 module "eks" {
-  source        = "../.."
-  cluster_name  = "${local.cluster_name}"
-  subnets       = "${module.vpc.public_subnets}"
-  tags          = "${local.tags}"
-  vpc_id        = "${module.vpc.vpc_id}"
-  worker_groups = "${local.worker_groups}"
-  map_roles     = "${var.map_roles}"
-  map_users     = "${var.map_users}"
-  map_accounts  = "${var.map_accounts}"
+  source             = "../.."
+  cluster_name       = "${local.cluster_name}"
+  subnets            = "${module.vpc.public_subnets}"
+  tags               = "${local.tags}"
+  vpc_id             = "${module.vpc.vpc_id}"
+  worker_groups      = "${local.worker_groups}"
+  worker_group_count = "1"
+  map_roles          = "${var.map_roles}"
+  map_users          = "${var.map_users}"
+  map_accounts       = "${var.map_accounts}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,12 @@ variable "worker_groups" {
   }]
 }
 
+variable "worker_group_count" {
+  description = "The number of maps contained within the worker_groups list."
+  type        = "string"
+  default     = "1"
+}
+
 variable "workers_group_defaults" {
   description = "Default values for target groups as defined by the list of maps."
   type        = "map"

--- a/workers.tf
+++ b/workers.tf
@@ -5,7 +5,7 @@ resource "aws_autoscaling_group" "workers" {
   min_size             = "${lookup(var.worker_groups[count.index], "asg_min_size",lookup(var.workers_group_defaults, "asg_min_size"))}"
   launch_configuration = "${element(aws_launch_configuration.workers.*.id, count.index)}"
   vpc_zone_identifier  = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), join(",", var.subnets)))}"]
-  count                = "${length(var.worker_groups)}"
+  count                = "${var.worker_group_count}"
 
   tags = ["${concat(
     list(
@@ -30,7 +30,7 @@ resource "aws_launch_configuration" "workers" {
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(var.workers_group_defaults, "key_name"))}"
   user_data_base64            = "${base64encode(element(data.template_file.userdata.*.rendered, count.index))}"
   ebs_optimized               = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type")), false))}"
-  count                       = "${length(var.worker_groups)}"
+  count                       = "${var.worker_group_count}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# PR o'clock

## Description

`length(var.worker_groups)` has been replaced by a top-level variable `worker_group_length` as `length` of a computed value cannot be used. This fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/73

Breaking Changes:
`worker_group_length` must be specified to use more than one worker group.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
