### PR TITLE
allow specifying an IAM role for each worker group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - A useful addition (slam dunk, @self 🔥)
+- Worker groups can be created with independent IAM profiles. (from @laverya)
 
 ### Changed
 
 - A subtle but thoughtful change. (Boomshakalaka, @self 🏀)
 - fix default worker subnets not working (by @erks)
 - fix default worker autoscaling_enabled not working (by @erks)
-- Worker groups can be created with independent IAM profiles. (from @laverya)
 
 ## [[v1.6.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.5.0...v1.6.0)] - 2018-09-04]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - A subtle but thoughtful change. (Boomshakalaka, @self 🏀)
 - fix default worker subnets not working (by @erks)
 - fix default worker autoscaling_enabled not working (by @erks)
+- Worker groups can be created with independent IAM profiles. (from @laverya)
 
 ## [[v1.6.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.5.0...v1.6.0)] - 2018-09-04]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - A useful addition (slam dunk, @self 🔥)
-- Worker groups can be created with independent IAM profiles. (from @laverya)
+- Worker groups can be created with a specified IAM profile. (from @laverya)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| multiple_worker_group_iam_roles | If provided, an IAM role will be created for each worker group instead of all worker groups sharing the same role. | string | `` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
@@ -134,10 +133,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_version | The Kubernetes server version for the EKS cluster. |
 | config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
-| worker_iam_role_arn | IAM role ID attached to the first EKS worker group |
-| worker_iam_role_arns | IAM role IDs attached to EKS workers |
-| worker_iam_role_name | IAM role name attached to the first EKS worker group |
-| worker_iam_role_names | IAM role names attached to EKS workers |
+| worker_iam_role_arn | default IAM role name for EKS worker groups |
+| worker_iam_role_name | default IAM role name for EKS worker groups |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
 | workers_asg_names | Names of the autoscaling groups containing workers. |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| multiple_worker_group_iam_roles | If provided, an IAM role will be created for each worker group instead of all worker groups sharing the same role. | string | `` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
@@ -133,8 +134,10 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_version | The Kubernetes server version for the EKS cluster. |
 | config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
-| worker_iam_role_arn | IAM role ID attached to EKS workers |
-| worker_iam_role_name | IAM role name attached to EKS workers |
+| worker_iam_role_arn | IAM role ID attached to the first EKS worker group |
+| worker_iam_role_arns | IAM role IDs attached to EKS workers |
+| worker_iam_role_name | IAM role name attached to the first EKS worker group |
+| worker_iam_role_names | IAM role names attached to EKS workers |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
 | workers_asg_names | Names of the autoscaling groups containing workers. |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_version | The Kubernetes server version for the EKS cluster. |
 | config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
-| worker_iam_role_arn | default IAM role name for EKS worker groups |
+| worker_iam_role_arn | default IAM role ARN for EKS worker groups |
 | worker_iam_role_name | default IAM role name for EKS worker groups |
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -16,12 +16,15 @@ resource "null_resource" "update_config_map_aws_auth" {
   count = "${var.manage_aws_auth ? 1 : 0}"
 }
 
