### PR TITLE
Use launch template defaults for launch template userdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ##### Changed
 
 - Change worker group ASG to use create_before_destroy (by @stefansedich)
+- Fixed a bug where worker group defaults were being used for launch template user data (by @leonsodhi-lf)
 
 # History
 

--- a/data.tf
+++ b/data.tf
@@ -91,8 +91,8 @@ data "template_file" "launch_template_userdata" {
     cluster_name        = "${aws_eks_cluster.this.name}"
     endpoint            = "${aws_eks_cluster.this.endpoint}"
     cluster_auth_base64 = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    pre_userdata        = "${lookup(var.worker_groups_launch_template[count.index], "pre_userdata", local.workers_group_defaults["pre_userdata"])}"
-    additional_userdata = "${lookup(var.worker_groups_launch_template[count.index], "additional_userdata", local.workers_group_defaults["additional_userdata"])}"
-    kubelet_extra_args  = "${lookup(var.worker_groups_launch_template[count.index], "kubelet_extra_args", local.workers_group_defaults["kubelet_extra_args"])}"
+    pre_userdata        = "${lookup(var.worker_groups_launch_template[count.index], "pre_userdata", local.workers_group_launch_template_defaults["pre_userdata"])}"
+    additional_userdata = "${lookup(var.worker_groups_launch_template[count.index], "additional_userdata", local.workers_group_launch_template_defaults["additional_userdata"])}"
+    kubelet_extra_args  = "${lookup(var.worker_groups_launch_template[count.index], "kubelet_extra_args", local.workers_group_launch_template_defaults["kubelet_extra_args"])}"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Fixes what I think is a bug where `workers_group_defaults` were being used as default values for `launch_template_userdata`. Anyone that relies on that behaviour will need to specify defaults via `workers_group_launch_template_defaults` once this is merged.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above
