### PR TITLE
Supply count for map_accounts, map_roles and map_users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## [[v2.0.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.8.0...HEAD)] - 2019-01-??]
 
 ### Added
-- (Breaking Change) New input variables `map_roles_count` and `map_users_count` to allow using computed values as part of `map_roles` and `map_users` configs.
+- (Breaking Change) New input variables `map_accounts_count`, `map_roles_count` and `map_users_count` to allow using computed values as part of `map_accounts`, `map_roles` and `map_users` configs (by @chili-man on behalf of OpenGov).
 - Added ability to choose local-exec interpreter (by @rothandrew)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+- New input variables `map_roles_count` and `map_users_count` to allow using computed values as part of `map_roles` and `map_users` configs.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map_roles_count | The count of roles in the map_roles list. Note: this is a workaround for a known issue with passing lists in terraform as variables | string | `<list>` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map_users_count | The count of roles in the map_users list. Note: this is a workaround for a known issue with passing lists in terraform as variables | string | `<list>` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |

--- a/README.md
+++ b/README.md
@@ -109,14 +109,15 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config_output_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `./` | no |
 | kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `<list>` | no |
 | kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials. | string | `aws-iam-authenticator` | no |
+| kubeconfig_aws_authenticator_command_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `<list>` | no |
 | kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `<map>` | no |
 | kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
 | manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_roles_count | The count of roles in the map_roles list. Note: this is a workaround for a known issue with passing lists in terraform as variables | string | `<list>` | no |
+| map_roles_count | The count of roles in the map_roles list. | string | `0` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_users_count | The count of roles in the map_users list. Note: this is a workaround for a known issue with passing lists in terraform as variables | string | `<list>` | no |
+| map_users_count | The count of roles in the map_users list. | string | `0` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
 | vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
@@ -144,3 +145,4 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker_security_group_id | Security group ID attached to the EKS workers. |
 | workers_asg_arns | IDs of the autoscaling groups containing workers. |
 | workers_asg_names | Names of the autoscaling groups containing workers. |
+

--- a/README.md
+++ b/README.md
@@ -101,50 +101,50 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| cluster_create_timeout | Timeout value when creating the EKS cluster. | string | `15m` | no |
-| cluster_delete_timeout | Timeout value when deleting the EKS cluster. | string | `15m` | no |
-| cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
-| cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
-| cluster_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
-| config_output_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `./` | no |
-| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `<list>` | no |
-| kubeconfig_aws_authenticator_command | Command to use to to fetch AWS EKS credentials. | string | `aws-iam-authenticator` | no |
-| kubeconfig_aws_authenticator_command_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `<list>` | no |
-| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `<map>` | no |
-| kubeconfig_name | Override the default name used for items kubeconfig. | string | `` | no |
-| local_exec_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. Defaults to ["/bin/sh", "-c"] | list | `<list>` | no |
-| manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
-| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_accounts_count | The count of accounts in the map_accounts list. | string | `0` | no |
-| map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_roles_count | The count of roles in the map_roles list. | string | `0` | no |
-| map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map_users_count | The count of roles in the map_users list. | string | `0` | no |
+| cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `15m` | no |
+| cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `15m` | no |
+| cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | - | yes |
+| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
+| cluster\_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
+| config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `./` | no |
+| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `<list>` | no |
+| kubeconfig\_aws\_authenticator\_command | Command to use to to fetch AWS EKS credentials. | string | `aws-iam-authenticator` | no |
+| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `<list>` | no |
+| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `<map>` | no |
+| kubeconfig\_name | Override the default name used for items kubeconfig. | string | `` | no |
+| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. Defaults to ["/bin/sh", "-c"] | list | `<list>` | no |
+| manage\_aws\_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
+| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map\_accounts\_count | The count of accounts in the map_accounts list. | string | `0` | no |
+| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map\_roles\_count | The count of roles in the map_roles list. | string | `0` | no |
+| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map\_users\_count | The count of roles in the map_users list. | string | `0` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
 | tags | A map of tags to add to all resources. | map | `<map>` | no |
