### PR TITLE
Add optional permissions_boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ##### Added
 
+- Ability to specify a permissions_boundary for IAM roles (by @dylanhellems)
 - Ability to configure force_delete for the worker group ASG (by @stefansedich)
 - Ability to configure worker group ASG tags (by @stefansedich)
 - Added EBS optimized mapping for the g3s.xlarge instance type (by @stefansedich)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | map\_roles\_count | The count of roles in the map_roles list. | string | `"0"` | no |
 | map\_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
 | map\_users\_count | The count of roles in the map_users list. | string | `"0"` | no |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `""` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list | n/a | yes |
 | tags | A map of tags to add to all resources. | map | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |

--- a/cluster.tf
+++ b/cluster.tf
@@ -52,6 +52,7 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
 resource "aws_iam_role" "cluster" {
   name_prefix           = "${var.cluster_name}"
   assume_role_policy    = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"
+  permissions_boundary  = "${var.permissions_boundary}"
   force_detach_policies = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -216,3 +216,8 @@ variable "worker_create_security_group" {
   description = "Whether to create a security group for the workers or attach the workers to `worker_security_group_id`."
   default     = true
 }
+
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  default     = ""
+}

--- a/workers.tf
+++ b/workers.tf
@@ -114,6 +114,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
 resource "aws_iam_role" "workers" {
   name_prefix           = "${aws_eks_cluster.this.name}"
   assume_role_policy    = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
+  permissions_boundary  = "${var.permissions_boundary}"
   force_detach_policies = true
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Add `permissions_boundary` as optional input, which will be attached to all IAM roles this modules creates.

On my project, we have an organizational requirement to apply a permissions boundary to all IAM roles. 

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
