### PR TITLE
Added support for Ubuntu EKS worker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ module "eks" {
   source                = "terraform-aws-modules/eks/aws"
   cluster_name          = "test-eks-cluster"
   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
-  tags                  = "${map("Environment", "test")}"
+  tags                  = {
+                            "Environment" = "test"
+                          }
   vpc_id                = "vpc-abcde012"
 }
 ```
@@ -90,6 +92,7 @@ Many thanks to [the contributors listed here](https://github.com/terraform-aws-m
 
 MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/LICENSE) for full details.
 
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -98,22 +101,22 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
 | config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. Should end in a forward slash / . | string | `./` | no |
-| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `<list>` | no |
+| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials. | string | `aws-iam-authenticator` | no |
-| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `<map>` | no |
+| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `{}` | no |
 | kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
 | manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
-| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
+| map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
+| map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
-| tags | A map of tags to add to all resources. | map | `<map>` | no |
+| tags | A map of tags to add to all resources. | map | `{}` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
 | worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
-| worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
+| worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
-| workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `<map>` | no |
+| workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `{ "additional_userdata": "", "ami_id": "", "asg_desired_capacity": "1", "asg_max_size": "3", "asg_min_size": "1", "ebs_optimized": true, "instance_type": "m4.large", "key_name": "", "kubelet_node_labels": "", "name": "count.index", "pre_userdata": "", "public_ip": false, "root_iops": "0", "root_volume_size": "100", "root_volume_type": "gp2", "spot_price": "", "subnets": "" }` | no |
 | write_kubeconfig | Whether to write a kubeconfig file containing the cluster configuration. | string | `true` | no |
 
 ## Outputs
@@ -132,3 +135,4 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
 | workers_asg_names | Names of the autoscaling groups containing workers. |
+

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Documentation should be modified within `main.tf` and generated using [terraform
 Generate them like so:
 
 ```bash
