### PR TITLE
add ec2:DescribeLaunchTemplateVersions action to worker node iam role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added "ec2:DescribeLaunchTemplateVersions" action to worker instance role (by @skang0601)
 - Added output for generated kubeconfig filename (by @syst0m)
 - Added outputs for cluster role ARN and name (by @spingel)
 - Added optional name filter variable to be able to pin worker AMI to a release (by @max-rocket-internet)

--- a/workers.tf
+++ b/workers.tf
@@ -173,6 +173,7 @@ data "aws_iam_policy_document" "worker_autoscaling" {
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
       "autoscaling:DescribeTags",
+      "ec2:DescribeLaunchTemplateVersions",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
# PR o'clock

## Description

Adds ec2:DescribeLaunchTemplateVersions to worker node IAM role to address scaling up from 0 for launch templates as noted here: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md

### Checklist

- [ /] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
