### PR TITLE
Adding optional name filter variable to be able to pin worker AMI to a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+- Added output for generated kubeconfig filename (by @syst0m)
+- Added outputs for cluster role ARN and name (by @spingel)
+- Added optional name filter variable to be able to pin worker AMI to a release (by @max-rocket-internet)
 
 ### Changed
 
@@ -20,11 +22,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 # History
 
 ## [[v2.2.1](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.2.0...v2.2.1)] - 2019-02-18]
-
-### Added
-
-- Added output for generated kubeconfig filename (by @syst0m)
-- Added outputs for cluster role ARN and name (by @spingel)
 
 ## [[v2.2.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.1.0...v2.2.0)] - 2019-02-07]
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | tags | A map of tags to add to all resources. | map | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `[]` | no |
+| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | string | `"true"` | no |
 | worker\_group\_count | The number of maps contained within the worker_groups list. | string | `"1"` | no |
 | worker\_group\_launch\_template\_count | The number of maps contained within the worker_groups_launch_template list. | string | `"0"` | no |
@@ -155,9 +156,9 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 |------|-------------|
 | cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
 | cluster\_endpoint | The endpoint for your EKS Kubernetes API. |
+| cluster\_iam\_role\_arn | IAM role ARN of the EKS cluster. |
+| cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
 | cluster\_id | The name/id of the EKS cluster. |
-| cluster\_role\_arn | IAM role ARN of the EKS cluster role. |
-| cluster\_role\_name | IAM role name of the EKS cluster role. |
 | cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
 | cluster\_version | The Kubernetes server version for the EKS cluster. |
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |

--- a/data.tf
+++ b/data.tf
@@ -18,11 +18,13 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
 data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-v*"]
+    values = ["amazon-eks-node-${var.cluster_version}-${var.worker_ami_name_filter}"]
   }
 
   most_recent = true
-  owners      = ["602401143452"]
+
+  # Owner ID of AWS EKS team
+  owners = ["602401143452"]
 }
 
 data "aws_iam_policy_document" "cluster_assume_role_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "worker_group_count" {
 }
 
 variable "workers_group_defaults" {
-  description = "Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys."
+  description = "Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys."
   type        = "map"
   default     = {}
 }
@@ -133,7 +133,7 @@ variable "worker_group_launch_template_count" {
 }
 
 variable "workers_group_launch_template_defaults" {
-  description = "Override default values for target groups. See workers_group_defaults_defaults in locals.tf for valid keys."
+  description = "Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys."
   type        = "map"
   default     = {}
 }
@@ -150,6 +150,11 @@ variable "worker_group_launch_template_tags" {
 variable "worker_security_group_id" {
   description = "If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster."
   default     = ""
+}
+
+variable "worker_ami_name_filter" {
+  description = "Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. \"v20190220\""
+  default     = "v*"
 }
 
 variable "worker_additional_security_group_ids" {


### PR DESCRIPTION
# PR o'clock

## Description

Currently the  worker AMI ID is always set to the latest for the Kubernetes version. This means when a new AMI is released then on next `terraform apply` the LC is updated. This is annoying for users who want to be able to pin the AMI to a release without having to lookup the AMI ID in each region.

With this PR we can just set this variable to a  [amazon-eks-ami](https://github.com/awslabs/amazon-eks-ami) release name:

```hcl
module "my_cluster" {
  source                           = "git@github.com:terraform-aws-modules/terraform-aws-eks.git"
  cluster_version                  = "1.11"
  worker_ami_name_filter           = "v20190109"
...
```

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
