### PR TITLE
Fixed issue with 'workers_group_defaults_defaults.iam_role_id' and added explicit depends_on for 'update_config_map_aws_auth'

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -5,6 +5,8 @@ resource "local_file" "config_map_aws_auth" {
 }
 
 resource "null_resource" "update_config_map_aws_auth" {
+  depends_on = ["aws_eks_cluster.this"]
+
   provisioner "local-exec" {
     command = "kubectl apply -f ${var.config_output_path}config-map-aws-auth_${var.cluster_name}.yaml --kubeconfig ${var.config_output_path}kubeconfig_${var.cluster_name}"
   }

--- a/local.tf
+++ b/local.tf
@@ -6,6 +6,7 @@ locals {
   cluster_security_group_id = "${coalesce(join("", aws_security_group.cluster.*.id), var.cluster_security_group_id)}"
 
   worker_security_group_id = "${coalesce(join("", aws_security_group.workers.*.id), var.worker_security_group_id)}"
+  default_iam_role_id      = "${element(concat(aws_iam_role.workers.*.id, list("")), 0)}"
   kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
   workers_group_defaults_defaults = {
@@ -30,7 +31,7 @@ locals {
     autoscaling_enabled           = false                           # Sets whether policy and matching tags will be added to allow autoscaling.
     additional_security_group_ids = ""                              # A comman delimited list of additional security group ids to include in worker launch config
     protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
-    iam_role_id                   = "${aws_iam_role.workers.id}"    # Use the specified IAM role if set.
+    iam_role_id                   = "${local.default_iam_role_id}"  # Use the specified IAM role if set.
   }
 
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"


### PR DESCRIPTION

Fixed issue with workers_group_defaults_defaults.iam_role_id and added explicit depends_on for 'update_config_map_aws_auth'

# PR o'clock

## Description

Minimal fixes for this issue:
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/146

This PR only attempts to fix the minimal requirements of the issue.
- `update_config_map_aws_auth` null resource now depends on `aws_eks_cluster.this` 
- `iam_role_id` uses the element/concat work around for its default value

Additional comments in line.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- both updated files passed checks
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [X] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above

I have internal test kitchen / rspec test scenarios that exercise and tear down complete clusters,  with sample output provided in lieu of ability to open source the tests at this time.

```
#Custom matcher as awspec does not have eks resources at this time
eks cluster exists
  should eql "tf-platform-test-kitchen"
... TRUCATED ...
Finished in 1.78 seconds (files took 2.25 seconds to load)
25 examples, 0 failures
```

```
Scenario 1: 
  worker_group_count = 0
  write_kubeconfig = false
  manage_aws_auth = false

Scenario 2:
  worker_group_count = 0
  write_kubeconfig = true
  manage_aws_auth = true

Scenario 3:
  worker_group_count = 1
  write_kubeconfig = true
  manage_aws_auth = true

Scenario 4:
  worker_group_count = 2
  worker_groups = [
    {
      "name"                 = "green"
      "instance_type"        = "t2.small"
      "asg_desired_capacity" = "0"
      "asg_max_size"         = "0"
      "asg_min_size"         = "0"
    },
    {
      "name"                 = "blue"
      "instance_type"        = "t2.small"
      "asg_desired_capacity" = "0"
      "asg_max_size"         = "0"
      "asg_min_size"         = "0"
    },
  ]
  write_kubeconfig = true
  manage_aws_auth = true
```