### PR TITLE
Cni custom networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| asset\_dir | Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.root}/assets`] | string | n/a | yes |
+| asset\_dir | Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.cwd}/assets`] | string | `""` | no |
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
 | cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `""` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.11"` | no |
+| cni\_cidr\_block | Additional IPV4 CIDR block to attach to VPC for CNI Custom Networking. [Example: `100.65.0.0/16`] https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html | string | `""` | no |
 | iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
@@ -146,6 +147,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
 | worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `""` | no |
 | worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
+| workers\_additional\_policies | Additional policies to be added to workers | list | `[]` | no |
+| workers\_additional\_policies\_count |  | string | `"0"` | no |
 | workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
 | workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| asset\_dir | Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.root}/assets`] | string | n/a | yes |
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
 | cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `""` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.11"` | no |
-| config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `"./"` | no |
+| iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
 | kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `[]` | no |
@@ -147,9 +148,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
 | workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
 | workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
-| write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | string | `"true"` | no |
-| write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `"true"` | no |
-| iam\_path | If provided, all IAM roles will be created with path. | string | `"/"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "my-cluster" {
 ## Other documentation
 
 - [Autoscaling](docs/autoscaling.md): How to enabled worker node autoscaling.
+- [CNI Custom Networking](docs/cni_custom_networking.md): Description of CNI Custom Networking.
 
 ## Release schedule
 
@@ -108,68 +109,68 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| asset\_dir | Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.cwd}/assets`] | string | `""` | no |
-| cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
-| cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
-| cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
-| cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
-| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `""` | no |
-| cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.11"` | no |
-| cni\_cidr\_block | Additional IPV4 CIDR block to attach to VPC for CNI Custom Networking. [Example: `100.65.0.0/16`] https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html | string | `""` | no |
-| iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
-| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
-| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
-| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `[]` | no |
-| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `{}` | no |
-| kubeconfig\_name | Override the default name used for items kubeconfig. | string | `""` | no |
-| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list | `[ "/bin/sh", "-c" ]` | no |
-| manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
-| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
-| map\_accounts\_count | The count of accounts in the map_accounts list. | string | `"0"` | no |
-| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
-| map\_roles\_count | The count of roles in the map_roles list. | string | `"0"` | no |
-| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
-| map\_users\_count | The count of roles in the map_users list. | string | `"0"` | no |
-| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `""` | no |
-| subnets | A list of subnets to place the EKS cluster and workers within. | list | n/a | yes |
-| tags | A map of tags to add to all resources. | map | `{}` | no |
-| vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
-| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `[]` | no |
-| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
-| worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | string | `"true"` | no |
-| worker\_group\_count | The number of maps contained within the worker_groups list. | string | `"1"` | no |
-| worker\_group\_launch\_template\_count | The number of maps contained within the worker_groups_launch_template list. | string | `"0"` | no |
-| worker\_group\_launch\_template\_tags | A map defining extra tags to be applied to the worker group template ASG. | map | `{ "default": [] }` | no |
-| worker\_group\_tags | A map defining extra tags to be applied to the worker group ASG. | map | `{ "default": [] }` | no |
-| worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `""` | no |
-| worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
-| workers\_additional\_policies | Additional policies to be added to workers | list | `[]` | no |
-| workers\_additional\_policies\_count |  | string | `"0"` | no |
-| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
-| workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
+| Name                                             | Description                                                                                                                                                                                                              |  Type  |           Default           | Required |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: | :-------------------------: | :------: |
+| asset\_dir                                       | Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.cwd}/assets`]                                                                                                   | string |            `""`             |    no    |
+| cluster\_create\_security\_group                 | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`.                                                                                                                 | string |          `"true"`           |    no    |
+| cluster\_create\_timeout                         | Timeout value when creating the EKS cluster.                                                                                                                                                                             | string |           `"15m"`           |    no    |
+| cluster\_delete\_timeout                         | Timeout value when deleting the EKS cluster.                                                                                                                                                                             | string |           `"15m"`           |    no    |
+| cluster\_name                                    | Name of the EKS cluster. Also used as a prefix in names of related resources.                                                                                                                                            | string |             n/a             |   yes    |
+| cluster\_security\_group\_id                     | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string |            `""`             |    no    |
+| cluster\_version                                 | Kubernetes version to use for the EKS cluster.                                                                                                                                                                           | string |          `"1.11"`           |    no    |
+| cni\_cidr\_block                                 | Additional IPV4 CIDR block to attach to VPC for CNI Custom Networking. [Example: `100.65.0.0/16`] https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html                                               | string |            `""`             |    no    |
+| iam\_path                                        | If provided, all IAM roles will be created on this path.                                                                                                                                                                 | string |            `"/"`            |    no    |
+| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"].                                                                                                              |  list  |            `[]`             |    no    |
+| kubeconfig\_aws\_authenticator\_command          | Command to use to fetch AWS EKS credentials.                                                                                                                                                                             | string |  `"aws-iam-authenticator"`  |    no    |
+| kubeconfig\_aws\_authenticator\_command\_args    | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name].                                                                                                                             |  list  |            `[]`             |    no    |
+| kubeconfig\_aws\_authenticator\_env\_variables   | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}.                                                                                                                 |  map   |            `{}`             |    no    |
+| kubeconfig\_name                                 | Override the default name used for items kubeconfig.                                                                                                                                                                     | string |            `""`             |    no    |
+| local\_exec\_interpreter                         | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice.                                                                                             |  list  |    `[ "/bin/sh", "-c" ]`    |    no    |
+| manage\_aws\_auth                                | Whether to apply the aws-auth configmap file.                                                                                                                                                                            | string |          `"true"`           |    no    |
+| map\_accounts                                    | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format.                                                                                          |  list  |            `[]`             |    no    |
+| map\_accounts\_count                             | The count of accounts in the map_accounts list.                                                                                                                                                                          | string |            `"0"`            |    no    |
+| map\_roles                                       | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format.                                                                                                    |  list  |            `[]`             |    no    |
+| map\_roles\_count                                | The count of roles in the map_roles list.                                                                                                                                                                                | string |            `"0"`            |    no    |
+| map\_users                                       | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format.                                                                                                    |  list  |            `[]`             |    no    |
+| map\_users\_count                                | The count of roles in the map_users list.                                                                                                                                                                                | string |            `"0"`            |    no    |
+| permissions\_boundary                            | If provided, all IAM roles will be created with this permissions boundary attached.                                                                                                                                      | string |            `""`             |    no    |
+| subnets                                          | A list of subnets to place the EKS cluster and workers within.                                                                                                                                                           |  list  |             n/a             |   yes    |
+| tags                                             | A map of tags to add to all resources.                                                                                                                                                                                   |  map   |            `{}`             |    no    |
+| vpc\_id                                          | VPC where the cluster and workers will be deployed.                                                                                                                                                                      | string |             n/a             |   yes    |
+| worker\_additional\_security\_group\_ids         | A list of additional security group ids to attach to worker instances                                                                                                                                                    |  list  |            `[]`             |    no    |
+| worker\_ami\_name\_filter                        | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220"                                             | string |           `"v*"`            |    no    |
+| worker\_create\_security\_group                  | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`.                                                                                                                  | string |          `"true"`           |    no    |
+| worker\_group\_count                             | The number of maps contained within the worker_groups list.                                                                                                                                                              | string |            `"1"`            |    no    |
+| worker\_group\_launch\_template\_count           | The number of maps contained within the worker_groups_launch_template list.                                                                                                                                              | string |            `"0"`            |    no    |
+| worker\_group\_launch\_template\_tags            | A map defining extra tags to be applied to the worker group template ASG.                                                                                                                                                |  map   |     `{ "default": [] }`     |    no    |
+| worker\_group\_tags                              | A map defining extra tags to be applied to the worker group ASG.                                                                                                                                                         |  map   |     `{ "default": [] }`     |    no    |
+| worker\_groups                                   | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys.                                                                            |  list  | `[ { "name": "default" } ]` |    no    |
+| worker\_groups\_launch\_template                 | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys.                                                                                 |  list  | `[ { "name": "default" } ]` |    no    |
+| worker\_security\_group\_id                      | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster.                                              | string |            `""`             |    no    |
+| worker\_sg\_ingress\_from\_port                  | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443).                                   | string |          `"1025"`           |    no    |
+| workers\_additional\_policies                    | Additional policies to be added to workers                                                                                                                                                                               |  list  |            `[]`             |    no    |
+| workers\_additional\_policies\_count             |                                                                                                                                                                                                                          | string |            `"0"`            |    no    |
+| workers\_group\_defaults                         | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys.                                                                                                               |  map   |            `{}`             |    no    |
+| workers\_group\_launch\_template\_defaults       | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys.                                                                                                               |  map   |            `{}`             |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
+| Name                                  | Description                                                                                                                                                     |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
-| cluster\_endpoint | The endpoint for your EKS Kubernetes API. |
-| cluster\_iam\_role\_arn | IAM role ARN of the EKS cluster. |
-| cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
-| cluster\_id | The name/id of the EKS cluster. |
-| cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
-| cluster\_version | The Kubernetes server version for the EKS cluster. |
-| config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
-| kubeconfig | kubectl config file contents for this EKS cluster. |
-| kubeconfig\_filename | The filename of the generated kubectl config. |
-| worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
-| worker\_iam\_role\_name | default IAM role name for EKS worker groups |
-| worker\_security\_group\_id | Security group ID attached to the EKS workers. |
-| workers\_asg\_arns | IDs of the autoscaling groups containing workers. |
-| workers\_asg\_names | Names of the autoscaling groups containing workers. |
+| cluster\_endpoint                     | The endpoint for your EKS Kubernetes API.                                                                                                                       |
+| cluster\_iam\_role\_arn               | IAM role ARN of the EKS cluster.                                                                                                                                |
+| cluster\_iam\_role\_name              | IAM role name of the EKS cluster.                                                                                                                               |
+| cluster\_id                           | The name/id of the EKS cluster.                                                                                                                                 |
+| cluster\_security\_group\_id          | Security group ID attached to the EKS cluster.                                                                                                                  |
+| cluster\_version                      | The Kubernetes server version for the EKS cluster.                                                                                                              |
+| config\_map\_aws\_auth                | A kubernetes configuration to authenticate to this EKS cluster.                                                                                                 |
+| kubeconfig                            | kubectl config file contents for this EKS cluster.                                                                                                              |
+| kubeconfig\_filename                  | The filename of the generated kubectl config.                                                                                                                   |
+| worker\_iam\_role\_arn                | default IAM role ARN for EKS worker groups                                                                                                                      |
+| worker\_iam\_role\_name               | default IAM role name for EKS worker groups                                                                                                                     |
+| worker\_security\_group\_id           | Security group ID attached to the EKS workers.                                                                                                                  |
+| workers\_asg\_arns                    | IDs of the autoscaling groups containing workers.                                                                                                               |
+| workers\_asg\_names                   | Names of the autoscaling groups containing workers.                                                                                                             |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/assets.tf
+++ b/assets.tf
@@ -1,0 +1,4 @@
+resource "local_file" "kubeconfig" {
+  content  = "${data.template_file.kubeconfig.rendered}"
+  filename = "${local.asset_dir}/auth/kubeconfig"
+}

--- a/docs/cni_custom_networking.md
+++ b/docs/cni_custom_networking.md
@@ -1,0 +1,40 @@
+# CNI Custom Networking
+
+[CNI Custom Networking](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html) can be enabled by passing in a CIDR in the `cni_cidr_block` variable.
+
+
+## What it does
+
+Attaches the provided `cni_cidr_block` to the VPC.
+
+Creates one subnet per discovered VPC availability zone. They will be as large as possible (depends on the CIDR block size and how many availability zones are discovered). Example for an Amazon region with 3 AZs and the provided `cni_cidr_block="100.65.0.0/16"`:
+
+- `100.65.0.0/8`
+- `100.65.64.0/18`
+- `100.65.128.0/18`
+
+Creates [ENIConfig](../templates/config-map-eni-config-part.yaml.tpl) resources for each of the discovered Availability Zones in the current Amazon region:
+
+```yaml
+# Definition of ENIConfig for zone: eu-west-1a
+---
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+  name: eu-west-1a
+spec:
+  subnet: subnet-abc123
+  securityGroups:
+  - sg-workersecuritygroup
+---
+# Definition of ENIConfig for zone: eu-west-1b
+# ...
+
+```
+
+[Patches](../templates/patch-vpc_cni_custom_network.yaml) the `aws-node` deployment to use a custom container image and include environment variables to make nodes choose its correct `ENIConfig`:
+
+- `AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG="true"`
+- `ENI_CONFIG_LABEL_DEF="failure-domain.beta.kubernetes.io/zone"`
+
+

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,5 +1,0 @@
-resource "local_file" "kubeconfig" {
-  content  = "${data.template_file.kubeconfig.rendered}"
-  filename = "${var.config_output_path}kubeconfig_${var.cluster_name}"
-  count    = "${var.write_kubeconfig ? 1 : 0}"
-}

--- a/local.tf
+++ b/local.tf
@@ -1,5 +1,5 @@
 locals {
-  asset_dir = "${replace(var.asset_dir, "/[/]$/", "")}" # trim any trailing slash
+  asset_dir = "${var.asset_dir == "" ? "${path.cwd}/assets" : replace(var.asset_dir, "/[/]$/", "")}"
 
   asg_tags = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
 

--- a/local.tf
+++ b/local.tf
@@ -1,4 +1,6 @@
 locals {
+  asset_dir = "${replace(var.asset_dir, "/[/]$/", "")}" # trim any trailing slash
+
   asg_tags = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
 
   # Followed recommendation http://67bricks.com/blog/?p=85

--- a/manifests.tf
+++ b/manifests.tf
@@ -1,0 +1,90 @@
+# https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
+
+resource "local_file" "config_map_eni_config" {
+  count = "${length(var.cni_cidr_block) > 0 ? 1 : 0}"
+
+  content  = "${data.template_file.config_map_eni_config.0.rendered}"
+  filename = "${local.asset_dir}/manifests/config-map-eni-config.yaml"
+}
+
+data "template_file" "patch_aws_node_configmap" {
+  count    = "${length(var.cni_cidr_block) > 0 ? 1 : 0}"
+  template = "${file("${path.module}/templates/patch-vpc_cni_custom_network.yaml")}"
+}
+
+resource "null_resource" "patch_aws_node_configmap" {
+  count = "${length(var.cni_cidr_block) > 0 ? 1 : 0}"
+
+  provisioner "local-exec" {
+    working_dir = "${path.module}"
+
+    command = <<EOS
+set -o errexit; \
+for i in `seq 1 10`;
+do \
+  kubectl patch daemonset \
+    -n kube-system aws-node --kubeconfig ${null_resource.update_config_map_eni_config.0.triggers.kubeconfig_filename} \
+    --patch "$(cat templates/patch-vpc_cni_custom_network.yaml)" && exit 0; \
+  sleep 10; \
+done; \
+exit 1;
+EOS
+  }
+
+  triggers {
+    custom_network_patch_contents = "${data.template_file.patch_aws_node_configmap.0.rendered}"
+  }
+}
+
+resource "null_resource" "update_config_map_eni_config" {
+  count = "${length(var.cni_cidr_block) > 0 ? 1 : 0}"
+
+  provisioner "local-exec" {
+    command = <<EOS
+set -o errexit; \
+for i in `seq 1 10`; do \
+  kubectl apply -f ${null_resource.update_config_map_eni_config.0.triggers.config_map_filename} \
+  --kubeconfig ${null_resource.update_config_map_eni_config.0.triggers.kubeconfig_filename} && exit 0; \
+sleep 10; \
+done; \
+exit 1;
+EOS
+
+    interpreter = ["${var.local_exec_interpreter}"]
+  }
+
+  triggers {
+    kubeconfig_filename = "${local_file.kubeconfig.filename}"
+    config_map_filename = "${local_file.config_map_eni_config.0.filename}"
+    endpoint            = "${aws_eks_cluster.this.endpoint}"
+  }
+}
+
+locals {
+  eni_security_groups = ["${local.worker_security_group_id}"]
+}
+
+data "template_file" "config_map_eni_config_part" {
+  #count = "${length(aws_subnet.kube.*.availability_zone)}"
+  count = "${length(var.cni_cidr_block) > 0 ? length(data.aws_availability_zones.available.names) : 0}"
+
+  template = "${file("${path.module}/templates/config-map-eni-config-part.yaml.tpl")}"
+
+  vars {
+    zone            = "${element(aws_subnet.kube.*.availability_zone, count.index)}"
+    subnet          = "${element(aws_subnet.kube.*.id, count.index)}"
+    security_groups = "${join("\n", formatlist("  - %s", local.eni_security_groups))}"
+  }
+}
+
+data "template_file" "config_map_eni_config" {
+  count = "${length(var.cni_cidr_block) > 0 ? 1 : 0}"
+
+  template = <<EOF
+$${content}
+  EOF
+
+  vars {
+    content = "${join("\n", data.template_file.config_map_eni_config_part.*.rendered)}"
+  }
+}

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,23 @@
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc_ipv4_cidr_block_association" "kube" {
+  vpc_id     = "${var.vpc_id}"
+  cidr_block = "${var.cni_cidr_block}"
+  count      = "${length(var.cni_cidr_block) > 0 ? 1 : 0}"
+}
+
+resource "aws_subnet" "kube" {
+  count = "${length(var.cni_cidr_block) > 0 ? length(data.aws_availability_zones.available.names) : 0}"
+
+  vpc_id            = "${aws_vpc_ipv4_cidr_block_association.kube.0.vpc_id}"
+  availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+  cidr_block        = "${cidrsubnet(aws_vpc_ipv4_cidr_block_association.kube.0.cidr_block, length(data.aws_availability_zones.available.names) - 1, count.index)}"
+
+  tags = "${merge(
+    var.tags,
+    map(
+      "Name", "${var.cluster_name}-${element(data.aws_availability_zones.available.names, count.index)}",
+      "kubernetes.io/cluster/${var.cluster_name}", "shared"
+      )
+  )}"
+}

--- a/templates/config-map-eni-config-part.yaml.tpl
+++ b/templates/config-map-eni-config-part.yaml.tpl
@@ -1,0 +1,10 @@
+# Definition of ENIConfig for zone: ${zone}
+---
+apiVersion: crd.k8s.amazonaws.com/v1alpha1
+kind: ENIConfig
+metadata:
+  name: ${zone}
+spec:
+  subnet: ${subnet}
+  securityGroups:
+${security_groups}

--- a/templates/patch-vpc_cni_custom_network.yaml
+++ b/templates/patch-vpc_cni_custom_network.yaml
@@ -1,0 +1,12 @@
+---
+spec:
+  template:
+    spec:
+      containers:
+      - name: aws-node
+        image: tilmankrauss/amazon-k8s-cni:v1.3.0-91-g1448130d
+        env:
+        - name: AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG
+          value: "true"
+        - name: ENI_CONFIG_LABEL_DEF
+          value: "failure-domain.beta.kubernetes.io/zone"

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,8 @@ variable "cluster_version" {
 }
 
 variable "asset_dir" {
-  description = "Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.root}/assets`]"
+  description = "Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.cwd}/assets`]"
+  default     = ""
 }
 
 variable "manage_aws_auth" {
@@ -60,6 +61,12 @@ variable "map_users_count" {
 variable "subnets" {
   description = "A list of subnets to place the EKS cluster and workers within."
   type        = "list"
+}
+
+variable "cni_cidr_block" {
+  description = "Additional IPV4 CIDR block to attach to VPC for CNI Custom Networking. [Example: `100.65.0.0/16`] https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html"
+  type        = "string"
+  default     = ""
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,23 +12,12 @@ variable "cluster_version" {
   default     = "1.11"
 }
 
-variable "config_output_path" {
-  description = "Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` ."
-  default     = "./"
-}
-
-variable "write_kubeconfig" {
-  description = "Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`."
-  default     = true
+variable "asset_dir" {
+  description = "Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.root}/assets`]"
 }
 
 variable "manage_aws_auth" {
   description = "Whether to apply the aws-auth configmap file."
-  default     = true
-}
-
-variable "write_aws_auth_config" {
-  description = "Whether to write the aws-auth configmap file."
   default     = true
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Favour some simplicity in the kubectl manifest applications. Terraform properly fails its run now unless kubectl explicitly succeeds.
Favour an `asset_dir` parameter over the `config_output_path` which has been explicitly removed. The asset dir will include manifests and the kubeconfig file.

Previously, these were only temporarily written to disk - in the module path. Now it will be properly output in the run, it will be the operators job to decide what to do with the files.

The `write_aws_auth_config` and `write_kubeconfig` parameters have been removed.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)  - Test kitchen fails due to it attempts terraform destroy on non-existing infra. https://github.com/newcontext-oss/kitchen-terraform/issues/271
- [ ] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
