### PR TITLE
adding IAM instance profiles to outputs, addresses #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+- Added outputs for worker IAM instance profile(s) (by @soapergem)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
+| worker\_iam\_instance\_profile\_arns | default IAM instance profile ARNs for EKS worker group |
+| worker\_iam\_instance\_profile\_names | default IAM instance profile names for EKS worker group |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
 | worker\_iam\_role\_name | default IAM role name for EKS worker groups |
 | worker\_security\_group\_id | Security group ID attached to the EKS workers. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,6 +69,16 @@ output "worker_security_group_id" {
   value       = "${local.worker_security_group_id}"
 }
 
+output "worker_iam_instance_profile_arns" {
+  description = "default IAM instance profile ARN for EKS worker groups"
+  value       = "${aws_iam_instance_profile.workers.*.arn}"
+}
+
+output "worker_iam_instance_profile_names" {
+  description = "default IAM instance profile name for EKS worker groups"
+  value       = "${aws_iam_instance_profile.workers.*.name}"
+}
+
 output "worker_iam_role_name" {
   description = "default IAM role name for EKS worker groups"
   value       = "${aws_iam_role.workers.name}"


### PR DESCRIPTION
# PR o'clock

## Description

Adds two outputs for IAM instance profile (role was already present, but not instance profile). See #323 

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [N/A] Tests for the changes have been added and passing (for bug fixes/features)
- [N/A] Test results are pasted in this PR (in lieu of CI)
- [X] I've added my change to CHANGELOG.md
- [N/A] Any breaking changes are highlighted above
