### PR TITLE
Added output for generated kubeconfig filename

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -39,6 +39,11 @@ output "kubeconfig" {
   value       = "${data.template_file.kubeconfig.rendered}"
 }
 
+output "kubeconfig_filename" {
+  description = "The filename of the generated kubectl config."
+  value       = "${local_file.kubeconfig.*.filename}"
+}
+
 output "workers_asg_arns" {
   description = "IDs of the autoscaling groups containing workers."
   value       = "${concat(aws_autoscaling_group.workers.*.arn, aws_autoscaling_group.workers_launch_template.*.arn)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,7 +41,7 @@ output "kubeconfig" {
 
 output "kubeconfig_filename" {
   description = "The filename of the generated kubectl config."
-  value       = "${local_file.kubeconfig.*.filename}"
+  value       = "${element(concat(local_file.kubeconfig.*.filename, list("")), 0)}"
 }
 
 output "workers_asg_arns" {


### PR DESCRIPTION
# PR o'clock

## Description

The terraform helm provider uses a kubectl config filename as a config parameter.
The eks module generates a kubectl config with a random filename.
In order to enable integration between the two and facilitate automated provisioning of an eks cluster, 
by passing the kubectl config filename as an input 
to the terraform helm provider, I added a new output to the eks module.

terraform helm provider: https://github.com/terraform-providers/terraform-provider-helm

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