+data "aws_caller_identity" "current" {}
+
 data "template_file" "worker_role_arns" {
-  count    = "${var.worker_group_count}"
-  template = "${file("${path.module}/templates/worker-role.tpl")}"
+  depends_on = ["aws_launch_configuration.workers"]
+  count      = "${var.worker_group_count}"
+  template   = "${file("${path.module}/templates/worker-role.tpl")}"
 
   vars {
-    worker_role_arn = "${"${element(aws_iam_instance_profile.workers.*.role, count.index)}"}"
+    worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${element(aws_iam_instance_profile.workers.*.role, count.index)}"
   }
 }
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -21,7 +21,7 @@ data "template_file" "worker_role_arns" {
   template = "${file("${path.module}/templates/worker-role.tpl")}"
 
   vars {
-    worker_role_arn = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", "") != "" ? lookup(local.workers_group_defaults, "iam_role_id", "") : aws_iam_instance_profile.workers.id)}"
+    worker_role_arn = "${"${element(aws_iam_instance_profile.workers.*.role, count.index)}"}"
   }
 }
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -19,8 +19,8 @@ resource "null_resource" "update_config_map_aws_auth" {
 data "aws_caller_identity" "current" {}
 
 data "template_file" "worker_role_arns" {
-  count      = "${var.worker_group_count}"
-  template   = "${file("${path.module}/templates/worker-role.tpl")}"
+  count    = "${var.worker_group_count}"
+  template = "${file("${path.module}/templates/worker-role.tpl")}"
 
   vars {
     worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${element(aws_iam_instance_profile.workers.*.role, count.index)}"

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -19,7 +19,6 @@ resource "null_resource" "update_config_map_aws_auth" {
 data "aws_caller_identity" "current" {}
 
 data "template_file" "worker_role_arns" {
-  depends_on = ["aws_launch_configuration.workers"]
   count      = "${var.worker_group_count}"
   template   = "${file("${path.module}/templates/worker-role.tpl")}"
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -21,7 +21,7 @@ data "template_file" "worker_role_arns" {
   template = "${file("${path.module}/templates/worker-role.tpl")}"
 
   vars {
-    worker_role_arn = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", aws_iam_role.workers.id))}"
+    worker_role_arn = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", "") != "" ? lookup(local.workers_group_defaults, "iam_role_id", "") : aws_iam_instance_profile.workers.id)}"
   }
 }
 

--- a/local.tf
+++ b/local.tf
@@ -30,7 +30,7 @@ locals {
     autoscaling_enabled           = false                           # Sets whether policy and matching tags will be added to allow autoscaling.
     additional_security_group_ids = ""                              # A comman delimited list of additional security group ids to include in worker launch config
     protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
-    iam_role_id                   = ""                              # Use the specified IAM role if set.
+    iam_role_id                   = "${aws_iam_role.workers.id}"    # Use the specified IAM role if set.
   }
 
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"

--- a/local.tf
+++ b/local.tf
@@ -159,6 +159,4 @@ locals {
     "x1e.8xlarge"  = true
     "x1e.xlarge"   = true
   }
-
-  worker_iam_role_count = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }

--- a/local.tf
+++ b/local.tf
@@ -157,4 +157,6 @@ locals {
     "x1e.8xlarge"  = true
     "x1e.xlarge"   = true
   }
+
+  worker_iam_role_count = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }

--- a/local.tf
+++ b/local.tf
@@ -30,6 +30,7 @@ locals {
     autoscaling_enabled           = false                           # Sets whether policy and matching tags will be added to allow autoscaling.
     additional_security_group_ids = ""                              # A comman delimited list of additional security group ids to include in worker launch config
     protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
+    iam_role_id                   = ""                              # Use the specified IAM role if set.
   }
 
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,11 +55,21 @@ output "worker_security_group_id" {
 }
 
 output "worker_iam_role_name" {
-  description = "IAM role name attached to EKS workers"
-  value       = "${aws_iam_role.workers.name}"
+  description = "IAM role name attached to the first EKS worker group"
+  value       = "${element(aws_iam_instance_profile.workers.*.name, 0)}"
 }
 
 output "worker_iam_role_arn" {
-  description = "IAM role ID attached to EKS workers"
-  value       = "${aws_iam_role.workers.arn}"
+  description = "IAM role ID attached to the first EKS worker group"
+  value       = "${element(aws_iam_instance_profile.workers.*.arn, 0)}"
+}
+
+output "worker_iam_role_names" {
+  description = "IAM role names attached to EKS workers"
+  value       = "${aws_iam_role.workers.*.name}"
+}
+
+output "worker_iam_role_arns" {
+  description = "IAM role IDs attached to EKS workers"
+  value       = "${aws_iam_role.workers.*.arn}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -56,12 +56,12 @@ output "worker_security_group_id" {
 
 output "worker_iam_role_name" {
   description = "IAM role name attached to the first EKS worker group"
-  value       = "${element(aws_iam_instance_profile.workers.*.name, 0)}"
+  value       = "${element(aws_iam_role.workers.*.name, 0)}"
 }
 
 output "worker_iam_role_arn" {
   description = "IAM role ID attached to the first EKS worker group"
-  value       = "${element(aws_iam_instance_profile.workers.*.arn, 0)}"
+  value       = "${element(aws_iam_role.workers.*.arn, 0)}"
 }
 
 output "worker_iam_role_names" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,21 +55,11 @@ output "worker_security_group_id" {
 }
 
 output "worker_iam_role_name" {
-  description = "IAM role name attached to the first EKS worker group"
-  value       = "${element(aws_iam_role.workers.*.name, 0)}"
+  description = "default IAM role name for EKS worker groups"
+  value       = "${element(aws_iam_role.workers.name, 0)}"
 }
 
 output "worker_iam_role_arn" {
-  description = "IAM role ID attached to the first EKS worker group"
-  value       = "${element(aws_iam_role.workers.*.arn, 0)}"
-}
-
-output "worker_iam_role_names" {
-  description = "IAM role names attached to EKS workers"
-  value       = "${aws_iam_role.workers.*.name}"
-}
-
-output "worker_iam_role_arns" {
-  description = "IAM role IDs attached to EKS workers"
-  value       = "${aws_iam_role.workers.*.arn}"
+  description = "default IAM role name for EKS worker groups"
+  value       = "${element(aws_iam_role.workers.arn, 0)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -56,10 +56,10 @@ output "worker_security_group_id" {
 
 output "worker_iam_role_name" {
   description = "default IAM role name for EKS worker groups"
-  value       = "${element(aws_iam_role.workers.name, 0)}"
+  value       = "${aws_iam_role.workers.name}"
 }
 
 output "worker_iam_role_arn" {
   description = "default IAM role name for EKS worker groups"
-  value       = "${element(aws_iam_role.workers.arn, 0)}"
+  value       = "${aws_iam_role.workers.arn}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -60,6 +60,6 @@ output "worker_iam_role_name" {
 }
 
 output "worker_iam_role_arn" {
-  description = "default IAM role name for EKS worker groups"
+  description = "default IAM role ARN for EKS worker groups"
   value       = "${aws_iam_role.workers.arn}"
 }

--- a/templates/config-map-aws-auth.yaml.tpl
+++ b/templates/config-map-aws-auth.yaml.tpl
@@ -5,11 +5,7 @@ metadata:
   namespace: kube-system
 data:
   mapRoles: |
-    - rolearn: ${worker_role_arn}
-      username: system:node:{{EC2PrivateDNSName}}
-      groups:
-        - system:bootstrappers
-        - system:nodes
+${worker_role_arn}
 ${map_roles}
   mapUsers: |
 ${map_users}

--- a/templates/worker-role.tpl
+++ b/templates/worker-role.tpl
@@ -1,0 +1,6 @@
+
+    - rolearn: ${worker_role_arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes

--- a/templates/worker-role.tpl
+++ b/templates/worker-role.tpl
@@ -1,4 +1,3 @@
-
     - rolearn: ${worker_role_arn}
       username: system:node:{{EC2PrivateDNSName}}
       groups:

--- a/variables.tf
+++ b/variables.tf
@@ -123,8 +123,3 @@ variable "kubeconfig_name" {
   description = "Override the default name used for items kubeconfig."
   default     = ""
 }
-
-variable "multiple_worker_group_iam_roles" {
-  description = "If provided, an IAM role will be created for each worker group instead of all worker groups sharing the same role."
-  default     = ""
-}

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,8 @@ variable "kubeconfig_name" {
   description = "Override the default name used for items kubeconfig."
   default     = ""
 }
+
+variable "multiple_worker_group_iam_roles" {
+  description = "If provided, an IAM role will be created for each worker group instead of all worker groups sharing the same role."
+  default     = ""
+}

--- a/workers.tf
+++ b/workers.tf
@@ -26,7 +26,7 @@ resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(local.workers_group_defaults, "public_ip"))}"
   security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups[count.index],"additional_security_group_ids",lookup(local.workers_group_defaults, "additional_security_group_ids"))))}"]
