### PR TITLE
Add option to change worker placement_tenancy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - A useful addition (slam dunk, @self 🔥)
 - Worker groups can be created with a specified IAM profile. (from @laverya)
 - exposed `aws_eks_cluster` create and destroy timeouts (by @RGPosadas)
+- exposed `placement_tenancy` for autoscaling group (by @monsterxx03)
 
 ### Changed
 

--- a/local.tf
+++ b/local.tf
@@ -16,6 +16,7 @@ locals {
     asg_min_size                  = "1"                             # Minimum worker capacity in the autoscaling group.
     instance_type                 = "m4.large"                      # Size of the workers instances.
     spot_price                    = ""                              # Cost of spot instance.
+    placement_tenancy             = ""                              # The tenancy of the instance. Valid values are "default" or "dedicated".
     root_volume_size              = "100"                           # root volume size of workers instances.
     root_volume_type              = "gp2"                           # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops                     = "0"                             # The amount of provisioned IOPS. This must be set with a volume_type of "io1".

--- a/workers.tf
+++ b/workers.tf
@@ -34,6 +34,7 @@ resource "aws_launch_configuration" "workers" {
   ebs_optimized               = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", local.workers_group_defaults["instance_type"]), false))}"
   enable_monitoring           = "${lookup(var.worker_groups[count.index], "enable_monitoring", local.workers_group_defaults["enable_monitoring"])}"
   spot_price                  = "${lookup(var.worker_groups[count.index], "spot_price", local.workers_group_defaults["spot_price"])}"
+  placement_tenancy           = "${lookup(var.worker_groups[count.index], "placement_tenancy", local.workers_group_defaults["placement_tenancy"])}"
   count                       = "${var.worker_group_count}"
 
   lifecycle {


### PR DESCRIPTION
# PR o'clock

## Description

Support launching worker node with non default tenancy.

Some companies have compliance requirements,  ec2 instances must be dedicated instances.

Without specific `placement_tenacy`, the value will keep emtpy(same as specified as `default`), won't show any surprising diff output for users not using before

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
