### PR TITLE
Fix typo with --node-labels

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "workers_group_defaults" {
     ebs_optimized        = true          # sets whether to use ebs optimization on supported types.
     enable_monitoring    = true          # Enables/disables detailed monitoring.
     public_ip            = false         # Associate a public ip address with a worker
-    kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-lables= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
+    kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-labels= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
     subnets              = ""            # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Fix typo with node-labels in comment

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
