### PR TITLE
Use sed instead of tail for terraform-docs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Documentation should be modified within `main.tf` and generated using [terraform
 Install it with `go get github.com/segmentio/terraform-docs` or `brew install terraform-docs` and then use it to generate the `README.md` file:
 
 ```
-terraform-docs --with-aggregate-type-defaults md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
+terraform-docs --with-aggregate-type-defaults md ./ | sed -e '$ d' -e 'N;/^\n$/D;P;D' > README.md
 ```
 
 ## Contributing

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@
 * Install it with `go get github.com/segmentio/terraform-docs` or `brew install terraform-docs` and then use it to generate the `README.md` file:
 *
 * ```
-* terraform-docs --with-aggregate-type-defaults md ./ | cat -s | tail -r | tail -n +2 | tail -r > README.md
+* terraform-docs --with-aggregate-type-defaults md ./ | sed -e '$ d' -e 'N;/^\n$/D;P;D' > README.md
 * ```
 
 * ## Contributing


### PR DESCRIPTION
# PR o'clock

## Description

Use `sed` instead of `tail` for the `terraform-docs` command since it is more universally compatible. Thanks to @dpiddockcmp for your suggestion at https://github.com/terraform-aws-modules/terraform-aws-eks/pull/209#issuecomment-446671578

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
