### PR TITLE
Adding workers_launch_template ebs encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Write your awesome addition here (by @you)
+- Adding ebs encryption for workers launched using workers_launch_template (by @russki)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
 - Adding ebs encryption for workers launched using workers_launch_template (by @russki)
 - Added output for generated kubeconfig filename (by @syst0m)
 - Added outputs for cluster role ARN and name (by @spingel)

--- a/local.tf
+++ b/local.tf
@@ -62,6 +62,8 @@ locals {
     root_volume_size                         = "100"                                         # root volume size of workers instances.
     root_volume_type                         = "gp2"                                         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops                                = "0"                                           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
+    root_encrypted                           = false                                         # root volume encryption for workers.
+    kms_key_id                               = ""                                            # KMS key ID used for encrypted block device. ASG must have access to this key. If not specified, the default KMS key will be used.
     key_name                                 = ""                                            # The key name that should be used for the instances in the autoscaling group
     pre_userdata                             = ""                                            # userdata to pre-append to the default userdata.
     additional_userdata                      = ""                                            # userdata to append to the default userdata.

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -96,6 +96,8 @@ resource "aws_launch_template" "workers_launch_template" {
       volume_size           = "${lookup(var.worker_groups_launch_template[count.index], "root_volume_size", local.workers_group_launch_template_defaults["root_volume_size"])}"
       volume_type           = "${lookup(var.worker_groups_launch_template[count.index], "root_volume_type", local.workers_group_launch_template_defaults["root_volume_type"])}"
       iops                  = "${lookup(var.worker_groups_launch_template[count.index], "root_iops", local.workers_group_launch_template_defaults["root_iops"])}"
+      encrypted             = "${lookup(var.worker_groups_launch_template[count.index], "root_encrypted", local.workers_group_launch_template_defaults["root_encrypted"])}"
+      kms_key_id            = "${lookup(var.worker_groups_launch_template[count.index], "kms_key_id", local.workers_group_launch_template_defaults["kms_key_id"])}"
       delete_on_termination = true
     }
   }


### PR DESCRIPTION
# PR o'clock

## Description

Adding EBS encryption option for EKS workers in workers_launch_template

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
