### PR TITLE
Added timeout configs and variables to aws_eks_cluster resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - **Breaking change** Removed `workstation_cidr` variable, http callout and unnecessary security rule. (by @dpiddockcmp)
+  If you are upgrading from 1.4 you should fix state after upgrade: `terraform state rm module.eks.data.http.workstation_external_ip`
 - Can now selectively override keys in `workers_group_defaults` variable rather than callers maintaining a duplicate of the whole map. (by @dpiddockcmp)
 
 ## [[v1.4.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.3.0...v1.4.0)] - 2018-08-02]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - A useful addition (slam dunk, @self 🔥)
+<<<<<<< HEAD
 - Worker groups can be created with a specified IAM profile. (from @laverya)
+=======
+- exposed `aws_eks_cluster` create and destroy timeouts (by @RGPosadas)
+>>>>>>> Updated CHANGELOG and README
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws_eks_cluster_create_timeout | Timeout value when creating the EKS cluster. | string | `15m` | no |
-| aws_eks_cluster_delete_timeout | Timeout value when deleting the EKS cluster. | string | `15m` | no |
+| cluster_create_timeout | Timeout value when creating the EKS cluster. | string | `15m` | no |
+| cluster_delete_timeout | Timeout value when deleting the EKS cluster. | string | `15m` | no |
 | cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
 | cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| aws_eks_cluster_create_timeout | Timeout value when creating the EKS cluster. | string | `15m` | no |
+| aws_eks_cluster_delete_timeout | Timeout value when deleting the EKS cluster. | string | `15m` | no |
 | cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
 | cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -9,8 +9,8 @@ resource "aws_eks_cluster" "this" {
   }
 
   timeouts {
-    create = "${var.aws_eks_cluster_create_timeout}"
-    delete = "${var.aws_eks_cluster_delete_timeout}"
+    create = "${var.cluster_create_timeout}"
+    delete = "${var.cluster_delete_timeout}"
   }
 
   depends_on = [

--- a/cluster.tf
+++ b/cluster.tf
@@ -8,6 +8,11 @@ resource "aws_eks_cluster" "this" {
     subnet_ids         = ["${var.subnets}"]
   }
 
+  timeouts {
+    create = "${var.aws_eks_cluster_create_timeout}"
+    delete = "${var.aws_eks_cluster_delete_timeout}"
+  }
+
   depends_on = [
     "aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy",
     "aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy",

--- a/variables.tf
+++ b/variables.tf
@@ -126,10 +126,10 @@ variable "kubeconfig_name" {
 
 variable "cluster_create_timeout" {
   description = "Timeout value when creating the EKS cluster."
-  default = "15m"
+  default     = "15m"
 }
 
 variable "cluster_delete_timeout" {
   description = "Timeout value when deleting the EKS cluster."
-  default = "15m"
+  default     = "15m"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -124,12 +124,12 @@ variable "kubeconfig_name" {
   default     = ""
 }
 
-variable "aws_eks_cluster_create_timeout" {
+variable "cluster_create_timeout" {
   description = "Timeout value when creating the EKS cluster."
   default = "15m"
 }
 
-variable "aws_eks_cluster_delete_timeout" {
+variable "cluster_delete_timeout" {
   description = "Timeout value when deleting the EKS cluster."
   default = "15m"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,13 @@ variable "kubeconfig_name" {
   description = "Override the default name used for items kubeconfig."
   default     = ""
 }
+
+variable "aws_eks_cluster_create_timeout" {
+  description = "Timeout value when creating the EKS cluster."
+  default = "15m"
+}
+
+variable "aws_eks_cluster_delete_timeout" {
+  description = "Timeout value when deleting the EKS cluster."
+  default = "15m"
+}

--- a/workers.tf
+++ b/workers.tf
@@ -28,7 +28,7 @@ resource "aws_launch_configuration" "workers" {
   name_prefix                 = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = "${lookup(var.worker_groups[count.index], "public_ip", local.workers_group_defaults["public_ip"])}"
   security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups[count.index],"additional_security_group_ids", local.workers_group_defaults["additional_security_group_ids"])))}"]
-  iam_instance_profile        = "${aws_iam_instance_profile.workers.id}"
+  iam_instance_profile        = "${element(aws_iam_instance_profile.workers.*.id, count.index)}"
   image_id                    = "${lookup(var.worker_groups[count.index], "ami_id", local.workers_group_defaults["ami_id"])}"
   instance_type               = "${lookup(var.worker_groups[count.index], "instance_type", local.workers_group_defaults["instance_type"])}"
   key_name                    = "${lookup(var.worker_groups[count.index], "key_name", local.workers_group_defaults["key_name"])}"


### PR DESCRIPTION
# PR o'clock

## Description

Added timeout configs to the `aws_eks_cluster` resource.

### Test Result
I set the timeouts to 1m to test for failure (could not test timeout for more than default time since it is unpredictable when it would happen). Here are the results:
```
1 error(s) occurred:
TestEKS 2018-10-02T12:32:30-04:00 command.go:100: 
TestEKS 2018-10-02T12:32:30-04:00 command.go:100: * module.test_eks_module.module.eks.aws_eks_cluster.this: 1 error(s) occurred:
TestEKS 2018-10-02T12:32:30-04:00 command.go:100: 
TestEKS 2018-10-02T12:32:30-04:00 command.go:100: * aws_eks_cluster.this: timeout while waiting for state to become 'ACTIVE' (last state: 'CREATING', timeout: 1m0s)
```

### `README.md` Changes
I tried to update `README.md` using `terraform-docs` and the given lines of code, but that ended up erasing the whole file for me. So I added in the new variables manually.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
