### PR TITLE
Fix zsh-specific syntax in retry loop within null_resource.update_config_map_aws_auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## [[v2.0.1](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.0.0...HEAD)] - 2019-01-??]
 
 ### Added
- - Write your awesome addition here (by @you)
+
+- Write your awesome addition here (by @you)
 
 ### Changed
- - Removed invalid action from worker_autoscaling iam policy
+
+- Removed invalid action from worker_autoscaling iam policy (by @marcelloromani)
+- Fixed zsh-specific syntax in retry loop for aws auth config map (by @marcelloromani)
+- Fix: fail deployment if applying the aws auth config map still fails after 10 attempts (by @marcelloromani)
 
 ## [[v2.0.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.8.0...v2.0.0)] - 2018-12-14]
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -8,7 +8,7 @@ resource "null_resource" "update_config_map_aws_auth" {
   depends_on = ["aws_eks_cluster.this"]
 
   provisioner "local-exec" {
-    command     = "for i in {1..5}; do kubectl apply -f ${var.config_output_path}config-map-aws-auth_${var.cluster_name}.yaml --kubeconfig ${var.config_output_path}kubeconfig_${var.cluster_name} && break || sleep 10; done"
+    command     = "for i in `seq 1 10`; do kubectl apply -f ${var.config_output_path}config-map-aws-auth_${var.cluster_name}.yaml --kubeconfig ${var.config_output_path}kubeconfig_${var.cluster_name} && exit 0 || sleep 10; done; exit 1"
     interpreter = ["${var.local_exec_interpreter}"]
   }
 


### PR DESCRIPTION
# PR o'clock

## Description

This is a fix for #238 
Fixes two problems:

* kubectl apply <aws auth config map> is actually tried up to 5 times
* terraform apply fails if said command fails after 5 attempts

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above

#### Tests

Not sure how to add automated testing to this.

I did test my code changes manually against module version 1.8.0, and noticed it took `kubectl` 4 times before succeeding. 
I therefore thought it would be safer to increase the number of retries to 10 