### PR TITLE
Add use_max_pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ##### Added
 
+- Add `use_max_pods` (by @knqyf263)
 - Write your awesome addition here (by @you)
 
 ##### Changed
@@ -52,7 +53,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--  Support for using AWS Launch Templates to define autoscaling groups (by @skang0601)
+- Support for using AWS Launch Templates to define autoscaling groups (by @skang0601)
 - `suspended_processes` to `worker_groups` input (by @bkmeneguello)
 - `target_group_arns` to `worker_groups` input (by @zihaoyu)
 - `force_detach_policies` to `aws_iam_role` `cluster` and `workers` (by @marky-mark)
@@ -96,7 +97,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - allow a custom AMI to be specified as a default (by @erks)
 - bugfix for above change (by @max-rocket-internet)
-- **Breaking change** Removed support for `eks-worker-*` AMI. The cluster specifying a custom AMI based off of `eks-worker-*` AMI will have to rebuild the AMI from `amazon-eks-node-*`.  (by @erks)
+- **Breaking change** Removed support for `eks-worker-*` AMI. The cluster specifying a custom AMI based off of `eks-worker-*` AMI will have to rebuild the AMI from `amazon-eks-node-*`. (by @erks)
 - **Breaking change** Removed `kubelet_node_labels` worker group option in favor of `kubelet_extra_args`. (by @erks)
 
 ## [[v1.5.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v1.4.0...v1.5.0)] - 2018-08-30]

--- a/data.tf
+++ b/data.tf
@@ -80,6 +80,7 @@ data "template_file" "userdata" {
     pre_userdata        = "${lookup(var.worker_groups[count.index], "pre_userdata", local.workers_group_defaults["pre_userdata"])}"
     additional_userdata = "${lookup(var.worker_groups[count.index], "additional_userdata", local.workers_group_defaults["additional_userdata"])}"
     kubelet_extra_args  = "${lookup(var.worker_groups[count.index], "kubelet_extra_args", local.workers_group_defaults["kubelet_extra_args"])}"
+    use_max_pods        = "${lookup(var.worker_groups[count.index], "use_max_pods", local.workers_group_defaults["use_max_pods"])}"
   }
 }
 
@@ -94,5 +95,6 @@ data "template_file" "launch_template_userdata" {
     pre_userdata        = "${lookup(var.worker_groups_launch_template[count.index], "pre_userdata", local.workers_group_defaults["pre_userdata"])}"
     additional_userdata = "${lookup(var.worker_groups_launch_template[count.index], "additional_userdata", local.workers_group_defaults["additional_userdata"])}"
     kubelet_extra_args  = "${lookup(var.worker_groups_launch_template[count.index], "kubelet_extra_args", local.workers_group_defaults["kubelet_extra_args"])}"
+    use_max_pods        = "${lookup(var.worker_groups[count.index], "use_max_pods", local.workers_group_defaults["use_max_pods"])}"
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -28,6 +28,7 @@ locals {
     enable_monitoring             = true                            # Enables/disables detailed monitoring.
     public_ip                     = false                           # Associate a public ip address with a worker
     kubelet_extra_args            = ""                              # This string is passed directly to kubelet if set. Useful for adding labels or taints.
+    use_max_pods                  = ""                              # Sets --max-pods for the kubelet when true
     subnets                       = "${join(",", var.subnets)}"     # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
     autoscaling_enabled           = false                           # Sets whether policy and matching tags will be added to allow autoscaling.
     additional_security_group_ids = ""                              # A comma delimited list of additional security group ids to include in worker launch config
@@ -66,6 +67,7 @@ locals {
     enable_monitoring                        = true                                          # Enables/disables detailed monitoring.
     public_ip                                = false                                         # Associate a public ip address with a worker
     kubelet_extra_args                       = ""                                            # This string is passed directly to kubelet if set. Useful for adding labels or taints.
+    use_max_pods                             = ""                                            # Sets --max-pods for the kubelet when true
     subnets                                  = "${join(",", var.subnets)}"                   # A comma delimited string of subnets to place the worker nodes in. i.e. subnet-123,subnet-456,subnet-789
     autoscaling_enabled                      = false                                         # Sets whether policy and matching tags will be added to allow autoscaling.
     additional_security_group_ids            = ""                                            # A comma delimited list of additional security group ids to include in worker launch config

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -4,7 +4,7 @@
 ${pre_userdata}
 
 # Bootstrap and join the cluster
-/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
+/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '${kubelet_extra_args}' --use-max-pods '${use_max_pods}' '${cluster_name}'
 
 # Allow user supplied userdata code
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

Add use_max_pods to `templates/userdata.sh.tpl`
https://github.com/awslabs/amazon-eks-ami/blob/208c114737303cc350a5778fe56d489c9476f945/files/bootstrap.sh#L19

Since the default value of `--use-max-pods` is true, an limit is set based on the following values.
https://github.com/awslabs/amazon-eks-ami/blob/208c114737303cc350a5778fe56d489c9476f945/files/eni-max-pods.txt

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [x] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
