### PR TITLE
Allow additional policies to be attached to worker nodes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,16 @@ variable "worker_sg_ingress_from_port" {
   default     = "1025"
 }
 
+variable "workers_additional_policies" {
+  description = "Additional policies to be added to workers"
+  type        = "list"
+  default     = []
+}
+
+variable "workers_additional_policies_count" {
+  default = 0
+}
+
 variable "kubeconfig_aws_authenticator_command" {
   description = "Command to use to fetch AWS EKS credentials."
   default     = "aws-iam-authenticator"

--- a/workers.tf
+++ b/workers.tf
@@ -141,6 +141,12 @@ resource "aws_iam_role_policy_attachment" "workers_AmazonEC2ContainerRegistryRea
   role       = "${aws_iam_role.workers.name}"
 }
 
+resource "aws_iam_role_policy_attachment" "workers_additional_policies" {
+  count      = "${var.workers_additional_policies_count}"
+  role       = "${aws_iam_role.workers.name}"
+  policy_arn = "${var.workers_additional_policies[count.index]}"
+}
+
 resource "null_resource" "tags_as_list_of_maps" {
   count = "${length(keys(var.tags))}"
 


### PR DESCRIPTION
## Description

Example usage : we want our nodes to be able to update route53 record
for using external-dns.

```hcl
data "template_file" "eks_worker_additional_route53_policy" {
  template = "${file("iam/route53_policy.json.tpl")}"
}

resource "aws_iam_policy" "eks_worker_additional_route53_policy" {
  description = "Allow nodes to update our zone"
  name = "${module.k8s_cluster01_label.id}-additional-route53-policy"
  policy = "${data.template_file.eks_worker_additional_route53_policy.rendered}"
}
```

which defines the policy; then in the EKS module :
```hcl
module "cluster01" {
  cluster_name = "cluster01"
<snip>
  workers_addtional_policies = [
    "${aws_iam_policy.eks_worker_additional_route53_policy.arn}"
  ]
  workers_addtional_policies_count = 1
<snip>
```

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above