### PR TITLE
Allow to use existing IAM resources instead of creating new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Allow to use existing IAM resources instead of creating new ones
+- Enable cluster ARN output
+- Output AWS region from EKS module
+- Add more outputs for test fixture
+
+### Changed
+
+- Move kubectl template_files to kubectl.tf
+- Declare update_config_map_aws_auth dependency on the existence of a kubeconfig
+- Use EKS module output for AWS region output in test fixture
+
 ## [[v1.7.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.6.0...HEAD)] - 2018-09-??]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Full contributing [guidelines are covered here](https://github.com/terraform-aws
 Testing and using this repo requires a minimum set of IAM permissions. Test permissions
 are listed in the [eks_test_fixture README](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/eks_test_fixture/README.md).
 
+For environments with strict `iam:*` permissions, existing IAM roles can be provided. See `cluster_service_role_name`, `worker_instance_role_name` and `worker_instance_profile_name`.
+
 ## Change log
 
 The [changelog](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/CHANGELOG.md) captures all important release notes.
@@ -100,6 +102,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 |------|-------------|:----:|:-----:|:-----:|
 | cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
 | cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
+| cluster_service_role_name | If provided, the EKS cluster will use this service role. If not given, a service IAM role will be created with the necessary policies attached. | string | `` | no |
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
 | config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. Should end in a forward slash / . | string | `./` | no |
 | create_elb_service_linked_role | Whether to create the service linked role for the elasticloadbalancing service. Without this EKS cannot create ELBs. | string | `false` | no |
@@ -117,6 +120,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_additional_security_group_ids | A list of additional security group ids to attach to worker instances | list | `<list>` | no |
 | worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
+| worker_instance_profile_name | If provided, the EKS worker nodes will spawn using this EC2 instance IAM profile. If not given, an instance profile will be created with the necessary policies attached. | string | `` | no |
+| worker_instance_role_name | If provided, the EKS worker nodes will spawn using this EC2 instance IAM role. If not given, an instance role will be created with the necessary policies attached. | string | `` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
 | workers_group_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `<map>` | no |
@@ -126,15 +131,21 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description |
 |------|-------------|
+| aws_region | The AWS region of the resources. |
+| cluster_arn | The Amazon Resource Name (ARN) of the cluster. |
 | cluster_certificate_authority_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
 | cluster_endpoint | The endpoint for your EKS Kubernetes API. |
 | cluster_id | The name/id of the EKS cluster. |
 | cluster_security_group_id | Security group ID attached to the EKS cluster. |
+| cluster_service_role_arn | Service IAM role ARN attached to the EKS cluster. |
+| cluster_service_role_name | Service IAM role name attached to the EKS cluster. |
 | cluster_version | The Kubernetes server version for the EKS cluster. |
