### PR TITLE
Add support for --enable-docker-bridge

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -74,12 +74,13 @@ data "template_file" "userdata" {
   count    = "${var.worker_group_count}"
 
   vars {
-    cluster_name        = "${aws_eks_cluster.this.name}"
-    endpoint            = "${aws_eks_cluster.this.endpoint}"
-    cluster_auth_base64 = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    pre_userdata        = "${lookup(var.worker_groups[count.index], "pre_userdata", local.workers_group_defaults["pre_userdata"])}"
-    additional_userdata = "${lookup(var.worker_groups[count.index], "additional_userdata", local.workers_group_defaults["additional_userdata"])}"
-    kubelet_extra_args  = "${lookup(var.worker_groups[count.index], "kubelet_extra_args", local.workers_group_defaults["kubelet_extra_args"])}"
+    cluster_name         = "${aws_eks_cluster.this.name}"
+    endpoint             = "${aws_eks_cluster.this.endpoint}"
+    cluster_auth_base64  = "${aws_eks_cluster.this.certificate_authority.0.data}"
+    pre_userdata         = "${lookup(var.worker_groups[count.index], "pre_userdata", local.workers_group_defaults["pre_userdata"])}"
+    additional_userdata  = "${lookup(var.worker_groups[count.index], "additional_userdata", local.workers_group_defaults["additional_userdata"])}"
+    enable_docker_bridge = "${lookup(var.worker_groups[count.index], "enable_docker_bridge", local.workers_group_defaults["enable_docker_bridge"])}"
+    kubelet_extra_args   = "${lookup(var.worker_groups[count.index], "kubelet_extra_args", local.workers_group_defaults["kubelet_extra_args"])}"
   }
 }
 
@@ -88,11 +89,12 @@ data "template_file" "launch_template_userdata" {
   count    = "${var.worker_group_launch_template_count}"
 
   vars {
-    cluster_name        = "${aws_eks_cluster.this.name}"
-    endpoint            = "${aws_eks_cluster.this.endpoint}"
-    cluster_auth_base64 = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    pre_userdata        = "${lookup(var.worker_groups_launch_template[count.index], "pre_userdata", local.workers_group_launch_template_defaults["pre_userdata"])}"
-    additional_userdata = "${lookup(var.worker_groups_launch_template[count.index], "additional_userdata", local.workers_group_launch_template_defaults["additional_userdata"])}"
-    kubelet_extra_args  = "${lookup(var.worker_groups_launch_template[count.index], "kubelet_extra_args", local.workers_group_launch_template_defaults["kubelet_extra_args"])}"
+    cluster_name         = "${aws_eks_cluster.this.name}"
+    endpoint             = "${aws_eks_cluster.this.endpoint}"
+    cluster_auth_base64  = "${aws_eks_cluster.this.certificate_authority.0.data}"
+    pre_userdata         = "${lookup(var.worker_groups_launch_template[count.index], "pre_userdata", local.workers_group_launch_template_defaults["pre_userdata"])}"
+    additional_userdata  = "${lookup(var.worker_groups_launch_template[count.index], "additional_userdata", local.workers_group_launch_template_defaults["additional_userdata"])}"
+    enable_docker_bridge = "${lookup(var.worker_groups_launch_template[count.index], "enable_docker_bridge", local.workers_group_launch_template_defaults["enable_docker_bridge"])}"
+    kubelet_extra_args   = "${lookup(var.worker_groups_launch_template[count.index], "kubelet_extra_args", local.workers_group_launch_template_defaults["kubelet_extra_args"])}"
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -24,6 +24,7 @@ locals {
     root_iops                     = "0"                             # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                              # The key name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                              # userdata to pre-append to the default userdata.
+    enable_docker_bridge          = "false"                         # --enable-docker-bridge bootstrap.sh arg
     additional_userdata           = ""                              # userdata to append to the default userdata.
     ebs_optimized                 = true                            # sets whether to use ebs optimization on supported types.
     enable_monitoring             = true                            # Enables/disables detailed monitoring.
@@ -64,6 +65,7 @@ locals {
     root_iops                                = "0"                                           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                                 = ""                                            # The key name that should be used for the instances in the autoscaling group
     pre_userdata                             = ""                                            # userdata to pre-append to the default userdata.
+    enable_docker_bridge                     = "false"                                       # --enable-docker-bridge bootstrap.sh arg
     additional_userdata                      = ""                                            # userdata to append to the default userdata.
     ebs_optimized                            = true                                          # sets whether to use ebs optimization on supported types.
     enable_monitoring                        = true                                          # Enables/disables detailed monitoring.

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -4,7 +4,7 @@
 ${pre_userdata}
 
 # Bootstrap and join the cluster
-/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
+/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --enable-docker-bridge '${enable_docker_bridge}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
 
 # Allow user supplied userdata code
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

This enables support for `--enable-docker-bridge` in the latest eks ami.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features) ---- ?
- [ ] Test results are pasted in this PR (in lieu of CI) --- ?
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