-  iam_instance_profile        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", aws_iam_role.workers.id))}"
+  iam_instance_profile        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", aws_iam_instance_profile.workers.id))}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.workers_group_defaults, "ami_id"))}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(local.workers_group_defaults, "instance_type"))}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(local.workers_group_defaults, "key_name"))}"
@@ -96,7 +96,7 @@ resource "aws_iam_role" "workers" {
 }
 
 resource "aws_iam_instance_profile" "workers" {
-  name_prefix = "${aws_eks_cluster.this.name}-${count.index}"
+  name_prefix = "${aws_eks_cluster.this.name}"
   role        = "${aws_iam_role.workers.name}"
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -26,7 +26,7 @@ resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(local.workers_group_defaults, "public_ip"))}"
   security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups[count.index],"additional_security_group_ids",lookup(local.workers_group_defaults, "additional_security_group_ids"))))}"]
-  iam_instance_profile        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", aws_iam_instance_profile.workers.id))}"
+  iam_instance_profile        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", "") != "" ? lookup(local.workers_group_defaults, "iam_role_id", "") : aws_iam_instance_profile.workers.id)}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.workers_group_defaults, "ami_id"))}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(local.workers_group_defaults, "instance_type"))}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(local.workers_group_defaults, "key_name"))}"

--- a/workers.tf
+++ b/workers.tf
@@ -92,31 +92,31 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
 resource "aws_iam_role" "workers" {
   name_prefix        = "${aws_eks_cluster.this.name}-${count.index}"
   assume_role_policy = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
-  count              = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
+  count              = "${local.worker_iam_role_count}"
 }
 
 resource "aws_iam_instance_profile" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}-${count.index}"
   role        = "${element(aws_iam_role.workers.*.name, count.index)}"
