### PR TITLE
Adding the g3s.xlarge instance type ebs optimized mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ##### Added
 
 - Ability to configure force_delete for the worker group ASG (by @stefansedich)
+- Added EBS optimized mapping for the g3s.xlarge instance type (by @stefansedich)
 
 ##### Changed
 

--- a/local.tf
+++ b/local.tf
@@ -115,6 +115,7 @@ locals {
     "f1.16xlarge"  = true
     "g2.2xlarge"   = true
     "g2.8xlarge"   = false
+    "g3s.xlarge"   = true
     "g3.4xlarge"   = true
     "g3.8xlarge"   = true
     "g3.16xlarge"  = true


### PR DESCRIPTION
# PR o'clock

## Description

Just adding the EBS optimized mapping for the g3s.xlarge instance type.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
