### PR TITLE
Destroying cluster causes some issues with removing policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - `suspended_processes` to `worker_groups` input (by @bkmeneguello)
 - `target_group_arns` to `worker_groups` input (by @zihaoyu)
+- `force_detach_policies` to `aws_iam_role` `cluster` and `workers` (by @marky-mark)
 
 ### Changed
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -52,6 +52,7 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
 resource "aws_iam_role" "cluster" {
   name_prefix        = "${var.cluster_name}"
   assume_role_policy = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"
+  force_detach_policies = true
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -50,8 +50,8 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
 }
 
 resource "aws_iam_role" "cluster" {
-  name_prefix        = "${var.cluster_name}"
-  assume_role_policy = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"
+  name_prefix           = "${var.cluster_name}"
+  assume_role_policy    = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"
   force_detach_policies = true
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -105,8 +105,8 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
 }
 
 resource "aws_iam_role" "workers" {
-  name_prefix        = "${aws_eks_cluster.this.name}"
-  assume_role_policy = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
+  name_prefix           = "${aws_eks_cluster.this.name}"
+  assume_role_policy    = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
   force_detach_policies = true
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -107,6 +107,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
 resource "aws_iam_role" "workers" {
   name_prefix        = "${aws_eks_cluster.this.name}"
   assume_role_policy = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
+  force_detach_policies = true
 }
 
 resource "aws_iam_instance_profile" "workers" {


### PR DESCRIPTION
# PR o'clock

## Description

use the force detach for the IAM policies created for the cluster and workers. Had issues destroying the cluster

https://www.terraform.io/docs/providers/aws/r/iam_role.html#force_detach_policies

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
