### PR TITLE
Adding minimum communication security group rule for Kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Write your awesome addition here (by @you)
+- Added minimum inbound traffic rule to the cluster worker security group as per the [EKS security group requirements](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) (by @sc250024)
 
 ### Changed
 

--- a/workers.tf
+++ b/workers.tf
@@ -111,7 +111,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster_kubelet" {
   from_port                = 10250
   to_port                  = 10250
   type                     = "ingress"
-  count                    = "${var.worker_create_security_group ? 1 : 0}"
+  count                    = "${var.worker_create_security_group ? (var.worker_sg_ingress_from_port <= 10250 ? 1 : 0) : 0}"
 }
 
 resource "aws_security_group_rule" "workers_ingress_cluster_https" {

--- a/workers.tf
+++ b/workers.tf
@@ -103,6 +103,17 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
   count                    = "${var.worker_create_security_group ? 1 : 0}"
 }
 
+resource "aws_security_group_rule" "workers_ingress_cluster_minimum" {
+  description              = "Allow workers Kubelets and pods to receive minimum communication from the cluster control plane."
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.workers.id}"
+  source_security_group_id = "${local.cluster_security_group_id}"
+  from_port                = 10250
+  to_port                  = 10250
+  type                     = "ingress"
+  count                    = "${var.worker_create_security_group ? 1 : 0}"
+}
+
 resource "aws_security_group_rule" "workers_ingress_cluster_https" {
   description              = "Allow pods running extension API servers on port 443 to receive communication from cluster control plane."
   protocol                 = "tcp"

--- a/workers.tf
+++ b/workers.tf
@@ -111,7 +111,7 @@ resource "aws_security_group_rule" "workers_ingress_cluster_kubelet" {
   from_port                = 10250
   to_port                  = 10250
   type                     = "ingress"
-  count                    = "${var.worker_create_security_group ? (var.worker_sg_ingress_from_port <= 10250 ? 1 : 0) : 0}"
+  count                    = "${var.worker_create_security_group ? (var.worker_sg_ingress_from_port > 10250 ? 1 : 0) : 0}"
 }
 
 resource "aws_security_group_rule" "workers_ingress_cluster_https" {

--- a/workers.tf
+++ b/workers.tf
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "workers_ingress_self" {
 }
 
 resource "aws_security_group_rule" "workers_ingress_cluster" {
-  description              = "Allow workers Kubelets and pods to receive communication from the cluster control plane."
+  description              = "Allow workers pods to receive communication from the cluster control plane."
   protocol                 = "tcp"
   security_group_id        = "${aws_security_group.workers.id}"
   source_security_group_id = "${local.cluster_security_group_id}"
@@ -103,8 +103,8 @@ resource "aws_security_group_rule" "workers_ingress_cluster" {
   count                    = "${var.worker_create_security_group ? 1 : 0}"
 }
 
-resource "aws_security_group_rule" "workers_ingress_cluster_minimum" {
-  description              = "Allow workers Kubelets and pods to receive minimum communication from the cluster control plane."
+resource "aws_security_group_rule" "workers_ingress_cluster_kubelet" {
+  description              = "Allow workers Kubelets to receive communication from the cluster control plane."
   protocol                 = "tcp"
   security_group_id        = "${aws_security_group.workers.id}"
   source_security_group_id = "${local.cluster_security_group_id}"


### PR DESCRIPTION
# PR o'clock

## Description

The docs at https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html specify that port 10250 is needed at a minimum for communication between the control plane, and the worker nodes; this is the port that the `kubelet` exposes. If you specify `worker_sg_ingress_from_port` as something like `30000`, then this minimum communication is not covered by the resource `aws_security_group_rule.workers_ingress_cluster `

I ran into this because I set `worker_sg_ingress_from_port = 30000`, and then deployed Helm onto my new cluster. I found that the communication was broken, and running a simple command like `helm list` resulted in the following error:

```
Error: forwarding ports: error upgrading connection: error dialing backend: dial tcp 10.62.164.50:10250: i/o timeout
```

Adding port 10250 to the worker security group then immediately fixed it. At a minimum, no matter what the person chooses for `worker_sg_ingress_from_port`, this use case should be covered.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [X] Tests for the changes have been added and passing (for bug fixes/features)
- [X] Test results are pasted in this PR (in lieu of CI)
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above
