### PR TITLE
Fix default worker autoscaling_enabled not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - A subtle but thoughtful change. (Boomshakalaka, @self 🏀)
 - fix default worker subnets not working (by @erks)
+- fix default worker autoscaling_enabled not working (by @erks)
 
 ## [[v1.6.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.5.0...v1.6.0)] - 2018-09-04]
 

--- a/workers.tf
+++ b/workers.tf
@@ -11,7 +11,7 @@ resource "aws_autoscaling_group" "workers" {
     list(
       map("key", "Name", "value", "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}-eks_asg", "propagate_at_launch", true),
       map("key", "kubernetes.io/cluster/${aws_eks_cluster.this.name}", "value", "owned", "propagate_at_launch", true),
-      map("key", "k8s.io/cluster-autoscaler/${lookup(var.worker_groups[count.index], "autoscaling_enabled", count.index) == 1 ? "enabled" : "disabled"  }", "value", "true", "propagate_at_launch", false),
+      map("key", "k8s.io/cluster-autoscaler/${lookup(var.worker_groups[count.index], "autoscaling_enabled", lookup(local.workers_group_defaults, "autoscaling_enabled")) == 1 ? "enabled" : "disabled"  }", "value", "true", "propagate_at_launch", false),
     ),
     local.asg_tags)
   }"]


### PR DESCRIPTION
# PR o'clock

## Description

A fix for `autoscaling_enabled` in `var.workers_group_defaults` not doing anything.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
