### PR TITLE
Allowing 443 to nodes from EKS service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - A useful addition (slam dunk, @self 🔥)
 - Worker groups can be created with a specified IAM profile. (from @laverya)
 - exposed `aws_eks_cluster` create and destroy timeouts (by @RGPosadas)
+- Allow port 443 from EKS service to nodes to run `metrics-server`. (by @max-rocket-internet)
 
 ### Changed
 

--- a/workers.tf
+++ b/workers.tf
@@ -90,6 +90,17 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
   count                    = "${var.worker_security_group_id == "" ? 1 : 0}"
 }
 
+resource "aws_security_group_rule" "workers_ingress_cluster_https" {
+  description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.workers.id}"
+  source_security_group_id = "${local.cluster_security_group_id}"
+  from_port                = 443
+  to_port                  = 443
+  type                     = "ingress"
+  count                    = "${var.worker_security_group_id == "" ? 1 : 0}"
+}
+
 resource "aws_iam_role" "workers" {
   name_prefix        = "${aws_eks_cluster.this.name}"
   assume_role_policy = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"


### PR DESCRIPTION
# PR o'clock

## Description

This allows the EKS cluster service to connect to the nodes on port 443. This is require to run the metrics-server, details [here](https://github.com/kubernetes-incubator/metrics-server/issues/45). Metrics-server is required to run horrizontal pod autoscalers.

AWS CFN is here: https://github.com/awslabs/amazon-eks-ami/blob/master/amazon-eks-nodegroup.yaml#L251-L260

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
