### PR TITLE
Allow a custom AMI to be specified as a default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - A subtle but thoughtful change. (Boomshakalaka, @self 🏀)
+- allow a custom AMI to be specified as a default (by @erks)
 
 ## [[v1.5.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.4.0...v1.5.0)] - 2018-08-30]
 

--- a/workers.tf
+++ b/workers.tf
@@ -26,7 +26,7 @@ resource "aws_launch_configuration" "workers" {
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(local.workers_group_defaults, "public_ip"))}"
   security_groups             = ["${local.worker_security_group_id}"]
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
-  image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", data.aws_ami.eks_worker.id)}"
+  image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.workers_group_defaults, "ami_id", data.aws_ami.eks_worker.id))}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(local.workers_group_defaults, "instance_type"))}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(local.workers_group_defaults, "key_name"))}"
   user_data_base64            = "${base64encode(element(data.template_file.userdata.*.rendered, count.index))}"


### PR DESCRIPTION
# PR o'clock

## Description

Allow a custom AMI to be specified as a default, instead of having to do it per worker group. This should also fix https://github.com/terraform-aws-modules/terraform-aws-eks/issues/85, which was closed without a fix (only a workaround).

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
