### PR TITLE
Add outputs for cluster role ARN and name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added output for generated kubeconfig filename (by @syst0m)
+- Added outputs for cluster role ARN and name (by @spingel)
 
 ## [[v2.2.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.1.0...v2.2.0)] - 2019-02-07]
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
 | cluster\_endpoint | The endpoint for your EKS Kubernetes API. |
 | cluster\_id | The name/id of the EKS cluster. |
+| cluster\_role\_arn | IAM role ARN of the EKS cluster role. |
+| cluster\_role\_name | IAM role name of the EKS cluster role. |
 | cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
 | cluster\_version | The Kubernetes server version for the EKS cluster. |
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,16 @@ output "config_map_aws_auth" {
   value       = "${data.template_file.config_map_aws_auth.rendered}"
 }
 
+output "cluster_iam_role_name" {
+  description = "IAM role name of the EKS cluster."
+  value       = "${aws_iam_role.cluster.name}"
+}
+
+output "cluster_iam_role_arn" {
+  description = "IAM role ARN of the EKS cluster."
+  value       = "${aws_iam_role.cluster.arn}"
+}
+
 output "kubeconfig" {
   description = "kubectl config file contents for this EKS cluster."
   value       = "${data.template_file.kubeconfig.rendered}"


### PR DESCRIPTION
# PR o'clock

## Description

This enables attaching additional policies, e.g. for using
encrypted volumes, to the cluster.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above

Signed-off-by: Steffen Pingel <steffen.pingel@tasktop.com>
