### PR TITLE
Add ability to specify a list of additional security groups to attach to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- A useful addition (slam dunk, @self 🔥)
+- Allow multiple additional security groups to be passed and attached to the workers
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
+| worker_additional_security_group_ids | Will append provided security group IDs to the workers to complement the security groups created by this module or provided by worker_security_group_id | string | `<list>` | no |
 | worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
-| worker_additional_security_group_ids | A list of existing security groups to attach to all the workers. These will be appended to the default worker security group needed by the cluster. It is recommended to not use worker_security_group in conjunction with this variable. | list | `<list>` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
 | workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `<map>` | no |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
 | worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
+| worker_additional_security_group_ids | A list of existing security groups to attach to all the workers. These will be appended to the default worker security group needed by the cluster. It is recommended to not use worker_security_group in conjunction with this variable. | list | `<list>` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
 | workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `<map>` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,11 @@ variable "worker_security_group_id" {
   default     = ""
 }
 
+variable "worker_additional_security_group_ids" {
+  description = "Will append provided security group IDs to the workers to complement the security groups created by this module or provided by worker_security_group_id"
+  default     = []
+}
+
 variable "worker_sg_ingress_from_port" {
   description = "Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443)."
   default     = "1025"

--- a/workers.tf
+++ b/workers.tf
@@ -23,7 +23,7 @@ resource "aws_autoscaling_group" "workers" {
 resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(var.workers_group_defaults, "public_ip"))}"
-  security_groups             = ["${local.worker_security_group_id}"]
+  security_groups             = ["${concat(list(local.worker_security_group_id), var.worker_additional_security_group_ids)}"]
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", data.aws_ami.eks_worker.id)}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type"))}"


### PR DESCRIPTION
# PR o'clock

## Description

This addresses #47 - I have been using this in a local fork and noticed there was an open issue for it. Basically, this allows the user to specify a list of additional existing security groups which will merge with `worker_security_group_id` if specified. This might make `worker_security_group_id` unnecessary, although it's assumed that the additional security groups are unaffiliated with the EKS cluster and more for VPC transit to other areas.

Please let me know what you think. 

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
