### PR TITLE
Add registering nodes with taints feature via worker group config

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -82,5 +82,6 @@ data "template_file" "userdata" {
     pre_userdata        = "${lookup(var.worker_groups[count.index], "pre_userdata",lookup(var.workers_group_defaults, "pre_userdata"))}"
     additional_userdata = "${lookup(var.worker_groups[count.index], "additional_userdata",lookup(var.workers_group_defaults, "additional_userdata"))}"
     kubelet_node_labels = "${lookup(var.worker_groups[count.index], "kubelet_node_labels",lookup(var.workers_group_defaults, "kubelet_node_labels"))}"
+    kubelet_node_taints = "${lookup(var.worker_groups[count.index], "kubelet_node_taints",lookup(var.workers_group_defaults, "kubelet_node_taints"))}"
   }
 }

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -9,6 +9,10 @@ CA_CERTIFICATE_FILE_PATH=$CA_CERTIFICATE_DIRECTORY/ca.crt
 mkdir -p $CA_CERTIFICATE_DIRECTORY
 echo "${cluster_auth_base64}" | base64 -d >$CA_CERTIFICATE_FILE_PATH
 
+# Set kubelet --register-with-taints if kubelet_node_taints were set
+KUBELET_NODE_TAINTS=${kubelet_node_taints}
+if [[ $KUBELET_NODE_TAINTS != "" ]]; then sed -i '/INTERNAL_IP/a \ \ --register-with-taints='"$KUBELET_NODE_TAINTS"'\ \\' /etc/systemd/system/kubelet.service; fi
+
 # Set kubelet --node-labels if kubelet_node_labels were set
 KUBELET_NODE_LABELS=${kubelet_node_labels}
 if [[ $KUBELET_NODE_LABELS != "" ]]; then sed -i '/INTERNAL_IP/a \ \ --node-labels='"$KUBELET_NODE_LABELS"'\ \\' /etc/systemd/system/kubelet.service; fi

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,7 @@ variable "workers_group_defaults" {
     enable_monitoring    = true          # Enables/disables detailed monitoring.
     public_ip            = false         # Associate a public ip address with a worker
     kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-lables= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
+    kubelet_node_taints  = ""            # This string is passed directly to kubelet via --register-with-taints= if set. It should be comma separated "=:" with no spaces. If left empty no --register-with-taints switch is added.
     subnets              = ""            # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Add supports for tainting nodes on creation via worker group config values. Follows the same pattern as kubelet_node_labels.

### Checklist

- [/] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above


Ill update my PR to include all the checklist items, but wanted to make sure you all are interested in this change.