### PR TITLE
Add worker group option to protect from scale in.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - A subtle but thoughtful change. (Boomshakalaka, @self 🏀)
 - fix default worker subnets not working (by @erks)
 - fix default worker autoscaling_enabled not working (by @erks)
+- add `protect_from_scale_in` to solve issue #134 (by @kinghajj)
 
 ## [[v1.6.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.5.0...v1.6.0)] - 2018-09-04]
 

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -2,6 +2,7 @@
 
 Autoscaling of worker nodes can be easily enabled by setting the `autoscaling_enabled` variable to `true` for a worker group in the `worker_groups` map.
 This will add the required tags to the autoscaling group for the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
+One should also set `protect_from_scale_in` to `true` for such worker groups, to ensure that cluster-autoscaler is solely responsible for scaling events.
 
 You will also need to install the cluster-autoscaler into your cluster. The easiest way to do this is with [helm](https://helm.sh/).
 

--- a/local.tf
+++ b/local.tf
@@ -29,6 +29,7 @@ locals {
     subnets                       = "${join(",", var.subnets)}"     # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
     autoscaling_enabled           = false                           # Sets whether policy and matching tags will be added to allow autoscaling.
     additional_security_group_ids = ""                              # A comman delimited list of additional security group ids to include in worker launch config
+    protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
   }
 
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"

--- a/workers.tf
+++ b/workers.tf
@@ -1,11 +1,12 @@
 resource "aws_autoscaling_group" "workers" {
-  name_prefix          = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
-  desired_capacity     = "${lookup(var.worker_groups[count.index], "asg_desired_capacity", lookup(local.workers_group_defaults, "asg_desired_capacity"))}"
-  max_size             = "${lookup(var.worker_groups[count.index], "asg_max_size",lookup(local.workers_group_defaults, "asg_max_size"))}"
-  min_size             = "${lookup(var.worker_groups[count.index], "asg_min_size",lookup(local.workers_group_defaults, "asg_min_size"))}"
-  launch_configuration = "${element(aws_launch_configuration.workers.*.id, count.index)}"
-  vpc_zone_identifier  = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), lookup(local.workers_group_defaults, "subnets")))}"]
-  count                = "${var.worker_group_count}"
+  name_prefix           = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
+  desired_capacity      = "${lookup(var.worker_groups[count.index], "asg_desired_capacity", lookup(local.workers_group_defaults, "asg_desired_capacity"))}"
+  max_size              = "${lookup(var.worker_groups[count.index], "asg_max_size",lookup(local.workers_group_defaults, "asg_max_size"))}"
+  min_size              = "${lookup(var.worker_groups[count.index], "asg_min_size",lookup(local.workers_group_defaults, "asg_min_size"))}"
+  launch_configuration  = "${element(aws_launch_configuration.workers.*.id, count.index)}"
+  vpc_zone_identifier   = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), lookup(local.workers_group_defaults, "subnets")))}"]
+  count                 = "${var.worker_group_count}"
+  protect_from_scale_in = "${lookup(var.worker_groups[count.index], "protect_from_scale_in", lookup(local.workers_group_defaults, "protect_from_scale_in"))}"
 
   tags = ["${concat(
     list(


### PR DESCRIPTION
# PR o'clock

## Description

See #134. Without setting `protect_from_scale_in=true` on a worker group with `autoscaling_enabled=true`, it's possible for AWS to terminate nodes before cluster-autoscaler. This is suboptimal, because AWS doesn't know which nodes are being used, and can cause temporary outages. This PR keeps the default as `false`, but notes in the docs that it should be set to `true`.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [X] Docs have been updated using `terraform-docs` per `README.md` instructions
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above
