### PR TITLE
add workers_asg_names to outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - manage eks workers' root volume size and type
+- `workers_asg_names` added to outputs.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -132,4 +132,5 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_iam_role_name | IAM role name attached to EKS workers |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
+| workers_asg_names | Names of the autoscaling groups containing workers. |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,6 +44,11 @@ output "workers_asg_arns" {
   value       = "${aws_autoscaling_group.workers.*.arn}"
 }
 
+output "workers_asg_names" {
+  description = "Names of the autoscaling groups containing workers."
+  value       = "${aws_autoscaling_group.workers.*.id}"
+}
+
 output "worker_security_group_id" {
   description = "Security group ID attached to the EKS workers."
   value       = "${local.worker_security_group_id}"


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

`workers_asg_names`, a counterpart to `workers_asg_arns`, was added to outputs. Fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/76

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