-| vpc_id | VPC where the cluster and workers will be deployed. | string | - | yes |
-| worker_additional_security_group_ids | A list of additional security group ids to attach to worker instances | list | `<list>` | no |
-| worker_group_count | The number of maps contained within the worker_groups list. | string | `1` | no |
-| worker_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
-| worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
-| worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
-| workers_group_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `<map>` | no |
-| write_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `true` | no |
+| vpc\_id | VPC where the cluster and workers will be deployed. | string | - | yes |
+| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `<list>` | no |
+| worker\_group\_count | The number of maps contained within the worker_groups list. | string | `1` | no |
+| worker\_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
+| worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
+| worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
+| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `<map>` | no |
+| write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cluster_certificate_authority_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
-| cluster_endpoint | The endpoint for your EKS Kubernetes API. |
-| cluster_id | The name/id of the EKS cluster. |
-| cluster_security_group_id | Security group ID attached to the EKS cluster. |
-| cluster_version | The Kubernetes server version for the EKS cluster. |
-| config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
+| cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
+| cluster\_endpoint | The endpoint for your EKS Kubernetes API. |
+| cluster\_id | The name/id of the EKS cluster. |
+| cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
+| cluster\_version | The Kubernetes server version for the EKS cluster. |
+| config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
-| worker_iam_role_arn | default IAM role ARN for EKS worker groups |
-| worker_iam_role_name | default IAM role name for EKS worker groups |
-| worker_security_group_id | Security group ID attached to the EKS workers. |
-| workers_asg_arns | IDs of the autoscaling groups containing workers. |
-| workers_asg_names | Names of the autoscaling groups containing workers. |
+| worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
+| worker\_iam\_role\_name | default IAM role name for EKS worker groups |
+| worker\_security\_group\_id | Security group ID attached to the EKS workers. |
+| workers\_asg\_arns | IDs of the autoscaling groups containing workers. |
+| workers\_asg\_names | Names of the autoscaling groups containing workers. |
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | local_exec_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. Defaults to ["/bin/sh", "-c"] | list | `<list>` | no |
 | manage_aws_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
 | map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map_accounts_count | The count of accounts in the map_accounts list. | string | `0` | no |
 | map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
 | map_roles_count | The count of roles in the map_roles list. | string | `0` | no |
 | map_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -41,7 +41,7 @@ data "template_file" "config_map_aws_auth" {
 }
 
 data "template_file" "map_users" {
-  count    = "${length(var.map_users)}"
+  count    = "${var.map_users_count}"
   template = "${file("${path.module}/templates/config-map-aws-auth-map_users.yaml.tpl")}"
 
   vars {
@@ -52,7 +52,7 @@ data "template_file" "map_users" {
 }
 
 data "template_file" "map_roles" {
-  count    = "${length(var.map_roles)}"
+  count    = "${var.map_roles_count}"
   template = "${file("${path.module}/templates/config-map-aws-auth-map_roles.yaml.tpl")}"
 
   vars {

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -64,7 +64,7 @@ data "template_file" "map_roles" {
 }
 
 data "template_file" "map_accounts" {
-  count    = "${length(var.map_accounts)}"
+  count    = "${var.map_accounts_count}"
   template = "${file("${path.module}/templates/config-map-aws-auth-map_accounts.yaml.tpl")}"
 
   vars {

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -140,4 +140,5 @@ module "eks" {
   map_users                            = "${var.map_users}"
   map_users_count                      = "${var.map_users_count}"
   map_accounts                         = "${var.map_accounts}"
+  map_accounts_count                   = "${var.map_accounts_count}"
 }

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -136,6 +136,8 @@ module "eks" {
   worker_group_count                   = "2"
   worker_additional_security_group_ids = ["${aws_security_group.all_worker_mgmt.id}"]
   map_roles                            = "${var.map_roles}"
+  map_roles_count                      = "${var.map_roles_count}"
   map_users                            = "${var.map_users}"
+  map_users_count                      = "${var.map_users_count}"
   map_accounts                         = "${var.map_accounts}"
 }

--- a/examples/eks_test_fixture/variables.tf
+++ b/examples/eks_test_fixture/variables.tf
@@ -15,7 +15,7 @@ variable "map_accounts" {
 variable "map_accounts_count" {
   description = "The count of accounts in the map_accounts list."
   type        = "string"
-  default     = 1
+  default     = 2
 }
 
 variable "map_roles" {
@@ -58,5 +58,5 @@ variable "map_users" {
 variable "map_users_count" {
   description = "The count of roles in the map_users list."
   type        = "string"
-  default     = 1
+  default     = 2
 }

--- a/examples/eks_test_fixture/variables.tf
+++ b/examples/eks_test_fixture/variables.tf
@@ -27,7 +27,7 @@ variable "map_roles" {
 
 variable "map_roles_count" {
   description = "The count of roles in the map_roles list."
-  type        = "list"
+  type        = "string"
   default     = 1
 }
 
@@ -51,6 +51,6 @@ variable "map_users" {
 
 variable "map_users_count" {
   description = "The count of roles in the map_users list."
-  type        = "list"
+  type        = "string"
   default     = 1
 }

--- a/examples/eks_test_fixture/variables.tf
+++ b/examples/eks_test_fixture/variables.tf
@@ -25,6 +25,12 @@ variable "map_roles" {
   ]
 }
 
+variable "map_roles_count" {
+  description = "The count of roles in the map_roles list."
+  type        = "list"
+  default     = 1
+}
+
 variable "map_users" {
   description = "Additional IAM users to add to the aws-auth configmap."
   type        = "list"
@@ -41,4 +47,10 @@ variable "map_users" {
       group    = "system:masters"
     },
   ]
+}
+
+variable "map_users_count" {
+  description = "The count of roles in the map_users list."
+  type        = "list"
+  default     = 1
 }

--- a/examples/eks_test_fixture/variables.tf
+++ b/examples/eks_test_fixture/variables.tf
@@ -12,6 +12,12 @@ variable "map_accounts" {
   ]
 }
 
+variable "map_accounts_count" {
+  description = "The count of accounts in the map_accounts list."
+  type        = "string"
+  default     = 1
+}
+
 variable "map_roles" {
   description = "Additional IAM roles to add to the aws-auth configmap."
   type        = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -39,10 +39,22 @@ variable "map_roles" {
   default     = []
 }
 
+variable "map_roles_count" {
+  description = "The count of roles in the map_roles list. Note: this is a workaround for a known issue with passing lists in terraform as variables"
+  type        = "string"
+  default     = 0
+}
+
 variable "map_users" {
   description = "Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format."
   type        = "list"
   default     = []
+}
+
+variable "map_users_count" {
+  description = "The count of roles in the map_users list. Note: this is a workaround for a known issue with passing lists in terraform as variables"
+  type        = "string"
+  default     = 0
 }
 
 variable "subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "map_roles" {
 }
 
 variable "map_roles_count" {
-  description = "The count of roles in the map_roles list. Note: this is a workaround for a known issue with passing lists in terraform as variables"
+  description = "The count of roles in the map_roles list."
   type        = "string"
   default     = 0
 }
@@ -52,7 +52,7 @@ variable "map_users" {
 }
 
 variable "map_users_count" {
-  description = "The count of roles in the map_users list. Note: this is a workaround for a known issue with passing lists in terraform as variables"
+  description = "The count of roles in the map_users list."
   type        = "string"
   default     = 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "map_accounts" {
   default     = []
 }
 
+variable "map_accounts_count" {
+  description = "The count of accounts in the map_accounts list."
+  type        = "string"
+  default     = 0
+}
+
 variable "map_roles" {
   description = "Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format."
   type        = "list"


### PR DESCRIPTION
# PR o'clock

## Description

We have a wrapper module around this (to enforce certain settings when invoked) and as such,  we're having issues passing in `map_accounts`, `map_roles`, `map_users` because of the `can not compute value of 'count'`. It pains me to have to do this, but this PR adds in count variables to be explicitly passed in for `map_accounts`,  `map_roles` and `map_users`  as a workaround for Terraforms limitations with respect to computed values for `count`  

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [X] Tests for the changes have been added and passing (for bug fixes/features)
- [X] Test results are pasted in this  PR (in lieu of CI) 
[new-cluster-tf-plan.txt](https://github.com/terraform-aws-modules/terraform-aws-eks/files/2655806/new-cluster-tf-plan.txt)
[apply-output.txt](https://github.com/terraform-aws-modules/terraform-aws-eks/files/2655807/apply-output.txt)

- [X] Docs have been updated using `terraform-docs` per `README.md` instructions
- [X] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
