### PR TITLE
Enable create_before_destroy for ASG and enable force_delete to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ##### Added
 
-- Write your awesome addition here (by @you)
+- Ability to configure force_delete for the worker group ASG (by @stefansedich)
 
 ##### Changed
 
-- Write your awesome change here (by @you)
+- Change worker group ASG to use create_before_destroy (by @stefansedich)
 
 # History
 

--- a/local.tf
+++ b/local.tf
@@ -15,6 +15,7 @@ locals {
     asg_desired_capacity          = "1"                             # Desired worker capacity in the autoscaling group.
     asg_max_size                  = "3"                             # Maximum worker capacity in the autoscaling group.
     asg_min_size                  = "1"                             # Minimum worker capacity in the autoscaling group.
+    asg_force_delete              = false                           # Enable forced deletion for the autoscaling group.
     instance_type                 = "m4.large"                      # Size of the workers instances.
     spot_price                    = ""                              # Cost of spot instance.
     placement_tenancy             = ""                              # The tenancy of the instance. Valid values are "default" or "dedicated".

--- a/local.tf
+++ b/local.tf
@@ -47,6 +47,7 @@ locals {
     asg_desired_capacity                     = "1"                                           # Desired worker capacity in the autoscaling group.
     asg_max_size                             = "3"                                           # Maximum worker capacity in the autoscaling group.
     asg_min_size                             = "1"                                           # Minimum worker capacity in the autoscaling group.
+    asg_force_delete                         = false                                         # Enable forced deletion for the autoscaling group.
     instance_type                            = "m4.large"                                    # Size of the workers instances.
     override_instance_type                   = "t3.large"                                    # Need to specify at least one additional instance type for mixed instances policy. The instance_type holds  higher priority for on demand instances.
     on_demand_allocation_strategy            = "prioritized"                                 # Strategy to use when launching on-demand instances. Valid values: prioritized.

--- a/workers.tf
+++ b/workers.tf
@@ -5,6 +5,7 @@ resource "aws_autoscaling_group" "workers" {
   desired_capacity      = "${lookup(var.worker_groups[count.index], "asg_desired_capacity", local.workers_group_defaults["asg_desired_capacity"])}"
   max_size              = "${lookup(var.worker_groups[count.index], "asg_max_size", local.workers_group_defaults["asg_max_size"])}"
   min_size              = "${lookup(var.worker_groups[count.index], "asg_min_size", local.workers_group_defaults["asg_min_size"])}"
+  force_delete          = "${lookup(var.worker_groups[count.index], "asg_force_delete", local.workers_group_defaults["asg_force_delete"])}"
   target_group_arns     = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "target_group_arns", ""), local.workers_group_defaults["target_group_arns"])))}"]
   launch_configuration  = "${element(aws_launch_configuration.workers.*.id, count.index)}"
   vpc_zone_identifier   = ["${split(",", coalesce(lookup(var.worker_groups[count.index], "subnets", ""), local.workers_group_defaults["subnets"]))}"]
@@ -22,6 +23,8 @@ resource "aws_autoscaling_group" "workers" {
   }"]
 
   lifecycle {
+    create_before_destroy = true
+
     ignore_changes = ["desired_capacity"]
   }
 }

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -5,6 +5,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   desired_capacity  = "${lookup(var.worker_groups_launch_template[count.index], "asg_desired_capacity", local.workers_group_launch_template_defaults["asg_desired_capacity"])}"
   max_size          = "${lookup(var.worker_groups_launch_template[count.index], "asg_max_size", local.workers_group_launch_template_defaults["asg_max_size"])}"
   min_size          = "${lookup(var.worker_groups_launch_template[count.index], "asg_min_size", local.workers_group_launch_template_defaults["asg_min_size"])}"
+  force_delete      = "${lookup(var.worker_groups_launch_template[count.index], "asg_force_delete", local.workers_group_launch_template_defaults["asg_force_delete"])}"
   target_group_arns = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template[count.index], "target_group_arns", ""), local.workers_group_launch_template_defaults["target_group_arns"])))}"]
 
   mixed_instances_policy {
@@ -48,6 +49,8 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   }"]
 
   lifecycle {
+    create_before_destroy = true
+
     ignore_changes = ["desired_capacity"]
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

This PR firstly enabled create_before_destroy for the ASG resource, previously it was killing the old ASG before creating the new one, felt like it made sense to just configure this for the ASG as it is already enabled for the launch configuration.

The second change was to enable the configuration of force_delete for the ASG, which is something I have found useful to do to enable myself to terminate an ASG that contains instance protected nodes.

I bundled them into one PR, if that is an issue I can split it out.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
