### PR TITLE
fix comment alignment on workers_group_defaults

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "workers_group_defaults" {
     asg_min_size         = "1"           # Minimum worker capacity in the autoscaling group.
     instance_type        = "m4.large"    # Size of the workers instances.
     spot_price           = ""            # Cost of spot instance.
-    root_volume_size     = "100"          # root volume size of workers instances.
+    root_volume_size     = "100"         # root volume size of workers instances.
     root_volume_type     = "gp2"         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops            = "0"           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name             = ""            # The key name that should be used for the instances in the autoscaling group


### PR DESCRIPTION
# PR o'clock

## Description

Very important change to remove an extra space from a comment.  You're welcome world!

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
