### PR TITLE
AWS region was missing in example

### DIFF
--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -14,6 +14,9 @@ rbac:
 
 sslCertPath: /etc/ssl/certs/ca-bundle.crt
 
+cloudProvider: aws
+awsRegion: YOUR_AWS_REGION
+
 autoDiscovery:
   clusterName: YOUR_CLUSTER_NAME
   enabled: true


### PR DESCRIPTION
awsRegion missing in example.
It's not working without it.

And added cloudProvider setting.
It's by default "aws" and not necessary at the moment. But it's to important and should be defined if default will change in the future.

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been updated using `terraform-docs` per `README.md` instructions
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
