### PR TITLE
Replacing enable_docker_bridge with a generic option called bootstrap_extra_args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Replaced `enable_docker_bridge` with a generic option called `bootstrap_extra_args` to resolve [310](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/310) (by @max-rocket-internet)
+- (Breaking Change) Replaced `enable_docker_bridge` with a generic option called `bootstrap_extra_args` to resolve [310](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/310) (by @max-rocket-internet)
 
 # History
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added support for eks public and private endpoints (by @stijndehaes)
-- Write your awesome addition here (by @you)
 - Added minimum inbound traffic rule to the cluster worker security group as per the [EKS security group requirements](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) (by @sc250024)
 
 ### Changed
 
-- Write your awesome change here (by @you)
+- Replaced `enable_docker_bridge` with a generic option called `bootstrap_extra_args` to resolve [310](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/310) (by @max-rocket-internet)
 
 # History
 
@@ -33,6 +32,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added output for generated kubeconfig filename (by @syst0m)
 - Added outputs for cluster role ARN and name (by @spingel)
 - Added optional name filter variable to be able to pin worker AMI to a release (by @max-rocket-internet)
+- Added `--enable-docker-bridge` option for bootstrap.sh in AMI (by @michaelmccord)
 
 ## [[v2.2.2](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v2.2.1...v2.2.2)] - 2019-02-25]
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,13 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
 | cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
+| cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `"false"` | no |
+| cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `"true"` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `""` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.11"` | no |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `"./"` | no |
+| iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
 | kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `[]` | no |
@@ -145,11 +148,12 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
 | worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `""` | no |
 | worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
+| workers\_additional\_policies | Additional policies to be added to workers | list | `[]` | no |
+| workers\_additional\_policies\_count |  | string | `"0"` | no |
 | workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
 | workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
 | write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | string | `"true"` | no |
 | write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `"true"` | no |
-| iam\_path | If provided, all IAM roles will be created with path. | string | `"/"` | no |
 
 ## Outputs
 

--- a/data.tf
+++ b/data.tf
@@ -81,7 +81,7 @@ data "template_file" "userdata" {
     cluster_auth_base64  = "${aws_eks_cluster.this.certificate_authority.0.data}"
     pre_userdata         = "${lookup(var.worker_groups[count.index], "pre_userdata", local.workers_group_defaults["pre_userdata"])}"
     additional_userdata  = "${lookup(var.worker_groups[count.index], "additional_userdata", local.workers_group_defaults["additional_userdata"])}"
-    enable_docker_bridge = "${lookup(var.worker_groups[count.index], "enable_docker_bridge", local.workers_group_defaults["enable_docker_bridge"])}"
+    bootstrap_extra_args = "${lookup(var.worker_groups[count.index], "bootstrap_extra_args", local.workers_group_defaults["bootstrap_extra_args"])}"
     kubelet_extra_args   = "${lookup(var.worker_groups[count.index], "kubelet_extra_args", local.workers_group_defaults["kubelet_extra_args"])}"
   }
 }
@@ -96,7 +96,7 @@ data "template_file" "launch_template_userdata" {
     cluster_auth_base64  = "${aws_eks_cluster.this.certificate_authority.0.data}"
     pre_userdata         = "${lookup(var.worker_groups_launch_template[count.index], "pre_userdata", local.workers_group_launch_template_defaults["pre_userdata"])}"
     additional_userdata  = "${lookup(var.worker_groups_launch_template[count.index], "additional_userdata", local.workers_group_launch_template_defaults["additional_userdata"])}"
-    enable_docker_bridge = "${lookup(var.worker_groups_launch_template[count.index], "enable_docker_bridge", local.workers_group_launch_template_defaults["enable_docker_bridge"])}"
+    bootstrap_extra_args = "${lookup(var.worker_groups_launch_template[count.index], "bootstrap_extra_args", local.workers_group_launch_template_defaults["bootstrap_extra_args"])}"
     kubelet_extra_args   = "${lookup(var.worker_groups_launch_template[count.index], "kubelet_extra_args", local.workers_group_launch_template_defaults["kubelet_extra_args"])}"
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -24,7 +24,7 @@ locals {
     root_iops                     = "0"                             # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                              # The key name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                              # userdata to pre-append to the default userdata.
-    enable_docker_bridge          = "false"                         # --enable-docker-bridge bootstrap.sh arg
+    bootstrap_extra_args          = ""                              # Extra arguments passed to the bootstrap.sh script from the EKS AMI.
     additional_userdata           = ""                              # userdata to append to the default userdata.
     ebs_optimized                 = true                            # sets whether to use ebs optimization on supported types.
     enable_monitoring             = true                            # Enables/disables detailed monitoring.
@@ -68,7 +68,7 @@ locals {
     kms_key_id                               = ""                                            # KMS key ID used for encrypted block device. ASG must have access to this key. If not specified, the default KMS key will be used.
     key_name                                 = ""                                            # The key name that should be used for the instances in the autoscaling group
     pre_userdata                             = ""                                            # userdata to pre-append to the default userdata.
-    enable_docker_bridge                     = "false"                                       # --enable-docker-bridge bootstrap.sh arg
+    bootstrap_extra_args                     = ""                                            # Extra arguments passed to the bootstrap.sh script from the EKS AMI.
     additional_userdata                      = ""                                            # userdata to append to the default userdata.
     ebs_optimized                            = true                                          # sets whether to use ebs optimization on supported types.
     enable_monitoring                        = true                                          # Enables/disables detailed monitoring.

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -4,7 +4,7 @@
 ${pre_userdata}
 
 # Bootstrap and join the cluster
-/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' --enable-docker-bridge '${enable_docker_bridge}' --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
+/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' ${bootstrap_extra_args} --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
 
 # Allow user supplied userdata code
 ${additional_userdata}


### PR DESCRIPTION
## Description

Replacing enable_docker_bridge with a generic option called bootstrap_extra_args

Fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/310 https://github.com/terraform-aws-modules/terraform-aws-eks/issues/317

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
