### PR TITLE
add spot_price option to aws_launch_configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- A useful addition (slam dunk, @self 🔥)
+- add spot_price option to aws_launch_configuration
 
 ### Changed
 

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,7 @@ variable "workers_group_defaults" {
     asg_max_size         = "3"           # Maximum worker capacity in the autoscaling group.
     asg_min_size         = "1"           # Minimum worker capacity in the autoscaling group.
     instance_type        = "m4.large"    # Size of the workers instances.
+    spot_price           = ""            # Cost of spot instance.
     root_volume_size     = "20"          # root volume size of workers instances.
     root_volume_type     = "gp2"         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops            = "0"           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".

--- a/workers.tf
+++ b/workers.tf
@@ -30,6 +30,7 @@ resource "aws_launch_configuration" "workers" {
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(var.workers_group_defaults, "key_name"))}"
   user_data_base64            = "${base64encode(element(data.template_file.userdata.*.rendered, count.index))}"
   ebs_optimized               = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type")), false))}"
+  spot_price                  = "${lookup(var.worker_groups[count.index], "spot_price", lookup(var.workers_group_defaults, "spot_price"))}"
   count                       = "${var.worker_group_count}"
 
   lifecycle {


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

Just add `spot_price` option to aws_launch_configuration and variable`update workers_group_defaults` for default spot value(on-demand, if spot_price is empty).
Firstly issue rised with #72 

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
