### PR TITLE
Fix issue where ConfigMap isn't applied to new cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
  - Removed invalid action from worker_autoscaling iam policy
+ - Updated the `update_config_map_aws_auth` resource to trigger when the EKS cluster endpoint changes. This likely
+   means that a new cluster was spun up so our ConfigMap won't exist (fixes #234) (by @elatt)
 
 ## [[v2.0.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.8.0...v2.0.0)] - 2018-12-14]
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -14,6 +14,7 @@ resource "null_resource" "update_config_map_aws_auth" {
 
   triggers {
     config_map_rendered = "${data.template_file.config_map_aws_auth.rendered}"
+    endpoint            = "${aws_eks_cluster.this.endpoint}"
   }
 
   count = "${var.manage_aws_auth ? 1 : 0}"


### PR DESCRIPTION
If you are trying to recover a cluster that was deleted, the current
code will not re-apply the ConfigMap because it is already rendered so
kubectl command won't get triggered.

This change adds the cluster endpoint (which should be different when
spinning up a new cluster even with the same name) so we will force a
re-render and cause the kubectl command to run.

# PR o'clock

## Description

This should be a simple way to work around the issue that we saw in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/234.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [ ] ~~Any breaking changes are highlighted above~~
