### PR TITLE
Add ability to pass computed values to cluster_security_group_id and worker_security_group_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - `suspended_processes` to `worker_groups` input (by @bkmeneguello)
 - `target_group_arns` to `worker_groups` input (by @zihaoyu)
+- `cluster_create_security_group` and `worker_create_security_group`. This allows using computed cluster and worker security groups. (by @rmakramims)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - `suspended_processes` to `worker_groups` input (by @bkmeneguello)
 - `target_group_arns` to `worker_groups` input (by @zihaoyu)
-- `cluster_create_security_group` and `worker_create_security_group`. This allows using computed cluster and worker security groups. (by @rmakramims)
+- `cluster_create_security_group` and `worker_create_security_group`. This allows using computed cluster and worker security groups. (by @rmakram-ims)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| cluster_create_security_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `true` | no |
 | cluster_create_timeout | Timeout value when creating the EKS cluster. | string | `15m` | no |
 | cluster_delete_timeout | Timeout value when deleting the EKS cluster. | string | `15m` | no |
 | cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
@@ -119,6 +120,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
 | worker_additional_security_group_ids | A list of additional security group ids to attach to worker instances | list | `<list>` | no |
+| worker_create_security_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | string | `true` | no |
 | worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
 | worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
 | worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "cluster" {
   description = "EKS cluster security group."
   vpc_id      = "${var.vpc_id}"
   tags        = "${merge(var.tags, map("Name", "${var.cluster_name}-eks_cluster_sg"))}"
-  count       = "${var.cluster_security_group_id == "" ? 1 : 0}"
+  count       = "${var.cluster_create_security_group ? 1 : 0}"
 }
 
 resource "aws_security_group_rule" "cluster_egress_internet" {
@@ -35,7 +35,7 @@ resource "aws_security_group_rule" "cluster_egress_internet" {
   from_port         = 0
   to_port           = 0
   type              = "egress"
-  count             = "${var.cluster_security_group_id == "" ? 1 : 0}"
+  count             = "${var.cluster_create_security_group ? 1 : 0}"
 }
 
 resource "aws_security_group_rule" "cluster_https_worker_ingress" {
@@ -46,7 +46,7 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
   from_port                = 443
   to_port                  = 443
   type                     = "ingress"
-  count                    = "${var.cluster_security_group_id == "" ? 1 : 0}"
+  count                    = "${var.cluster_create_security_group ? 1 : 0}"
 }
 
 resource "aws_iam_role" "cluster" {

--- a/variables.tf
+++ b/variables.tf
@@ -134,3 +134,13 @@ variable "cluster_delete_timeout" {
   description = "Timeout value when deleting the EKS cluster."
   default     = "15m"
 }
+
+variable "cluster_create_security_group" {
+  description = "Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`."
+  default = true
+}
+
+variable "worker_create_security_group" {
+  description = "Whether to create a security group for the workers or attach the workers to `worker_security_group_id`."
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -137,10 +137,10 @@ variable "cluster_delete_timeout" {
 
 variable "cluster_create_security_group" {
   description = "Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`."
-  default = true
+  default     = true
 }
 
 variable "worker_create_security_group" {
   description = "Whether to create a security group for the workers or attach the workers to `worker_security_group_id`."
-  default = true
+  default     = true
 }

--- a/workers.tf
+++ b/workers.tf
@@ -55,7 +55,7 @@ resource "aws_security_group" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}"
   description = "Security group for all nodes in the cluster."
   vpc_id      = "${var.vpc_id}"
-  count       = "${var.worker_security_group_id == "" ? 1 : 0}"
+  count       = "${var.worker_create_security_group ? 1 : 0}"
   tags        = "${merge(var.tags, map("Name", "${aws_eks_cluster.this.name}-eks_worker_sg", "kubernetes.io/cluster/${aws_eks_cluster.this.name}", "owned"
   ))}"
 }
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "workers_egress_internet" {
   from_port         = 0
   to_port           = 0
   type              = "egress"
-  count             = "${var.worker_security_group_id == "" ? 1 : 0}"
+  count             = "${var.worker_create_security_group ? 1 : 0}"
 }
 
 resource "aws_security_group_rule" "workers_ingress_self" {
@@ -79,7 +79,7 @@ resource "aws_security_group_rule" "workers_ingress_self" {
   from_port                = 0
   to_port                  = 65535
   type                     = "ingress"
-  count                    = "${var.worker_security_group_id == "" ? 1 : 0}"
+  count                    = "${var.worker_create_security_group ? 1 : 0}"
 }
 
 resource "aws_security_group_rule" "workers_ingress_cluster" {
@@ -90,7 +90,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
   from_port                = "${var.worker_sg_ingress_from_port}"
   to_port                  = 65535
   type                     = "ingress"
-  count                    = "${var.worker_security_group_id == "" ? 1 : 0}"
+  count                    = "${var.worker_create_security_group ? 1 : 0}"
 }
 
 resource "aws_security_group_rule" "workers_ingress_cluster_https" {
@@ -101,7 +101,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
   from_port                = 443
   to_port                  = 443
   type                     = "ingress"
-  count                    = "${var.worker_security_group_id == "" ? 1 : 0}"
+  count                    = "${var.worker_create_security_group ? 1 : 0}"
 }
 
 resource "aws_iam_role" "workers" {


### PR DESCRIPTION
# PR o'clock

## Description

Since we cannot pass computed values to cluster_security_group_id or worker_security_group_id, I specified a cluster_create_security_group and worker_create_security_group.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [X] Docs have been updated using `terraform-docs` per `README.md` instructions
- [X] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