-  count       = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
+  count       = "${local.worker_iam_role_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = "${element(aws_iam_role.workers.*.name, count.index)}"
-  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
+  count      = "${local.worker_iam_role_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKS_CNI_Policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = "${element(aws_iam_role.workers.*.name, count.index)}"
-  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
+  count      = "${local.worker_iam_role_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEC2ContainerRegistryReadOnly" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = "${element(aws_iam_role.workers.*.name, count.index)}"
-  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
+  count      = "${local.worker_iam_role_count}"
 }
 
 resource "null_resource" "tags_as_list_of_maps" {
@@ -132,7 +132,7 @@ resource "null_resource" "tags_as_list_of_maps" {
 resource "aws_iam_role_policy_attachment" "workers_autoscaling" {
   policy_arn = "${aws_iam_policy.worker_autoscaling.arn}"
   role       = "${element(aws_iam_role.workers.*.name, count.index)}"
-  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
+  count      = "${local.worker_iam_role_count}"
 }
 
 resource "aws_iam_policy" "worker_autoscaling" {

--- a/workers.tf
+++ b/workers.tf
@@ -26,7 +26,7 @@ resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", lookup(local.workers_group_defaults, "public_ip"))}"
   security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups[count.index],"additional_security_group_ids",lookup(local.workers_group_defaults, "additional_security_group_ids"))))}"]
-  iam_instance_profile        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", "") != "" ? lookup(local.workers_group_defaults, "iam_role_id", "") : aws_iam_instance_profile.workers.id)}"
+  iam_instance_profile        = "${element(aws_iam_instance_profile.workers.*.id, count.index)}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", lookup(local.workers_group_defaults, "ami_id"))}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", lookup(local.workers_group_defaults, "instance_type"))}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", lookup(local.workers_group_defaults, "key_name"))}"
@@ -97,7 +97,8 @@ resource "aws_iam_role" "workers" {
 
 resource "aws_iam_instance_profile" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}"
-  role        = "${aws_iam_role.workers.name}"
+  role        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", "") != "" ? lookup(local.workers_group_defaults, "iam_role_id", "") : aws_iam_role.workers.id)}"
+  count       = "${var.worker_group_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {

--- a/workers.tf
+++ b/workers.tf
@@ -97,7 +97,7 @@ resource "aws_iam_role" "workers" {
 
 resource "aws_iam_instance_profile" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}"
-  role        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id", "") != "" ? lookup(local.workers_group_defaults, "iam_role_id", "") : aws_iam_role.workers.id)}"
+  role        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id"))}"
   count       = "${var.worker_group_count}"
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -90,29 +90,33 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
 }
 
 resource "aws_iam_role" "workers" {
-  name_prefix        = "${aws_eks_cluster.this.name}"
+  name_prefix        = "${aws_eks_cluster.this.name}-${count.index}"
   assume_role_policy = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
+  count              = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }
 
 resource "aws_iam_instance_profile" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}-${count.index}"
-  role        = "${aws_iam_role.workers.name}"
+  role        = "${element(aws_iam_role.workers.*.name, count.index)}"
   count       = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
-  role       = "${aws_iam_role.workers.name}"
+  role       = "${element(aws_iam_role.workers.*.name, count.index)}"
+  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKS_CNI_Policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
-  role       = "${aws_iam_role.workers.name}"
+  role       = "${element(aws_iam_role.workers.*.name, count.index)}"
+  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEC2ContainerRegistryReadOnly" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
-  role       = "${aws_iam_role.workers.name}"
+  role       = "${element(aws_iam_role.workers.*.name, count.index)}"
+  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }
 
 resource "null_resource" "tags_as_list_of_maps" {
@@ -127,7 +131,8 @@ resource "null_resource" "tags_as_list_of_maps" {
 
 resource "aws_iam_role_policy_attachment" "workers_autoscaling" {
   policy_arn = "${aws_iam_policy.worker_autoscaling.arn}"
-  role       = "${aws_iam_role.workers.name}"
+  role       = "${element(aws_iam_role.workers.*.name, count.index)}"
+  count      = "${var.multiple_worker_group_iam_roles == "" ? 1 : var.worker_group_count}"
 }
 
 resource "aws_iam_policy" "worker_autoscaling" {


### PR DESCRIPTION
# PR o'clock

## Description

-resolves #136 
-added `iam_role_id` to the worker group config

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
