### PR TITLE
Fix for ERROR: 'aws_iam_instance_profile.workers' not found

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -28,7 +28,7 @@ resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", local.workers_group_defaults["public_ip"])}"
   security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups[count.index],"additional_security_group_ids", local.workers_group_defaults["additional_security_group_ids"])))}"]
-  iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
+  iam_instance_profile        = "${element(aws_iam_instance_profile.workers.*.id, count.index)}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", local.workers_group_defaults["ami_id"])}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", local.workers_group_defaults["instance_type"])}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", local.workers_group_defaults["key_name"])}"


### PR DESCRIPTION
I think I made this mistake in my rebase of https://github.com/terraform-aws-modules/terraform-aws-eks/pull/131. I was using a new UI tool for interactive rebase 🤨
