### PR TITLE
Adding new "--with-aggregate-type-default" option to terraform-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Write your awesome change here (by @you)
+- Added `--with-aggregate-type-defaults` option to terraform-docs (by @max-rocket-internet)
 
 ## [[v1.8.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.7.0...v1.8.0)] - 2018-12-04]
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ kubectl get nodes --watch --kubeconfig kubeconfig
 ## Doc generation
 
 Documentation should be modified within `main.tf` and generated using [terraform-docs](https://github.com/segmentio/terraform-docs).
-Generate them like so:
 
-```bash
-go get github.com/segmentio/terraform-docs
-terraform-docs md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
+Install it with `go get github.com/segmentio/terraform-docs` or `brew install terraform-docs` and then use it to generate the `README.md` file:
+
+```
+terraform-docs --with-aggregate-type-defaults md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
 ```
 
 ## Contributing
@@ -107,25 +107,25 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | string | `1.10` | no |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `./` | no |
-| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `<list>` | no |
+| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to to fetch AWS EKS credentials. | string | `aws-iam-authenticator` | no |
-| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `<list>` | no |
-| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `<map>` | no |
+| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `[]` | no |
+| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `{}` | no |
 | kubeconfig\_name | Override the default name used for items kubeconfig. | string | `` | no |
-| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. Defaults to ["/bin/sh", "-c"] | list | `<list>` | no |
+| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list | `[ "/bin/sh", "-c" ]` | no |
 | manage\_aws\_auth | Whether to write and apply the aws-auth configmap file. | string | `true` | no |
-| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
-| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `<list>` | no |
+| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
+| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
+| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | - | yes |
-| tags | A map of tags to add to all resources. | map | `<map>` | no |
+| tags | A map of tags to add to all resources. | map | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | - | yes |
-| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `<list>` | no |
+| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `[]` | no |
 | worker\_group\_count | The number of maps contained within the worker_groups list. | string | `1` | no |
-| worker\_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `<list>` | no |
+| worker\_groups | A list of maps defining worker group configurations. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
 | worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `` | no |
 | worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `1025` | no |
-| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `<map>` | no |
+| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `{}` | no |
 | write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `true` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -67,11 +67,11 @@
 * ## Doc generation
 
 * Documentation should be modified within `main.tf` and generated using [terraform-docs](https://github.com/segmentio/terraform-docs).
-* Generate them like so:
-
-* ```bash
-* go get github.com/segmentio/terraform-docs
-* terraform-docs md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
+*
+* Install it with `go get github.com/segmentio/terraform-docs` or `brew install terraform-docs` and then use it to generate the `README.md` file:
+*
+* ```
+* terraform-docs --with-aggregate-type-defaults md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
 * ```
 
 * ## Contributing

--- a/variables.tf
+++ b/variables.tf
@@ -136,7 +136,7 @@ variable "cluster_delete_timeout" {
 }
 
 variable "local_exec_interpreter" {
-  description = "Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. Defaults to [\"/bin/sh\", \"-c\"]"
+  description = "Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice."
   type        = "list"
   default     = ["/bin/sh", "-c"]
 }


### PR DESCRIPTION
# PR o'clock

## Description

Just a small change to add the new `--with-aggregate-type-defaults` option to terraform-docs instructions.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