-| config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
-| kubeconfig | kubectl config file contents for this EKS cluster. |
-| worker_iam_role_arn | IAM role ID attached to EKS workers |
-| worker_iam_role_name | IAM role name attached to EKS workers |
+| config_map_aws_auth | A kubernetes configuration to authenticate to the EKS cluster. |
+| kubeconfig | kubectl config file contents for the EKS cluster. |
+| worker_instance_profile_arn | EC2 instance IAM role ARN attached to the EKS workers. |
+| worker_instance_profile_name | EC2 instance IAM role ARN attached to the EKS workers. |
+| worker_instance_role_arn | Instance IAM role ARN attached to the EKS workers. |
+| worker_instance_role_name | Instance IAM role name attached to the EKS workers. |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
-| workers_asg_arns | IDs of the autoscaling groups containing workers. |
+| workers_asg_arns | ARNs of the autoscaling groups containing workers. |
 | workers_asg_names | Names of the autoscaling groups containing workers. |

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -20,7 +20,7 @@ data "template_file" "config_map_aws_auth" {
   template = "${file("${path.module}/templates/config-map-aws-auth.yaml.tpl")}"
 
   vars {
-    worker_role_arn = "${aws_iam_role.workers.arn}"
+    worker_role_arn = "${data.aws_iam_role.workers.arn}"
     map_users       = "${join("", data.template_file.map_users.*.rendered)}"
     map_roles       = "${join("", data.template_file.map_roles.*.rendered)}"
     map_accounts    = "${join("", data.template_file.map_accounts.*.rendered)}"

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -16,7 +16,7 @@ resource "null_resource" "update_config_map_aws_auth" {
   count = "${var.manage_aws_auth ? 1 : 0}"
 
   depends_on = [
-    "local_file.kubeconfig"
+    "local_file.kubeconfig",
   ]
 }
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -14,6 +14,10 @@ resource "null_resource" "update_config_map_aws_auth" {
   }
 
   count = "${var.manage_aws_auth ? 1 : 0}"
+
+  depends_on = [
+    "local_file.kubeconfig"
+  ]
 }
 
 data "template_file" "config_map_aws_auth" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_cluster" "this" {
   name     = "${var.cluster_name}"
-  role_arn = "${aws_iam_role.cluster.arn}"
+  role_arn = "${data.aws_iam_role.cluster.arn}"
   version  = "${var.cluster_version}"
 
   vpc_config {
@@ -47,16 +47,19 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
 resource "aws_iam_role" "cluster" {
   name_prefix        = "${var.cluster_name}"
   assume_role_policy = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"
+  count              = "${var.cluster_service_role_name == "" ? 1 : 0}"
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
   role       = "${aws_iam_role.cluster.name}"
+  count      = "${var.cluster_service_role_name == "" ? 1 : 0}"
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
   role       = "${aws_iam_role.cluster.name}"
+  count      = "${var.cluster_service_role_name == "" ? 1 : 0}"
 }
 
 resource "aws_iam_service_linked_role" "elasticloadbalancing" {

--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,13 @@
 data "aws_region" "current" {}
 
+data "aws_iam_role" "workers" {
+  name = "${local.worker_instance_role_name}"
+}
+
+data "aws_iam_instance_profile" "workers" {
+  name = "${local.worker_instance_profile_name}"
+}
+
 data "aws_iam_policy_document" "workers_assume_role_policy" {
   statement {
     sid = "EKSWorkerAssumeRole"
@@ -23,6 +31,10 @@ data "aws_ami" "eks_worker" {
 
   most_recent = true
   owners      = ["602401143452"] # Amazon
+}
+
+data "aws_iam_role" "cluster" {
+  name = "${local.cluster_service_role_name}"
 }
 
 data "aws_iam_policy_document" "cluster_assume_role_policy" {

--- a/data.tf
+++ b/data.tf
@@ -52,35 +52,6 @@ data "aws_iam_policy_document" "cluster_assume_role_policy" {
   }
 }
 
-data "template_file" "kubeconfig" {
-  template = "${file("${path.module}/templates/kubeconfig.tpl")}"
-
-  vars {
-    cluster_name                      = "${aws_eks_cluster.this.name}"
-    kubeconfig_name                   = "${local.kubeconfig_name}"
-    endpoint                          = "${aws_eks_cluster.this.endpoint}"
-    region                            = "${data.aws_region.current.name}"
-    cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    aws_authenticator_command         = "${var.kubeconfig_aws_authenticator_command}"
-    aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : "" }"
-    aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"
-  }
-}
-
-data "template_file" "aws_authenticator_env_variables" {
-  template = <<EOF
-        - name: $${key}
-          value: $${value}
-EOF
-
-  count = "${length(var.kubeconfig_aws_authenticator_env_variables)}"
-
-  vars {
-    value = "${element(values(var.kubeconfig_aws_authenticator_env_variables), count.index)}"
-    key   = "${element(keys(var.kubeconfig_aws_authenticator_env_variables), count.index)}"
-  }
-}
-
 data "template_file" "userdata" {
   template = "${file("${path.module}/templates/userdata.sh.tpl")}"
   count    = "${var.worker_group_count}"

--- a/examples/eks_test_fixture/outputs.tf
+++ b/examples/eks_test_fixture/outputs.tf
@@ -1,3 +1,8 @@
+output "region" {
+  description = "AWS region."
+  value       = "${module.eks.aws_region}"
+}
+
 output "cluster_endpoint" {
   description = "Endpoint for EKS control plane."
   value       = "${module.eks.cluster_endpoint}"
@@ -16,9 +21,4 @@ output "kubectl_config" {
 output "config_map_aws_auth" {
   description = ""
   value       = "${module.eks.config_map_aws_auth}"
-}
-
-output "region" {
-  description = "AWS region."
-  value       = "${var.region}"
 }

--- a/examples/eks_test_fixture/outputs.tf
+++ b/examples/eks_test_fixture/outputs.tf
@@ -3,9 +3,24 @@ output "region" {
   value       = "${module.eks.aws_region}"
 }
 
+output "cluster_id" {
+  description = "The name/id of the EKS cluster."
+  value       = "${module.eks.cluster_id}"
+}
+
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster."
+  value       = "${module.eks.cluster_arn}"
+}
+
 output "cluster_endpoint" {
   description = "Endpoint for EKS control plane."
   value       = "${module.eks.cluster_endpoint}"
+}
+
+output "cluster_version" {
+  description = "The Kubernetes server version for the EKS cluster."
+  value       = "${module.eks.cluster_version}"
 }
 
 output "cluster_security_group_id" {

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,3 +1,32 @@
+data "template_file" "kubeconfig" {
+  template = "${file("${path.module}/templates/kubeconfig.tpl")}"
+
+  vars {
+    cluster_name                      = "${aws_eks_cluster.this.name}"
+    kubeconfig_name                   = "${local.kubeconfig_name}"
+    endpoint                          = "${aws_eks_cluster.this.endpoint}"
+    region                            = "${data.aws_region.current.name}"
+    cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
+    aws_authenticator_command         = "${var.kubeconfig_aws_authenticator_command}"
+    aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : "" }"
+    aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"
+  }
+}
+
+data "template_file" "aws_authenticator_env_variables" {
+  template = <<EOF
+        - name: $${key}
+          value: $${value}
+EOF
+
+  count = "${length(var.kubeconfig_aws_authenticator_env_variables)}"
+
+  vars {
+    value = "${element(values(var.kubeconfig_aws_authenticator_env_variables), count.index)}"
+    key   = "${element(keys(var.kubeconfig_aws_authenticator_env_variables), count.index)}"
+  }
+}
+
 resource "local_file" "kubeconfig" {
   content  = "${data.template_file.kubeconfig.rendered}"
   filename = "${var.config_output_path}kubeconfig_${var.cluster_name}"

--- a/local.tf
+++ b/local.tf
@@ -1,11 +1,12 @@
 locals {
   asg_tags = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
 
-  kubeconfig_name              = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
+  kubeconfig_name = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
   # Followed recommendation http://67bricks.com/blog/?p=85
   # to workaround terraform not supporting short circut evaluation
   cluster_service_role_name = "${coalesce(join("", aws_iam_role.cluster.*.name), var.cluster_service_role_name)}"
+
   cluster_security_group_id = "${coalesce(join("", aws_security_group.cluster.*.id), var.cluster_security_group_id)}"
 
   worker_instance_role_name    = "${coalesce(join("", aws_iam_role.workers.*.name), var.worker_instance_role_name)}"

--- a/local.tf
+++ b/local.tf
@@ -1,12 +1,16 @@
 locals {
   asg_tags = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
 
+  kubeconfig_name              = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
+
   # Followed recommendation http://67bricks.com/blog/?p=85
   # to workaround terraform not supporting short circut evaluation
+  cluster_service_role_name = "${coalesce(join("", aws_iam_role.cluster.*.name), var.cluster_service_role_name)}"
   cluster_security_group_id = "${coalesce(join("", aws_security_group.cluster.*.id), var.cluster_security_group_id)}"
 
-  worker_security_group_id = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
-  kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
+  worker_instance_role_name    = "${coalesce(join("", aws_iam_role.workers.*.name), var.worker_instance_role_name)}"
+  worker_instance_profile_name = "${coalesce(join("", aws_iam_instance_profile.workers.*.name), var.worker_instance_profile_name)}"
+  worker_security_group_id     = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
 
   workers_group_defaults_defaults = {
     name                          = "count.index"                   # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,8 @@
 * Testing and using this repo requires a minimum set of IAM permissions. Test permissions
 * are listed in the [eks_test_fixture README](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/eks_test_fixture/README.md).
 
+* For environments with strict `iam:*` permissions, existing IAM roles can be provided. See `cluster_service_role_name`, `worker_instance_role_name` and `worker_instance_profile_name`.
+
 * ## Change log
 
 * The [changelog](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/CHANGELOG.md) captures all important release notes.

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,10 @@ output "cluster_id" {
   value       = "${aws_eks_cluster.this.id}"
 }
 
-# Though documented, not yet supported
-# output "cluster_arn" {
-#   description = "The Amazon Resource Name (ARN) of the cluster."
-#   value       = "${aws_eks_cluster.this.arn}"
-# }
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster."
+  value       = "${aws_eks_cluster.this.arn}"
+}
 
 output "cluster_certificate_authority_data" {
   description = "Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster."

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_version" {
   value       = "${aws_eks_cluster.this.version}"
 }
 
+output "cluster_service_role_arn" {
+  description = "Service IAM role ARN attached to the EKS cluster."
+  value       = "${data.aws_iam_role.cluster.arn}"
+}
+
+output "cluster_service_role_name" {
+  description = "Service IAM role name attached to the EKS cluster."
+  value       = "${data.aws_iam_role.cluster.name}"
+}
+
 output "cluster_security_group_id" {
   description = "Security group ID attached to the EKS cluster."
   value       = "${local.cluster_security_group_id}"
@@ -54,12 +64,22 @@ output "worker_security_group_id" {
   value       = "${local.worker_security_group_id}"
 }
 
-output "worker_iam_role_name" {
-  description = "IAM role name attached to EKS workers"
-  value       = "${aws_iam_role.workers.name}"
+output "worker_instance_role_arn" {
+  description = "Instance IAM role ARN attached to EKS workers"
+  value       = "${data.aws_iam_role.workers.arn}"
 }
 
-output "worker_iam_role_arn" {
-  description = "IAM role ID attached to EKS workers"
-  value       = "${aws_iam_role.workers.arn}"
+output "worker_instance_role_name" {
+  description = "Instance IAM role name attached to EKS workers"
+  value       = "${data.aws_iam_role.workers.name}"
+}
+
+output "worker_instance_profile_arn" {
+  description = "EC2 instance IAM role ARN attached to EKS workers"
+  value       = "${data.aws_iam_instance_profile.workers.arn}"
+}
+
+output "worker_instance_profile_name" {
+  description = "EC2 instance IAM role ARN attached to EKS workers"
+  value       = "${data.aws_iam_instance_profile.workers.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,17 +44,17 @@ output "cluster_security_group_id" {
 }
 
 output "config_map_aws_auth" {
-  description = "A kubernetes configuration to authenticate to this EKS cluster."
+  description = "A kubernetes configuration to authenticate to the EKS cluster."
   value       = "${data.template_file.config_map_aws_auth.rendered}"
 }
 
 output "kubeconfig" {
-  description = "kubectl config file contents for this EKS cluster."
+  description = "kubectl config file contents for the EKS cluster."
   value       = "${data.template_file.kubeconfig.rendered}"
 }
 
 output "workers_asg_arns" {
-  description = "IDs of the autoscaling groups containing workers."
+  description = "ARNs of the autoscaling groups containing workers."
   value       = "${aws_autoscaling_group.workers.*.arn}"
 }
 
@@ -69,21 +69,21 @@ output "worker_security_group_id" {
 }
 
 output "worker_instance_role_arn" {
-  description = "Instance IAM role ARN attached to EKS workers"
+  description = "Instance IAM role ARN attached to the EKS workers."
   value       = "${data.aws_iam_role.workers.arn}"
 }
 
 output "worker_instance_role_name" {
-  description = "Instance IAM role name attached to EKS workers"
+  description = "Instance IAM role name attached to the EKS workers."
   value       = "${data.aws_iam_role.workers.name}"
 }
 
 output "worker_instance_profile_arn" {
-  description = "EC2 instance IAM role ARN attached to EKS workers"
+  description = "EC2 instance IAM role ARN attached to the EKS workers."
   value       = "${data.aws_iam_instance_profile.workers.arn}"
 }
 
 output "worker_instance_profile_name" {
-  description = "EC2 instance IAM role ARN attached to EKS workers"
+  description = "EC2 instance IAM role ARN attached to the EKS workers."
   value       = "${data.aws_iam_instance_profile.workers.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "aws_region" {
+  description = "The AWS region of the resources."
+  value       = "${data.aws_region.current.name}"
+}
+
 output "cluster_id" {
   description = "The name/id of the EKS cluster."
   value       = "${aws_eks_cluster.this.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "cluster_name" {
   description = "Name of the EKS cluster. Also used as a prefix in names of related resources."
 }
 
+variable "cluster_service_role_name" {
+  description = "If provided, the EKS cluster will use this service role. If not given, a service IAM role will be created with the necessary policies attached."
+  default     = ""
+}
+
 variable "cluster_security_group_id" {
   description = "If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32."
   default     = ""
@@ -84,6 +89,16 @@ variable "workers_group_defaults" {
   description = "Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys."
   type        = "map"
   default     = {}
+}
+
+variable "worker_instance_role_name" {
+  description = "If provided, the EKS worker nodes will spawn using this EC2 instance IAM role. If not given, an instance role will be created with the necessary policies attached."
+  default     = ""
+}
+
+variable "worker_instance_profile_name" {
+  description = "If provided, the EKS worker nodes will spawn using this EC2 instance IAM profile. If not given, an instance profile will be created with the necessary policies attached."
+  default     = ""
 }
 
 variable "worker_security_group_id" {


### PR DESCRIPTION
# PR o'clock

## Description

This PR adds the ability to conditionally use existing IAM roles and instance profiles instead of creating new ones.

The feature is crucial in organizations where you have very strict `iam:*` access and can't freely create/attach/pass roles.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example) 
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [X] Docs have been updated using `terraform-docs` per `README.md` instructions
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above
