### PR TITLE
Example: remove public subnets from eks module call

### DIFF
--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -69,7 +69,7 @@ module "vpc" {
 module "eks" {
   source             = "../.."
   cluster_name       = "${local.cluster_name}"
-  subnets            = ["${module.vpc.public_subnets}", "${module.vpc.private_subnets}"]
+  subnets            = ["${module.vpc.private_subnets}"]
   tags               = "${local.tags}"
   vpc_id             = "${module.vpc.vpc_id}"
   worker_groups      = "${local.worker_groups}"


### PR DESCRIPTION
# PR o'clock

## Description

This is a fix for #104 . Passing public and private subnets to terraform-aws-eks causes nodes to end up as public or private at random. 

In current EKS implementation this works, as the magic `kubernetes.io/cluster/${local.cluster_name} = shared` tag is set on public subnets by the VPC module. This allows kubernetes to correctly create public ELBs.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
