### PR TITLE
No http callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - A subtle but thoughtful change. (Boomshakalaka, @self 🏀)
+- **Breaking change** Removed `workstation_cidr` variable, http callout and unnecessary security rule. (by @dpiddockcmp)
 
 ## [[v1.4.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.3.0...v1.4.0)] - 2018-08-02]
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
 | workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `<map>` | no |
-| workstation_cidr | Override the default ingress rule that allows communication with the EKS cluster API. If not given, will use current IP/32. | string | `` | no |
 | write_kubeconfig | Whether to write a kubeconfig file containing the cluster configuration. | string | `true` | no |
 
 ## Outputs

--- a/cluster.tf
+++ b/cluster.tf
@@ -44,17 +44,6 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
   count                    = "${var.cluster_security_group_id == "" ? 1 : 0}"
 }
 
-resource "aws_security_group_rule" "cluster_https_cidr_ingress" {
-  cidr_blocks       = ["${local.workstation_cidr}"]
-  description       = "Allow kubectl communication with the EKS cluster API."
-  protocol          = "tcp"
-  security_group_id = "${aws_security_group.cluster.id}"
-  from_port         = 443
-  to_port           = 443
-  type              = "ingress"
-  count             = "${var.cluster_security_group_id == "" ? 1 : 0}"
-}
-
 resource "aws_iam_role" "cluster" {
   name_prefix        = "${var.cluster_name}"
   assume_role_policy = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"

--- a/data.tf
+++ b/data.tf
@@ -1,9 +1,5 @@
 data "aws_region" "current" {}
 
-data "http" "workstation_external_ip" {
-  url = "https://ipv4.icanhazip.com"
-}
-
 data "aws_iam_policy_document" "workers_assume_role_policy" {
   statement {
     sid = "EKSWorkerAssumeRole"

--- a/local.tf
+++ b/local.tf
@@ -5,10 +5,8 @@ locals {
   # to workaround terraform not supporting short circut evaluation
   cluster_security_group_id = "${coalesce(join("", aws_security_group.cluster.*.id), var.cluster_security_group_id)}"
 
-  worker_security_group_id  = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
-  workstation_external_cidr = "${chomp(data.http.workstation_external_ip.body)}/32"
-  workstation_cidr          = "${coalesce(var.workstation_cidr, local.workstation_external_cidr)}"
-  kubeconfig_name           = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
+  worker_security_group_id = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
+  kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
   # Mapping from the node type that we selected and the max number of pods that it can run
   # Taken from https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/amazon-eks-nodegroup.yaml

--- a/main.tf
+++ b/main.tf
@@ -94,4 +94,3 @@
 
 provider "null" {}
 provider "template" {}
-provider "http" {}

--- a/variables.tf
+++ b/variables.tf
@@ -7,11 +7,6 @@ variable "cluster_security_group_id" {
   default     = ""
 }
 
-variable "workstation_cidr" {
-  description = "Override the default ingress rule that allows communication with the EKS cluster API. If not given, will use current IP/32. "
-  default     = ""
-}
-
 variable "cluster_version" {
   description = "Kubernetes version to use for the EKS cluster."
   default     = "1.10"


### PR DESCRIPTION
# PR o'clock

## Description

This PR removes the HTTP callout and security rule logic for master security group. Access to the Kubernetes masters cannot be restricted, nor does it need granting. As mentioned on https://github.com/terraform-aws-modules/terraform-aws-eks/pull/69#issuecomment-406123233

Breaking change for some users: This removes the, now redundant, `workstation_cidr` variable.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