-go get github.com/segmentio/terraform-docs
-terraform-docs md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
+go get github.com/getcloudnative/terraform-docs
+terraform-docs md ./ > README.md
 ```
 
 ## Contributing
@@ -116,7 +116,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
-| workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `{ "additional_userdata": "", "ami_id": "", "asg_desired_capacity": "1", "asg_max_size": "3", "asg_min_size": "1", "ebs_optimized": true, "instance_type": "m4.large", "key_name": "", "kubelet_node_labels": "", "name": "count.index", "pre_userdata": "", "public_ip": false, "root_iops": "0", "root_volume_size": "100", "root_volume_type": "gp2", "spot_price": "", "subnets": "" }` | no |
+| workers_group_defaults | Default values for target groups as defined by the list of maps. | map | `{ "additional_userdata": "", "ami_id": "", "asg_desired_capacity": "1", "asg_max_size": "3", "asg_min_size": "1", "distro": "amazon", "ebs_optimized": true, "instance_type": "m4.large", "key_name": "", "kubelet_node_labels": "", "name": "count.index", "pre_userdata": "", "public_ip": false, "root_iops": "0", "root_volume_size": "100", "root_volume_type": "gp2", "spot_price": "", "subnets": "" }` | no |
 | write_kubeconfig | Whether to write a kubeconfig file containing the cluster configuration. | string | `true` | no |
 
 ## Outputs

--- a/data.tf
+++ b/data.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
   }
 }
 
-data "aws_ami" "eks_worker" {
+data "aws_ami" "eks_worker_amazon" {
   filter {
     name   = "name"
     values = ["eks-worker-*"]
@@ -23,6 +23,16 @@ data "aws_ami" "eks_worker" {
 
   most_recent = true
   owners      = ["602401143452"] # Amazon
+}
+
+data "aws_ami" "eks_worker_ubuntu" {
+  filter {
+    name   = "name"
+    values = ["ubuntu-eks/*"]
+  }
+
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
 }
 
 data "aws_iam_policy_document" "cluster_assume_role_policy" {
@@ -70,7 +80,7 @@ EOF
 }
 
 data "template_file" "userdata" {
-  template = "${file("${path.module}/templates/userdata.sh.tpl")}"
+  template = "${lookup(local.distros[lookup(var.worker_groups[count.index], "distro", var.workers_group_defaults["distro"])], "userdata_tpl")}"
   count    = "${var.worker_group_count}"
 
   vars {

--- a/data.tf
+++ b/data.tf
@@ -78,9 +78,9 @@ data "template_file" "userdata" {
     cluster_name        = "${aws_eks_cluster.this.name}"
     endpoint            = "${aws_eks_cluster.this.endpoint}"
     cluster_auth_base64 = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    max_pod_count       = "${lookup(local.max_pod_per_node, lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type")))}"
-    pre_userdata        = "${lookup(var.worker_groups[count.index], "pre_userdata",lookup(var.workers_group_defaults, "pre_userdata"))}"
-    additional_userdata = "${lookup(var.worker_groups[count.index], "additional_userdata",lookup(var.workers_group_defaults, "additional_userdata"))}"
-    kubelet_node_labels = "${lookup(var.worker_groups[count.index], "kubelet_node_labels",lookup(var.workers_group_defaults, "kubelet_node_labels"))}"
+    max_pod_count       = "${lookup(local.max_pod_per_node, lookup(var.worker_groups[count.index], "instance_type", var.workers_group_defaults["instance_type"]))}"
+    pre_userdata        = "${lookup(var.worker_groups[count.index], "pre_userdata", var.workers_group_defaults["pre_userdata"])}"
+    additional_userdata = "${lookup(var.worker_groups[count.index], "additional_userdata", var.workers_group_defaults["additional_userdata"])}"
+    kubelet_node_labels = "${lookup(var.worker_groups[count.index], "kubelet_node_labels", var.workers_group_defaults["kubelet_node_labels"])}"
   }
 }

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -44,14 +44,13 @@ locals {
       instance_type       = "t2.small"
       additional_userdata = "echo foo bar"
       subnets             = "${join(",", module.vpc.private_subnets)}"
-    }
+    },
   ]
-
   tags = {
-    "Environment"       = "test"
-    "GithubRepo"        = "terraform-aws-eks"
-    "GithubOrg"         = "terraform-aws-modules"
-    "Workspace"         = "${terraform.workspace}"
+    "Environment" = "test"
+    "GithubRepo"  = "terraform-aws-eks"
+    "GithubOrg"   = "terraform-aws-modules"
+    "Workspace"   = "${terraform.workspace}"
   }
 }
 

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -18,34 +18,39 @@ locals {
 
   # the commented out worker group list below shows an example of how to define
   # multiple worker groups of differing configurations
-  # worker_groups = "${list(
-  #                   map("asg_desired_capacity", "2",
-  #                       "asg_max_size", "10",
-  #                       "asg_min_size", "2",
-  #                       "instance_type", "m4.xlarge",
-  #                       "name", "worker_group_a",
-  #                       "subnets", "${join(",", module.vpc.private_subnets)}",
-  #                   ),
-  #                   map("asg_desired_capacity", "1",
-  #                       "asg_max_size", "5",
-  #                       "asg_min_size", "1",
-  #                       "instance_type", "m4.2xlarge",
-  #                       "name", "worker_group_b",
-  #                       "subnets", "${join(",", module.vpc.private_subnets)}",
-  #                   ),
-  # )}"
+  # worker_groups =  [
+  #   {
+  #     name                  = "worker_group_a"
+  #     instance_type         = "m4.xlarge"
+  #     asg_desired_capacity  = 2
+  #     asg_min_size          = 2
+  #     asg_max_size          = 10
+  #     subnets               = "${join(",", module.vpc.private_subnets)}"
+  #   },
+  #   {
+  #     name                  = "worker_group_b"
+  #     instance_type         = "m4.2xlarge"
+  #     asg_desired_capacity  = 1
+  #     asg_min_size          = 1
+  #     asg_max_size          = 5
+  #     subnets               = "${join(",", module.vpc.private_subnets)}"
+  #   },
+  # ]
 
-  worker_groups = "${list(
-                  map("instance_type","t2.small",
-                      "additional_userdata","echo foo bar",
-                      "subnets", "${join(",", module.vpc.private_subnets)}",
-                      ),
-  )}"
-  tags = "${map("Environment", "test",
-                "GithubRepo", "terraform-aws-eks",
-                "GithubOrg", "terraform-aws-modules",
-                "Workspace", "${terraform.workspace}",
-  )}"
+  worker_groups = [
+    {
+      instance_type       = "t2.small"
+      additional_userdata = "echo foo bar"
+      subnets             = "${join(",", module.vpc.private_subnets)}"
+    }
+  ]
+
+  tags = {
+    "Environment"       = "test"
+    "GithubRepo"        = "terraform-aws-eks"
+    "GithubOrg"         = "terraform-aws-modules"
+    "Workspace"         = "${terraform.workspace}"
+  }
 }
 
 resource "random_string" "suffix" {

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -22,6 +22,7 @@ locals {
   #   {
   #     name                  = "worker_group_a"
   #     instance_type         = "m4.xlarge"
+  #     distro                = "ubuntu"
   #     asg_desired_capacity  = 2
   #     asg_min_size          = 2
   #     asg_max_size          = 10
@@ -30,6 +31,7 @@ locals {
   #   {
   #     name                  = "worker_group_b"
   #     instance_type         = "m4.2xlarge"
+  #     distro                = "amazon"
   #     asg_desired_capacity  = 1
   #     asg_min_size          = 1
   #     asg_max_size          = 5

--- a/local.tf
+++ b/local.tf
@@ -187,4 +187,18 @@ locals {
     "x1e.8xlarge"  = true
     "x1e.xlarge"   = true
   }
+
+  distros = {
+    amazon = {
+      ami_id       = "${data.aws_ami.eks_worker_amazon.id}"
+      userdata_tpl = "${file("${path.module}/templates/userdata.sh.tpl")}"
+    }
+
+    ubuntu = {
+      ami_id = "${data.aws_ami.eks_worker_ubuntu.id}"
+      userdata_tpl = "${file("${path.module}/templates/userdata.yaml.tpl")}"
+    }
+
+  }
+
 }

--- a/local.tf
+++ b/local.tf
@@ -195,10 +195,8 @@ locals {
     }
 
     ubuntu = {
-      ami_id = "${data.aws_ami.eks_worker_ubuntu.id}"
+      ami_id       = "${data.aws_ami.eks_worker_ubuntu.id}"
       userdata_tpl = "${file("${path.module}/templates/userdata.yaml.tpl")}"
     }
-
   }
-
 }

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,9 @@
 *   source                = "terraform-aws-modules/eks/aws"
 *   cluster_name          = "test-eks-cluster"
 *   subnets               = ["subnet-abcde012", "subnet-bcde012a"]
-*   tags                  = "${map("Environment", "test")}"
+*   tags                  = {
+*                             "Environment" = "test"
+*                           }
 *   vpc_id                = "vpc-abcde012"
 * }
 * ```

