### PR TITLE
Update userdata.sh.tpl with node_labels based on ondemand/spot detection

### DIFF
--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -3,8 +3,17 @@
 # Allow user supplied pre userdata code
 ${pre_userdata}
 
+# Detect instance life cycle
+iid=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+export AWS_DEFAULT_REGION=${AWS::Region}
+ilc=`aws ec2 describe-instances --instance-ids  $iid  --query 'Reservations[0].Instances[0].InstanceLifecycle' --output text`
+
 # Bootstrap and join the cluster
-/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
+if [ "$ilc" == "spot" ]; then
+  /etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args --node-labels=ondemand=yes '${kubelet_extra_args}' '${cluster_name}'
+else
+  /etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '--node-labels=spotfleet=yes --register-with-taints=spotInstance=true:PreferNoSchedule' '${kubelet_extra_args}' '${cluster_name}'
+end
 
 # Allow user supplied userdata code
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

In order to detect wheter an instance is running ondemand or spot I integrated a small detection logic from @pahud.

This is a change based on this template:
https://github.com/pahud/eks-templates/blob/master/cloudformation/nodegroup.yaml

This will allow us to use his eks lambda drainer in the future:
https://github.com/pahud/eks-lambda-drainer

This change is also relevant for the mixed instances pull request because once you have a mixed fleet you want to know which instances are ondemand or spot:
https://github.com/terraform-aws-modules/terraform-aws-eks/pull/222

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
