### PR TITLE
allow additional security groups to be passed to worker launch config…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - add spot_price option to aws_launch_configuration
 - add enable_monitoring option to aws_launch_configuration
 - add t3 instance class settings
+- add optional input `worker_additional_security_group_ids` of type list that allows the passing of additional security groups for inclusion in the launch configuration of the worker nodes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
+| worker_additional_security_group_ids | A list of additional security group ids to attach to worker instances | list | `<list>` | no |
 | worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -69,7 +69,7 @@ module "vpc" {
 module "eks" {
   source             = "../.."
   cluster_name       = "${local.cluster_name}"
-  subnets            = ["${module.vpc.public_subnets}", "${module.vpc.private_subnets}"]
+  subnets            = ["${module.vpc.private_subnets}"]
   tags               = "${local.tags}"
   vpc_id             = "${module.vpc.vpc_id}"
   worker_groups      = "${local.worker_groups}"

--- a/variables.tf
+++ b/variables.tf
@@ -80,25 +80,25 @@ variable "workers_group_defaults" {
   type        = "map"
 
   default = {
-    name                 = "count.index" # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
-    ami_id               = ""            # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.
-    asg_desired_capacity = "1"           # Desired worker capacity in the autoscaling group.
-    asg_max_size         = "3"           # Maximum worker capacity in the autoscaling group.
-    asg_min_size         = "1"           # Minimum worker capacity in the autoscaling group.
-    instance_type        = "m4.large"    # Size of the workers instances.
-    spot_price           = ""            # Cost of spot instance.
-    root_volume_size     = "100"         # root volume size of workers instances.
-    root_volume_type     = "gp2"         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
-    root_iops            = "0"           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
-    key_name             = ""            # The key name that should be used for the instances in the autoscaling group
-    pre_userdata         = ""            # userdata to pre-append to the default userdata.
-    additional_userdata  = ""            # userdata to append to the default userdata.
-    ebs_optimized        = true          # sets whether to use ebs optimization on supported types.
-    enable_monitoring    = true          # Enables/disables detailed monitoring.
-    public_ip            = false         # Associate a public ip address with a worker
-    kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-labels= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
-    subnets              = ""            # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
-    additional_security_group_ids = ""   # A comma delimited string of security group ids to attach to worker nodes in this group.
+    name                          = "count.index" # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
+    ami_id                        = ""            # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.
+    asg_desired_capacity          = "1"           # Desired worker capacity in the autoscaling group.
+    asg_max_size                  = "3"           # Maximum worker capacity in the autoscaling group.
+    asg_min_size                  = "1"           # Minimum worker capacity in the autoscaling group.
+    instance_type                 = "m4.large"    # Size of the workers instances.
+    spot_price                    = ""            # Cost of spot instance.
+    root_volume_size              = "100"         # root volume size of workers instances.
+    root_volume_type              = "gp2"         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
+    root_iops                     = "0"           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
+    key_name                      = ""            # The key name that should be used for the instances in the autoscaling group
+    pre_userdata                  = ""            # userdata to pre-append to the default userdata.
+    additional_userdata           = ""            # userdata to append to the default userdata.
+    ebs_optimized                 = true          # sets whether to use ebs optimization on supported types.
+    enable_monitoring             = true          # Enables/disables detailed monitoring.
+    public_ip                     = false         # Associate a public ip address with a worker
+    kubelet_node_labels           = ""            # This string is passed directly to kubelet via --node-labels= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
+    subnets                       = ""            # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
+    additional_security_group_ids = ""            # A comma delimited string of security group ids to attach to worker nodes in this group.
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,7 @@ variable "workers_group_defaults" {
     public_ip            = false         # Associate a public ip address with a worker
     kubelet_node_labels  = ""            # This string is passed directly to kubelet via --node-labels= if set. It should be comma delimited with no spaces. If left empty no --node-labels switch is added.
     subnets              = ""            # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
+    additional_security_group_ids = ""   # A comma delimited string of security group ids to attach to worker nodes in this group.
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,9 @@ variable "kubeconfig_name" {
   description = "Override the default name used for items kubeconfig."
   default     = ""
 }
+
+variable "worker_additional_security_group_ids" {
+  description = "A list of additional security group ids to attach to worker instances"
+  type        = "list"
+  default     = []
+}

--- a/workers.tf
+++ b/workers.tf
@@ -23,7 +23,7 @@ resource "aws_autoscaling_group" "workers" {
 resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(var.workers_group_defaults, "public_ip"))}"
-  security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}"]
+  security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${lookup(var.worker_groups[count.index], "additional_security_group_ids", lookup(var.workers_group_defaults, "additional_security_group_ids"))}"]
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", data.aws_ami.eks_worker.id)}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type"))}"

--- a/workers.tf
+++ b/workers.tf
@@ -23,7 +23,7 @@ resource "aws_autoscaling_group" "workers" {
 resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(var.workers_group_defaults, "public_ip"))}"
-  security_groups             = ["${local.worker_security_group_id}"]
+  security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}"]
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", data.aws_ami.eks_worker.id)}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(var.workers_group_defaults, "instance_type"))}"


### PR DESCRIPTION
## Description
xref: #110 

Added optional input `worker_additional_security_group_ids` of type list that allows the passing of additional security groups for inclusion in the launch configuration of the worker nodes.

This is not a breaking change.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
