### PR TITLE
Setting worker default volume size to 100GB

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "workers_group_defaults" {
     asg_min_size         = "1"           # Minimum worker capacity in the autoscaling group.
     instance_type        = "m4.large"    # Size of the workers instances.
     spot_price           = ""            # Cost of spot instance.
-    root_volume_size     = "20"          # root volume size of workers instances.
+    root_volume_size     = "100"          # root volume size of workers instances.
     root_volume_type     = "gp2"         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops            = "0"           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name             = ""            # The key name that should be used for the instances in the autoscaling group


### PR DESCRIPTION
I think as a default, 20GB is way too low. For example, GKE uses 100GB.