### PR TITLE
add t3 instance type settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - add spot_price option to aws_launch_configuration
 - add enable_monitoring option to aws_launch_configuration
+- add t3 instance class settings
 
 ### Changed
 

--- a/local.tf
+++ b/local.tf
@@ -64,6 +64,11 @@ locals {
     t2.large    = 35
     t2.xlarge   = 44
     t2.2xlarge  = 44
+    t3.small    = 8
+    t3.medium   = 17
+    t3.large    = 35
+    t3.xlarge   = 44
+    t3.2xlarge  = 44
     x1.16xlarge = 234
     x1.32xlarge = 234
   }
@@ -178,6 +183,11 @@ locals {
     "t2.nano"      = false
     "t2.small"     = false
     "t2.xlarge"    = false
+    "t3.small"     = false
+    "t3.medium"    = false
+    "t3.large"     = false
+    "t3.xlarge"    = false
+    "t3.2xlarge"   = false
     "x1.16xlarge"  = true
     "x1.32xlarge"  = true
     "x1e.16xlarge" = true


### PR DESCRIPTION
## Description

AWS announced [1] new t3 instance types, this PR adds the necessary configuration to use them. 

[1] https://aws.amazon.com/blogs/aws/new-t3-instances-burstable-cost-effective-performance/

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
