### PR TITLE
Update documentation for removed `configure_kubectl_session`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Remove aws_iam_service_linked_role (by @max-rocket-internet)
 - Adjust the order and correct/update the ec2 instance type info. (@chenrui333)
 - Removed providers from `main.tf`. (by @max-rocket-internet)
+- Removed `configure_kubectl_session` references in documentation [#171](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/171) (by @dominik-k)
 
 ## [[v1.7.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.6.0...v1.7.0)] - 2018-10-09]
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read the [AWS docs on EKS to get connected to the k8s dashboard](https://docs.aw
 * You want to create an EKS cluster and an autoscaling group of workers for the cluster.
 * You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
 * You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources.
-* If using the default variable value (`true`) for `configure_kubectl_session`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
+* If `manage_aws_auth = true`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
 
 ## Usage example
 
@@ -56,9 +56,12 @@ This module has been packaged with [awspec](https://github.com/k1LoW/awspec) tes
 4. Test using `bundle exec kitchen test` from the root of the repo.
 
 For now, connectivity to the kubernetes cluster is not tested but will be in the
-future. If `configure_kubectl_session` is set `true`, once the test fixture has
-converged, you can query the test cluster from that terminal session with
-`kubectl get nodes --watch --kubeconfig kubeconfig`.
+future. Once the test fixture has converged, you can query the test cluster from
+that terminal session with
+```bash
+kubectl get nodes --watch --kubeconfig kubeconfig
+```
+(using default settings `config_output_path = "./"` & `write_kubeconfig = true`)
 
 ## Doc generation
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
 | cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
 | cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
-| config_output_path | Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. Should end in a forward slash / . | string | `./` | no |
+| config_output_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `./` | no |
 | kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `<list>` | no |
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials. | string | `aws-iam-authenticator` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `<map>` | no |
@@ -121,7 +121,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
 | workers_group_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `<map>` | no |
-| write_kubeconfig | Whether to write a kubeconfig file containing the cluster configuration. | string | `true` | no |
+| write_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `true` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 ** You want to create an EKS cluster and an autoscaling group of workers for the cluster.
 ** You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
 ** You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources.
-** If using the default variable value (`true`) for `configure_kubectl_session`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
+** If `manage_aws_auth = true`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
 
 * ## Usage example
 
@@ -57,9 +57,12 @@
 * 4. Test using `bundle exec kitchen test` from the root of the repo.
 
 * For now, connectivity to the kubernetes cluster is not tested but will be in the
-* future. If `configure_kubectl_session` is set `true`, once the test fixture has
-* converged, you can query the test cluster from that terminal session with
-* `kubectl get nodes --watch --kubeconfig kubeconfig`.
+* future. Once the test fixture has converged, you can query the test cluster from
+* that terminal session with
+* ```bash
+* kubectl get nodes --watch --kubeconfig kubeconfig
+* ```
+* (using default settings `config_output_path = "./"` & `write_kubeconfig = true`)
 
 * ## Doc generation
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,12 +13,12 @@ variable "cluster_version" {
 }
 
 variable "config_output_path" {
-  description = "Determines where config files are placed if using configure_kubectl_session and you want config files to land outside the current working directory. Should end in a forward slash / ."
+  description = "Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` ."
   default     = "./"
 }
 
 variable "write_kubeconfig" {
-  description = "Whether to write a kubeconfig file containing the cluster configuration."
+  description = "Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`."
   default     = true
 }
 


### PR DESCRIPTION
## Description

Updated all occasions in documentation where `configure_kubectl_session` was still referenced. This field was 
* introduced in #13 (commit 8483fa2)
* and removed in #54 (commit 1a1d92da6636cdca1c2fe).

I hope it's ok that I didn't create an issue beforehand, ss this PR only changes documentation, not code.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
