### PR TITLE
Added write_aws_auth_config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ##### Changed
 
-- Removed invalid action from worker_autoscaling iam policy
+- Change worker group ASG to use create_before_destroy (by @stefansedich)
 - Fixed a bug where worker group defaults were being used for launch template user data (by @leonsodhi-lf)
 - Managed_aws_auth option is true, the aws-auth configmap file is no longer created, and write_aws_auth_config must be set to true to generate config_map. (by @yutachaos)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to configure force_delete for the worker group ASG (by @stefansedich)
 - Added EBS optimized mapping for the g3s.xlarge instance type (by @stefansedich)
 - `enabled_metrics` input (by @zanitete)
+- write_aws_auth_config to input (by @yutachaos)
 
 ##### Changed
 
-- Change worker group ASG to use create_before_destroy (by @stefansedich)
+- Removed invalid action from worker_autoscaling iam policy
 - Fixed a bug where worker group defaults were being used for launch template user data (by @leonsodhi-lf)
+- Managed_aws_auth option is true, the aws-auth configmap file is no longer created, and write_aws_auth_config must be set to true to generate config_map. (by @yutachaos)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `{}` | no |
 | kubeconfig\_name | Override the default name used for items kubeconfig. | string | `""` | no |
 | local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list | `[ "/bin/sh", "-c" ]` | no |
-| manage\_aws\_auth | Whether to write and apply the aws-auth configmap file. | string | `"true"` | no |
+| manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
 | map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
 | map\_accounts\_count | The count of accounts in the map_accounts list. | string | `"0"` | no |
 | map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
@@ -143,6 +143,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
 | workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `{}` | no |
 | workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `{}` | no |
+| write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | string | `"true"` | no |
 | write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `"true"` | no |
 
 ## Outputs

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -11,7 +11,7 @@ resource "null_resource" "update_config_map_aws_auth" {
     working_dir = "${path.module}"
 
     command = <<EOS
-for i in {1..5}; do \
+for i in `seq 1 10`; do \
 echo "${null_resource.update_config_map_aws_auth.triggers.kube_config_map_rendered}" > kube_config.yaml & \
 echo "${null_resource.update_config_map_aws_auth.triggers.config_map_rendered}" > aws_auth_configmap.yaml & \
 kubectl apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && break || \

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -26,7 +26,7 @@ EOS
   triggers {
     kube_config_map_rendered = "${data.template_file.kubeconfig.rendered}"
     config_map_rendered      = "${data.template_file.config_map_aws_auth.rendered}"
-    endpoint            = "${aws_eks_cluster.this.endpoint}"
+    endpoint                 = "${aws_eks_cluster.this.endpoint}"
   }
 
   count = "${var.manage_aws_auth ? 1 : 0}"

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -11,14 +11,13 @@ resource "null_resource" "update_config_map_aws_auth" {
     working_dir = "${path.module}"
 
     command = <<EOS
-mkfifo aws_auth_configmap kube_config & \
 for i in {1..5}; do \
-echo "${null_resource.update_config_map_aws_auth.triggers.kube_config_map_rendered}" > kube_config & \
-echo "${null_resource.update_config_map_aws_auth.triggers.config_map_rendered}" > aws_auth_configmap & \
-kubectl apply -f aws_auth_configmap --kubeconfig kube_config && break || \
+echo "${null_resource.update_config_map_aws_auth.triggers.kube_config_map_rendered}" > kube_config.yaml & \
+echo "${null_resource.update_config_map_aws_auth.triggers.config_map_rendered}" > aws_auth_configmap.yaml & \
+kubectl apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && break || \
 sleep 10; \
 done; \
-rm -f aws_auth_configmap kube_config;
+rm aws_auth_configmap.yaml kube_config.yaml;
 EOS
 
     interpreter = ["${var.local_exec_interpreter}"]

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,12 @@ variable "write_kubeconfig" {
 }
 
 variable "manage_aws_auth" {
-  description = "Whether to write and apply the aws-auth configmap file."
+  description = "Whether to apply the aws-auth configmap file."
+  default     = true
+}
+
+variable "write_aws_auth_config" {
+  description = "Whether to write the aws-auth configmap file."
   default     = true
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Added an option not to create aws_auth configmap.
I made it possible to apply kubectl apply without generating a file to correspond.

Refer issues
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/169
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/170

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
