### PR TITLE
Rely properly on the asset_dir, proper abort on kubectl fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,71 +108,69 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
-| cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
-| cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
-| cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `"false"` | no |
-| cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `"true"` | no |
-| cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
-| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `""` | no |
-| cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.11"` | no |
-| config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `"./"` | no |
-| iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
-| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
-| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
-| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `[]` | no |
-| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `{}` | no |
-| kubeconfig\_name | Override the default name used for items kubeconfig. | string | `""` | no |
-| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list | `[ "/bin/sh", "-c" ]` | no |
-| manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
-| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
-| map\_accounts\_count | The count of accounts in the map_accounts list. | string | `"0"` | no |
-| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
-| map\_roles\_count | The count of roles in the map_roles list. | string | `"0"` | no |
-| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format. | list | `[]` | no |
-| map\_users\_count | The count of roles in the map_users list. | string | `"0"` | no |
-| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `""` | no |
-| subnets | A list of subnets to place the EKS cluster and workers within. | list | n/a | yes |
-| tags | A map of tags to add to all resources. | map | `{}` | no |
-| vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
-| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `[]` | no |
-| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
-| worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | string | `"true"` | no |
-| worker\_group\_count | The number of maps contained within the worker_groups list. | string | `"1"` | no |
-| worker\_group\_launch\_template\_count | The number of maps contained within the worker_groups_launch_template list. | string | `"0"` | no |
-| worker\_group\_launch\_template\_tags | A map defining extra tags to be applied to the worker group template ASG. | map | `{ "default": [] }` | no |
-| worker\_group\_tags | A map defining extra tags to be applied to the worker group ASG. | map | `{ "default": [] }` | no |
-| worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `""` | no |
-| worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
-| workers\_additional\_policies | Additional policies to be added to workers | list | `[]` | no |
-| workers\_additional\_policies\_count |  | string | `"0"` | no |
-| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
-| workers\_group\_launch\_template\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
-| write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | string | `"true"` | no |
-| write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `"true"` | no |
+| Name                                             | Description                                                                                                                                                                                                              |  Type  |           Default           | Required |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: | :-------------------------: | :------: |
+| asset\_dir                                       | Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.cwd}/assets`]                                                                                                   | string |            `""`             |    no    |
+| cluster\_create\_security\_group                 | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`.                                                                                                                 | string |          `"true"`           |    no    |
+| cluster\_create\_timeout                         | Timeout value when creating the EKS cluster.                                                                                                                                                                             | string |           `"15m"`           |    no    |
+| cluster\_delete\_timeout                         | Timeout value when deleting the EKS cluster.                                                                                                                                                                             | string |           `"15m"`           |    no    |
+| cluster\_endpoint\_private\_access               | Indicates whether or not the Amazon EKS private API server endpoint is enabled.                                                                                                                                          | string |          `"false"`          |    no    |
+| cluster\_endpoint\_public\_access                | Indicates whether or not the Amazon EKS public API server endpoint is enabled.                                                                                                                                           | string |          `"true"`           |    no    |
+| cluster\_name                                    | Name of the EKS cluster. Also used as a prefix in names of related resources.                                                                                                                                            | string |             n/a             |   yes    |
+| cluster\_security\_group\_id                     | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string |            `""`             |    no    |
+| cluster\_version                                 | Kubernetes version to use for the EKS cluster.                                                                                                                                                                           | string |          `"1.11"`           |    no    |
+| iam\_path                                        | If provided, all IAM roles will be created on this path.                                                                                                                                                                 | string |            `"/"`            |    no    |
+| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"].                                                                                                              |  list  |            `[]`             |    no    |
+| kubeconfig\_aws\_authenticator\_command          | Command to use to fetch AWS EKS credentials.                                                                                                                                                                             | string |  `"aws-iam-authenticator"`  |    no    |
+| kubeconfig\_aws\_authenticator\_command\_args    | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name].                                                                                                                             |  list  |            `[]`             |    no    |
+| kubeconfig\_aws\_authenticator\_env\_variables   | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}.                                                                                                                 |  map   |            `{}`             |    no    |
+| kubeconfig\_name                                 | Override the default name used for items kubeconfig.                                                                                                                                                                     | string |            `""`             |    no    |
+| local\_exec\_interpreter                         | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice.                                                                                             |  list  |    `[ "/bin/sh", "-c" ]`    |    no    |
+| manage\_aws\_auth                                | Whether to apply the aws-auth configmap file.                                                                                                                                                                            | string |          `"true"`           |    no    |
+| map\_accounts                                    | Additional AWS account numbers to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format.                                                                                          |  list  |            `[]`             |    no    |
+| map\_accounts\_count                             | The count of accounts in the map_accounts list.                                                                                                                                                                          | string |            `"0"`            |    no    |
+| map\_roles                                       | Additional IAM roles to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format.                                                                                                    |  list  |            `[]`             |    no    |
+| map\_roles\_count                                | The count of roles in the map_roles list.                                                                                                                                                                                | string |            `"0"`            |    no    |
+| map\_users                                       | Additional IAM users to add to the aws-auth configmap. See examples/eks_test_fixture/variables.tf for example format.                                                                                                    |  list  |            `[]`             |    no    |
+| map\_users\_count                                | The count of roles in the map_users list.                                                                                                                                                                                | string |            `"0"`            |    no    |
+| permissions\_boundary                            | If provided, all IAM roles will be created with this permissions boundary attached.                                                                                                                                      | string |            `""`             |    no    |
+| subnets                                          | A list of subnets to place the EKS cluster and workers within.                                                                                                                                                           |  list  |             n/a             |   yes    |
+| tags                                             | A map of tags to add to all resources.                                                                                                                                                                                   |  map   |            `{}`             |    no    |
+| vpc\_id                                          | VPC where the cluster and workers will be deployed.                                                                                                                                                                      | string |             n/a             |   yes    |
+| worker\_additional\_security\_group\_ids         | A list of additional security group ids to attach to worker instances                                                                                                                                                    |  list  |            `[]`             |    no    |
+| worker\_ami\_name\_filter                        | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220"                                             | string |           `"v*"`            |    no    |
+| worker\_create\_security\_group                  | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`.                                                                                                                  | string |          `"true"`           |    no    |
+| worker\_group\_count                             | The number of maps contained within the worker_groups list.                                                                                                                                                              | string |            `"1"`            |    no    |
+| worker\_group\_launch\_template\_count           | The number of maps contained within the worker_groups_launch_template list.                                                                                                                                              | string |            `"0"`            |    no    |
+| worker\_group\_launch\_template\_tags            | A map defining extra tags to be applied to the worker group template ASG.                                                                                                                                                |  map   |     `{ "default": [] }`     |    no    |
+| worker\_group\_tags                              | A map defining extra tags to be applied to the worker group ASG.                                                                                                                                                         |  map   |     `{ "default": [] }`     |    no    |
+| worker\_groups                                   | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys.                                                                            |  list  | `[ { "name": "default" } ]` |    no    |
+| worker\_groups\_launch\_template                 | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys.                                                                                 |  list  | `[ { "name": "default" } ]` |    no    |
+| worker\_security\_group\_id                      | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster.                                              | string |            `""`             |    no    |
+| worker\_sg\_ingress\_from\_port                  | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443).                                   | string |          `"1025"`           |    no    |
+| workers\_additional\_policies                    | Additional policies to be added to workers                                                                                                                                                                               |  list  |            `[]`             |    no    |
+| workers\_additional\_policies\_count             |                                                                                                                                                                                                                          | string |            `"0"`            |    no    |
+| workers\_group\_defaults                         | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys.                                                                                                               |  map   |            `{}`             |    no    |
+| workers\_group\_launch\_template\_defaults       | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys.                                                                                                               |  map   |            `{}`             |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
+| Name                                  | Description                                                                                                                                                     |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
-| cluster\_endpoint | The endpoint for your EKS Kubernetes API. |
-| cluster\_iam\_role\_arn | IAM role ARN of the EKS cluster. |
-| cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
-| cluster\_id | The name/id of the EKS cluster. |
-| cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
-| cluster\_version | The Kubernetes server version for the EKS cluster. |
-| config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
-| kubeconfig | kubectl config file contents for this EKS cluster. |
-| kubeconfig\_filename | The filename of the generated kubectl config. |
-| worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
-| worker\_iam\_role\_name | default IAM role name for EKS worker groups |
-| worker\_security\_group\_id | Security group ID attached to the EKS workers. |
-| workers\_asg\_arns | IDs of the autoscaling groups containing workers. |
-| workers\_asg\_names | Names of the autoscaling groups containing workers. |
+| cluster\_endpoint                     | The endpoint for your EKS Kubernetes API.                                                                                                                       |
+| cluster\_iam\_role\_arn               | IAM role ARN of the EKS cluster.                                                                                                                                |
+| cluster\_iam\_role\_name              | IAM role name of the EKS cluster.                                                                                                                               |
+| cluster\_id                           | The name/id of the EKS cluster.                                                                                                                                 |
+| cluster\_security\_group\_id          | Security group ID attached to the EKS cluster.                                                                                                                  |
+| cluster\_version                      | The Kubernetes server version for the EKS cluster.                                                                                                              |
+| config\_map\_aws\_auth                | A kubernetes configuration to authenticate to this EKS cluster.                                                                                                 |
+| kubeconfig                            | kubectl config file contents for this EKS cluster.                                                                                                              |
+| kubeconfig\_filename                  | The filename of the generated kubectl config.                                                                                                                   |
+| worker\_iam\_role\_arn                | default IAM role ARN for EKS worker groups                                                                                                                      |
+| worker\_iam\_role\_name               | default IAM role name for EKS worker groups                                                                                                                     |
+| worker\_security\_group\_id           | Security group ID attached to the EKS workers.                                                                                                                  |
+| workers\_asg\_arns                    | IDs of the autoscaling groups containing workers.                                                                                                               |
+| workers\_asg\_names                   | Names of the autoscaling groups containing workers.                                                                                                             |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/assets.tf
+++ b/assets.tf
@@ -1,0 +1,4 @@
+resource "local_file" "kubeconfig" {
+  content  = "${data.template_file.kubeconfig.rendered}"
+  filename = "${local.asset_dir}/auth/kubeconfig"
+}

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,5 +1,0 @@
-resource "local_file" "kubeconfig" {
-  content  = "${data.template_file.kubeconfig.rendered}"
-  filename = "${var.config_output_path}kubeconfig_${var.cluster_name}"
-  count    = "${var.write_kubeconfig ? 1 : 0}"
-}

--- a/local.tf
+++ b/local.tf
@@ -1,4 +1,6 @@
 locals {
+  asset_dir = "${var.asset_dir == "" ? "${path.cwd}/assets" : replace(var.asset_dir, "/[/]$/", "")}"
+
   asg_tags = ["${null_resource.tags_as_list_of_maps.*.triggers}"]
 
   # Followed recommendation http://67bricks.com/blog/?p=85

--- a/variables.tf
+++ b/variables.tf
@@ -12,23 +12,13 @@ variable "cluster_version" {
   default     = "1.11"
 }
 
-variable "config_output_path" {
-  description = "Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` ."
-  default     = "./"
-}
-
-variable "write_kubeconfig" {
-  description = "Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`."
-  default     = true
+variable "asset_dir" {
+  description = "Absolute path to base directory of bootstrap manifests and secrets such as kubeconfig. [Example: `${path.cwd}/assets`]"
+  default     = ""
 }
 
 variable "manage_aws_auth" {
   description = "Whether to apply the aws-auth configmap file."
-  default     = true
-}
-
-variable "write_aws_auth_config" {
-  description = "Whether to write the aws-auth configmap file."
   default     = true
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Implement a more reliable way for kubectl errors to propagate. Reliability is also discussed in #199 

Add *asset_dir* variable where auth and manifests get written. Manifest and config write-outs are no longer optional. Make them "first-class" instead. Operator responsibility to clean up if clean-up is needed.
Since files are written temporarily anyway, I see no clear motivation to keeping them "hidden" other than to avoid admin mistakes (git commit etc).

Variables removed:
- `config_output_path`
- `write_kubeconfig`
- `write_aws_auth_config`

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