--- a/main.tf
+++ b/main.tf
@@ -65,8 +65,8 @@
 * Generate them like so:
 
 * ```bash
-* go get github.com/segmentio/terraform-docs
-* terraform-docs md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
+* go get github.com/getcloudnative/terraform-docs
+* terraform-docs md ./ > README.md
 * ```
 
 * ## Contributing

--- a/templates/userdata.yaml.tpl
+++ b/templates/userdata.yaml.tpl
@@ -1,0 +1,5 @@
+#cloud-config
+# Allow user supplied pre userdata
+${pre_userdata}
+# Allow user supplied userdata
+${additional_userdata}

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,7 @@ variable "workers_group_defaults" {
   default = {
     name                 = "count.index" # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
     ami_id               = ""            # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.
+    distro               = "amazon"      # Worker distro (amazon or ubuntu).
     asg_desired_capacity = "1"           # Desired worker capacity in the autoscaling group.
     asg_max_size         = "3"           # Maximum worker capacity in the autoscaling group.
     asg_min_size         = "1"           # Minimum worker capacity in the autoscaling group.

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "workers_group_defaults" {
     asg_min_size         = "1"           # Minimum worker capacity in the autoscaling group.
     instance_type        = "m4.large"    # Size of the workers instances.
     spot_price           = ""            # Cost of spot instance.
-    root_volume_size     = "100"          # root volume size of workers instances.
+    root_volume_size     = "100"         # root volume size of workers instances.
     root_volume_type     = "gp2"         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops            = "0"           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name             = ""            # The key name that should be used for the instances in the autoscaling group

--- a/workers.tf
+++ b/workers.tf
@@ -32,12 +32,12 @@ resource "aws_launch_configuration" "workers" {
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.distros[lookup(var.worker_groups[count.index], "distro", var.workers_group_defaults["distro"])], "ami_id"))}"
 
-  instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", var.workers_group_defaults["instance_type"])}"
-  key_name                    = "${lookup(var.worker_groups[count.index], "key_name", var.workers_group_defaults["key_name"])}"
-  user_data_base64            = "${base64encode(element(data.template_file.userdata.*.rendered, count.index))}"
-  ebs_optimized               = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", var.workers_group_defaults["instance_type"]), false))}"
-  spot_price                  = "${lookup(var.worker_groups[count.index], "spot_price", var.workers_group_defaults["spot_price"])}"
-  count                       = "${var.worker_group_count}"
+  instance_type    = "${lookup(var.worker_groups[count.index], "instance_type", var.workers_group_defaults["instance_type"])}"
+  key_name         = "${lookup(var.worker_groups[count.index], "key_name", var.workers_group_defaults["key_name"])}"
+  user_data_base64 = "${base64encode(element(data.template_file.userdata.*.rendered, count.index))}"
+  ebs_optimized    = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", var.workers_group_defaults["instance_type"]), false))}"
+  spot_price       = "${lookup(var.worker_groups[count.index], "spot_price", var.workers_group_defaults["spot_price"])}"
+  count            = "${var.worker_group_count}"
 
   lifecycle {
     create_before_destroy = true
@@ -122,8 +122,8 @@ resource "null_resource" "tags_as_list_of_maps" {
   count = "${length(keys(var.tags))}"
 
   triggers = {
-    key                 = "${element(keys(var.tags), count.index)}",
-    value               = "${element(values(var.tags), count.index)}",
+    key                 = "${element(keys(var.tags), count.index)}"
+    value               = "${element(values(var.tags), count.index)}"
     propagate_at_launch = "true"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

* Added support for Ubuntu EKS worker nodes
* Minor code and documentation cleanup

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
