### PR TITLE
changed to use a locals var rather then a input var for worker group count

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -19,7 +19,7 @@ resource "null_resource" "update_config_map_aws_auth" {
 data "aws_caller_identity" "current" {}
 
 data "template_file" "worker_role_arns" {
-  count    = "${var.worker_group_count}"
+  count    = "${local.worker_group_count}"
   template = "${file("${path.module}/templates/worker-role.tpl")}"
 
   vars {

--- a/data.tf
+++ b/data.tf
@@ -71,7 +71,7 @@ EOF
 
 data "template_file" "userdata" {
   template = "${file("${path.module}/templates/userdata.sh.tpl")}"
-  count    = "${var.worker_group_count}"
+  count    = "${local.worker_group_count}"
 
   vars {
     cluster_name        = "${aws_eks_cluster.this.name}"

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -133,7 +133,6 @@ module "eks" {
   tags                                 = "${local.tags}"
   vpc_id                               = "${module.vpc.vpc_id}"
   worker_groups                        = "${local.worker_groups}"
-  worker_group_count                   = "2"
   worker_additional_security_group_ids = ["${aws_security_group.all_worker_mgmt.id}"]
   map_roles                            = "${var.map_roles}"
   map_users                            = "${var.map_users}"

--- a/local.tf
+++ b/local.tf
@@ -32,7 +32,8 @@ locals {
     protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
     iam_role_id                   = "${aws_iam_role.workers.id}"    # Use the specified IAM role if set.
   }
-  worker_group_count = "${length(var.worker_groups)}"
+
+  worker_group_count     = "${length(var.worker_groups)}"
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"
 
   ebs_optimized = {

--- a/local.tf
+++ b/local.tf
@@ -32,7 +32,7 @@ locals {
     protect_from_scale_in         = false                           # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
     iam_role_id                   = "${aws_iam_role.workers.id}"    # Use the specified IAM role if set.
   }
-
+  worker_group_count = "${length(var.worker_groups)}"
   workers_group_defaults = "${merge(local.workers_group_defaults_defaults, var.workers_group_defaults)}"
 
   ebs_optimized = {

--- a/variables.tf
+++ b/variables.tf
@@ -73,13 +73,6 @@ variable "worker_groups" {
     "name" = "default"
   }]
 }
-
-variable "worker_group_count" {
-  description = "The number of maps contained within the worker_groups list."
-  type        = "string"
-  default     = "1"
-}
-
 variable "workers_group_defaults" {
   description = "Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys."
   type        = "map"

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,7 @@ variable "worker_groups" {
     "name" = "default"
   }]
 }
+
 variable "workers_group_defaults" {
   description = "Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys."
   type        = "map"

--- a/workers.tf
+++ b/workers.tf
@@ -1,6 +1,4 @@
 resource "aws_autoscaling_group" "workers" {
-
-
   name_prefix           = "${aws_eks_cluster.this.name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   desired_capacity      = "${lookup(var.worker_groups[count.index], "asg_desired_capacity", local.workers_group_defaults["asg_desired_capacity"])}"
   max_size              = "${lookup(var.worker_groups[count.index], "asg_max_size", local.workers_group_defaults["asg_max_size"])}"
@@ -36,7 +34,7 @@ resource "aws_launch_configuration" "workers" {
   ebs_optimized               = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", local.workers_group_defaults["instance_type"]), false))}"
   enable_monitoring           = "${lookup(var.worker_groups[count.index], "enable_monitoring", local.workers_group_defaults["enable_monitoring"])}"
   spot_price                  = "${lookup(var.worker_groups[count.index], "spot_price", local.workers_group_defaults["spot_price"])}"
-  count                 = "${local.worker_group_count}"
+  count                       = "${local.worker_group_count}"
 
   lifecycle {
     create_before_destroy = true

--- a/workers.tf
+++ b/workers.tf
@@ -8,7 +8,7 @@ resource "aws_autoscaling_group" "workers" {
   launch_configuration  = "${element(aws_launch_configuration.workers.*.id, count.index)}"
   vpc_zone_identifier   = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), local.workers_group_defaults["subnets"]))}"]
   protect_from_scale_in = "${lookup(var.worker_groups[count.index], "protect_from_scale_in", local.workers_group_defaults["protect_from_scale_in"])}"
-  count                 = "${var.worker_group_count}"
+  count                 = "${local.worker_group_count}"
 
   tags = ["${concat(
     list(
@@ -36,7 +36,7 @@ resource "aws_launch_configuration" "workers" {
   ebs_optimized               = "${lookup(var.worker_groups[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups[count.index], "instance_type", local.workers_group_defaults["instance_type"]), false))}"
   enable_monitoring           = "${lookup(var.worker_groups[count.index], "enable_monitoring", local.workers_group_defaults["enable_monitoring"])}"
   spot_price                  = "${lookup(var.worker_groups[count.index], "spot_price", local.workers_group_defaults["spot_price"])}"
-  count                       = "${var.worker_group_count}"
+  count                 = "${local.worker_group_count}"
 
   lifecycle {
     create_before_destroy = true
@@ -100,7 +100,7 @@ resource "aws_iam_role" "workers" {
 resource "aws_iam_instance_profile" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}"
   role        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id"))}"
-  count       = "${var.worker_group_count}"
+  count       = "${local.worker_group_count}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {


### PR DESCRIPTION
# PR o'clock

## Description

This PR replaces the worker_group_count variable with a locals variable that takes the count from the worker group var using the length function.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
