### PR TITLE
Adding support for Ubuntu and GPU worker AMIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- A useful addition (slam dunk, @self 🔥)
+- Added support for EKS GPU and Ubuntu AMIs. (by @max-rocket-internet)
 
 ### Changed
 

--- a/data.tf
+++ b/data.tf
@@ -15,14 +15,34 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
   }
 }
 
-data "aws_ami" "eks_worker" {
+data "aws_ami" "eks_default" {
   filter {
     name   = "name"
     values = ["amazon-eks-node-*"]
   }
 
   most_recent = true
-  owners      = ["602401143452"] # Amazon
+  owners      = ["602401143452"]
+}
+
+data "aws_ami" "eks_gpu" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-gpu-node-*"]
+  }
+
+  most_recent = true
+  owners      = ["679593333241"]
+}
+
+data "aws_ami" "ubuntu" {
+  filter {
+    name   = "name"
+    values = ["ubuntu-eks/*"]
+  }
+
+  most_recent = true
+  owners      = ["099720109477"]
 }
 
 data "aws_iam_policy_document" "cluster_assume_role_policy" {

--- a/local.tf
+++ b/local.tf
@@ -8,27 +8,39 @@ locals {
   worker_security_group_id = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
   kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
+  ami_id = {
+    # The default EKS AMI maintained and supported by AWS.
+    eks_default = "${data.aws_ami.eks_default.id}"
+
+    # Same as above but with GPU support.
+    eks_gpu = "${data.aws_ami.eks_gpu.id}"
+
+    # EKS AMI built from minimal Ubuntu OS. Maintained by Ubuntu and supported by AWS.
+    ubuntu = "${data.aws_ami.ubuntu.id}"
+  }
+
   workers_group_defaults_defaults = {
-    name                          = "count.index"                   # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
-    ami_id                        = "${data.aws_ami.eks_worker.id}" # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.
-    asg_desired_capacity          = "1"                             # Desired worker capacity in the autoscaling group.
-    asg_max_size                  = "3"                             # Maximum worker capacity in the autoscaling group.
-    asg_min_size                  = "1"                             # Minimum worker capacity in the autoscaling group.
-    instance_type                 = "m4.large"                      # Size of the workers instances.
-    spot_price                    = ""                              # Cost of spot instance.
-    root_volume_size              = "100"                           # root volume size of workers instances.
-    root_volume_type              = "gp2"                           # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
-    root_iops                     = "0"                             # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
-    key_name                      = ""                              # The key name that should be used for the instances in the autoscaling group
-    pre_userdata                  = ""                              # userdata to pre-append to the default userdata.
-    additional_userdata           = ""                              # userdata to append to the default userdata.
-    ebs_optimized                 = true                            # sets whether to use ebs optimization on supported types.
-    enable_monitoring             = true                            # Enables/disables detailed monitoring.
-    public_ip                     = false                           # Associate a public ip address with a worker
-    kubelet_extra_args            = ""                              # This string is passed directly to kubelet if set. Useful for adding labels or taints.
-    subnets                       = ""                              # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
-    autoscaling_enabled           = false                           # Sets whether policy and matching tags will be added to allow autoscaling.
-    additional_security_group_ids = ""                              # A comman delimited list of additional security group ids to include in worker launch config
+    name                          = "count.index"                    # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
+    ami_type                      = "eks_default"                    # What type of AMI ID to use. See local.ami_id for options.
+    ami_id                        = "${local.ami_id["eks_default"]}" # AMI ID for the eks workers. If none is provided, the default EKS AMI from AWS will be used. See local.ami_id for options.
+    asg_desired_capacity          = "1"                              # Desired worker capacity in the autoscaling group.
+    asg_max_size                  = "3"                              # Maximum worker capacity in the autoscaling group.
+    asg_min_size                  = "1"                              # Minimum worker capacity in the autoscaling group.
+    instance_type                 = "m4.large"                       # Size of the workers instances.
+    spot_price                    = ""                               # Cost of spot instance.
+    root_volume_size              = "100"                            # root volume size of workers instances.
+    root_volume_type              = "gp2"                            # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
+    root_iops                     = "0"                              # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
+    key_name                      = ""                               # The key name that should be used for the instances in the autoscaling group
+    pre_userdata                  = ""                               # userdata to pre-append to the default userdata.
+    additional_userdata           = ""                               # userdata to append to the default userdata.
+    ebs_optimized                 = true                             # sets whether to use ebs optimization on supported types.
+    enable_monitoring             = true                             # Enables/disables detailed monitoring.
+    public_ip                     = false                            # Associate a public ip address with a worker
+    kubelet_extra_args            = ""                               # This string is passed directly to kubelet if set. Useful for adding labels or taints.
+    subnets                       = ""                               # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
+    autoscaling_enabled           = false                            # Sets whether policy and matching tags will be added to allow autoscaling.
+    additional_security_group_ids = ""                               # A comman delimited list of additional security group ids to include in worker launch config
   }
 
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -4,7 +4,7 @@
 ${pre_userdata}
 
 # Bootstrap and join the cluster
-/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
+test -f /etc/eks/bootstrap.sh && /etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
 
 # Allow user supplied userdata code
 ${additional_userdata}

--- a/workers.tf
+++ b/workers.tf
@@ -26,7 +26,7 @@ resource "aws_launch_configuration" "workers" {
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(local.workers_group_defaults, "public_ip"))}"
   security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups[count.index],"additional_security_group_ids",lookup(local.workers_group_defaults, "additional_security_group_ids"))))}"]
   iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
-  image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.workers_group_defaults, "ami_id"))}"
+  image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.ami_id, lookup(var.worker_groups[count.index], "ami_type", lookup(local.workers_group_defaults, "ami_type"))))}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(local.workers_group_defaults, "instance_type"))}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(local.workers_group_defaults, "key_name"))}"
   user_data_base64            = "${base64encode(element(data.template_file.userdata.*.rendered, count.index))}"


### PR DESCRIPTION
# PR o'clock

## Description

Adding 3 options for AMIS:

- EKS standard: https://github.com/awslabs/amazon-eks-ami
- EKS GPU: https://docs.aws.amazon.com/eks/latest/userguide/gpu-ami.html
- Ubuntu: https://blog.ubuntu.com/2018/06/06/ubuntu-to-host-containers-in-amazons-eks-for-container-portability & https://cloud-images.ubuntu.com/docs/aws/eks/amazon-eks-ubuntu-nodegroup.yaml

If I've done this correctly, the order of preference for the AMI is:

1. `ami_id` in `worker_groups` map
2. `ami_type` in `worker_groups` map
3. `ami_type` in `workers_group_defaults` map

*NOTE* I can't work out a nice and clean way to allow these changes and also allow setting an `ami_id` in `workers_group_defaults`.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
