### PR TITLE
Add optional iam_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 # History
 
+## [[v2.2.2](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.2.1...v2.2.2)] - 2019-02-25]
+
+### Added
+
+- Ability to specify a path for IAM roles (by @tekn0ir)
+
 ## [[v2.2.1](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.2.0...v2.2.1)] - 2019-02-18]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys. | map | `{}` | no |
 | write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | string | `"true"` | no |
 | write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `"true"` | no |
+| iam\_path | If provided, all IAM roles will be created with path. | string | `"/"` | no |
 
 ## Outputs
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -53,6 +53,7 @@ resource "aws_iam_role" "cluster" {
   name_prefix           = "${var.cluster_name}"
   assume_role_policy    = "${data.aws_iam_policy_document.cluster_assume_role_policy.json}"
   permissions_boundary  = "${var.permissions_boundary}"
+  path                  = "${var.iam_path}"
   force_detach_policies = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -221,3 +221,8 @@ variable "permissions_boundary" {
   description = "If provided, all IAM roles will be created with this permissions boundary attached."
   default     = ""
 }
+
+variable "iam_path" {
+  description = "If provided, all IAM roles will be created on this path."
+  default     = "/"
+}

--- a/workers.tf
+++ b/workers.tf
@@ -115,6 +115,7 @@ resource "aws_iam_role" "workers" {
   name_prefix           = "${aws_eks_cluster.this.name}"
   assume_role_policy    = "${data.aws_iam_policy_document.workers_assume_role_policy.json}"
   permissions_boundary  = "${var.permissions_boundary}"
+  path                  = "${var.iam_path}"
   force_detach_policies = true
 }
 
@@ -122,6 +123,7 @@ resource "aws_iam_instance_profile" "workers" {
   name_prefix = "${aws_eks_cluster.this.name}"
   role        = "${lookup(var.worker_groups[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id"))}"
   count       = "${var.worker_group_count}"
+  path        = "${var.iam_path}"
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {
@@ -158,6 +160,7 @@ resource "aws_iam_policy" "worker_autoscaling" {
   name_prefix = "eks-worker-autoscaling-${aws_eks_cluster.this.name}"
   description = "EKS worker node autoscaling policy for cluster ${aws_eks_cluster.this.name}"
   policy      = "${data.aws_iam_policy_document.worker_autoscaling.json}"
+  path        = "${var.iam_path}"
 }
 
 data "aws_iam_policy_document" "worker_autoscaling" {

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -105,4 +105,5 @@ resource "aws_iam_instance_profile" "workers_launch_template" {
   name_prefix = "${aws_eks_cluster.this.name}"
   role        = "${lookup(var.worker_groups_launch_template[count.index], "iam_role_id",  lookup(local.workers_group_launch_template_defaults, "iam_role_id"))}"
   count       = "${var.worker_group_launch_template_count}"
+  path        = "${var.iam_path}"
 }


### PR DESCRIPTION
# PR o'clock

## Description

In some corporate environments you may only be allowed to create iam roles and policies within a certain path. Added an optional iam_path variable to allow support this type of configuration.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
