### PR TITLE
Add support for eks endpoint_private_access and endpoint_public_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+- Added support for eks public and private endpoints (by @stijndehaes)
 
 ### Changed
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -4,8 +4,10 @@ resource "aws_eks_cluster" "this" {
   version  = "${var.cluster_version}"
 
   vpc_config {
-    security_group_ids = ["${local.cluster_security_group_id}"]
-    subnet_ids         = ["${var.subnets}"]
+    security_group_ids      = ["${local.cluster_security_group_id}"]
+    subnet_ids              = ["${var.subnets}"]
+    endpoint_private_access = "${var.cluster_endpoint_private_access}"
+    endpoint_public_access  = "${var.cluster_endpoint_public_access}"
   }
 
   timeouts {

--- a/variables.tf
+++ b/variables.tf
@@ -241,3 +241,13 @@ variable "iam_path" {
   description = "If provided, all IAM roles will be created on this path."
   default     = "/"
 }
+
+variable "cluster_endpoint_private_access" {
+  description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled."
+  default     = false
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled."
+  default     = true
+}


### PR DESCRIPTION
# PR o'clock

## Description

Added support for the eks private and public endpoints.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
