### PR TITLE
Option to install kubectl and aws-iam-authenticator in module path

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -17,7 +17,7 @@ resource "null_resource" "update_config_map_aws_auth" {
 for i in `seq 1 10`; do \
 echo "${null_resource.update_config_map_aws_auth.triggers.kube_config_map_rendered}" > kube_config.yaml & \
 echo "${null_resource.update_config_map_aws_auth.triggers.config_map_rendered}" > aws_auth_configmap.yaml & \
-kubectl apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && break || \
+${local.kubectl_command} apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && break || \
 sleep 10; \
 done; \
 rm aws_auth_configmap.yaml kube_config.yaml;

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -5,7 +5,10 @@ resource "local_file" "config_map_aws_auth" {
 }
 
 resource "null_resource" "update_config_map_aws_auth" {
-  depends_on = ["aws_eks_cluster.this"]
+  depends_on = [
+    "aws_eks_cluster.this",
+    "null_resource.install_kubectl",
+  ]
 
   provisioner "local-exec" {
     working_dir = "${path.module}"

--- a/data.tf
+++ b/data.tf
@@ -50,7 +50,7 @@ data "template_file" "kubeconfig" {
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    aws_authenticator_command         = "${var.install_kubectl ? "${path.module}/${var.kubeconfig_aws_authenticator_command}" : "${var.kubeconfig_aws_authenticator_command}"}"
+    aws_authenticator_command         = "${local.kubeconfig_aws_authenticator_command}"
     aws_authenticator_command_args    = "${length(var.kubeconfig_aws_authenticator_command_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_command_args)}" : "        - ${join("\n        - ", formatlist("\"%s\"", list("token", "-i", aws_eks_cluster.this.name)))}"}"
     aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : ""}"
     aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"

--- a/data.tf
+++ b/data.tf
@@ -50,7 +50,7 @@ data "template_file" "kubeconfig" {
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    aws_authenticator_command         = "${var.install_kubectl ? "abc" : "def"}"
+    aws_authenticator_command         = "${var.install_kubectl ? "${path.module}/${var.kubeconfig_aws_authenticator_command}" : "${var.kubeconfig_aws_authenticator_command}"}"
     aws_authenticator_command_args    = "${length(var.kubeconfig_aws_authenticator_command_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_command_args)}" : "        - ${join("\n        - ", formatlist("\"%s\"", list("token", "-i", aws_eks_cluster.this.name)))}"}"
     aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : ""}"
     aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"

--- a/data.tf
+++ b/data.tf
@@ -50,7 +50,7 @@ data "template_file" "kubeconfig" {
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    aws_authenticator_command         = "${var.install_kubectl == true ? "abc" : "def"}"
+    aws_authenticator_command         = "${var.install_kubectl ? "abc" : "def"}"
     aws_authenticator_command_args    = "${length(var.kubeconfig_aws_authenticator_command_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_command_args)}" : "        - ${join("\n        - ", formatlist("\"%s\"", list("token", "-i", aws_eks_cluster.this.name)))}"}"
     aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : ""}"
     aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"

--- a/data.tf
+++ b/data.tf
@@ -50,7 +50,7 @@ data "template_file" "kubeconfig" {
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    aws_authenticator_command         = "${var.install_kubectl == true ? "${path.module}/${var.kubeconfig_aws_authenticator_command}" : "${var.kubeconfig_aws_authenticator_command}"}"
+    aws_authenticator_command         = "${var.install_kubectl == true ? "abc" : "def"}"
     aws_authenticator_command_args    = "${length(var.kubeconfig_aws_authenticator_command_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_command_args)}" : "        - ${join("\n        - ", formatlist("\"%s\"", list("token", "-i", aws_eks_cluster.this.name)))}"}"
     aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : ""}"
     aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"

--- a/data.tf
+++ b/data.tf
@@ -50,7 +50,7 @@ data "template_file" "kubeconfig" {
     endpoint                          = "${aws_eks_cluster.this.endpoint}"
     region                            = "${data.aws_region.current.name}"
     cluster_auth_base64               = "${aws_eks_cluster.this.certificate_authority.0.data}"
-    aws_authenticator_command         = "${var.kubeconfig_aws_authenticator_command}"
+    aws_authenticator_command         = "${var.install_kubectl == true ? "${path.module}/${var.kubeconfig_aws_authenticator_command}" : "${var.kubeconfig_aws_authenticator_command}"}"
     aws_authenticator_command_args    = "${length(var.kubeconfig_aws_authenticator_command_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_command_args)}" : "        - ${join("\n        - ", formatlist("\"%s\"", list("token", "-i", aws_eks_cluster.this.name)))}"}"
     aws_authenticator_additional_args = "${length(var.kubeconfig_aws_authenticator_additional_args) > 0 ? "        - ${join("\n        - ", var.kubeconfig_aws_authenticator_additional_args)}" : ""}"
     aws_authenticator_env_variables   = "${length(var.kubeconfig_aws_authenticator_env_variables) > 0 ? "      env:\n${join("\n", data.template_file.aws_authenticator_env_variables.*.rendered)}" : ""}"

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,11 +1,7 @@
 resource "null_resource" "install_kubectl" {
   provisioner "local-exec" {
     working_dir = "${path.module}"
-
-    command = <<EOH
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl \
-&& chmod +x kubectl
-EOH
+    command     = "${local.install_kubectl_command}"
   }
 
   triggers {

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,7 +1,8 @@
 resource "null_resource" "install_kubectl" {
   provisioner "local-exec" {
     working_dir = "${path.module}"
-    command     = <<EOH
+
+    command = <<EOH
 curl -LO https://storage.googleapis.com/kubernetes-release/release/v${local.kubectl_versions[var.cluster_version]}/bin/linux/amd64/kubectl && \
 chmod +x ./kubectl && \
 curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator && \

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -14,7 +14,7 @@ EOH
     endpoint                 = "${aws_eks_cluster.this.endpoint}"
   }
 
-  count = "${var.manage_aws_auth ? 1 : 0}"
+  count = "${var.install_kubectl ? 1 : 0}"
 }
 
 resource "local_file" "kubeconfig" {

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,3 +1,22 @@
+resource "null_resource" "install_kubectl" {
+  provisioner "local-exec" {
+    working_dir = "${path.module}"
+
+    command = <<EOH
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl \
+&& chmod +x kubectl
+EOH
+  }
+
+  triggers {
+    kube_config_map_rendered = "${data.template_file.kubeconfig.rendered}"
+    config_map_rendered      = "${data.template_file.config_map_aws_auth.rendered}"
+    endpoint                 = "${aws_eks_cluster.this.endpoint}"
+  }
+
+  count = "${var.manage_aws_auth ? 1 : 0}"
+}
+
 resource "local_file" "kubeconfig" {
   content  = "${data.template_file.kubeconfig.rendered}"
   filename = "${var.config_output_path}kubeconfig_${var.cluster_name}"

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,7 +1,12 @@
 resource "null_resource" "install_kubectl" {
   provisioner "local-exec" {
     working_dir = "${path.module}"
-    command     = "${local.install_kubectl_command}"
+    command     = <<EOH
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v${local.kubectl_versions[var.cluster_version]}/bin/linux/amd64/kubectl && \
+chmod +x ./kubectl && \
+curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator && \
+chmod +x ./aws-iam-authenticator
+EOH
   }
 
   triggers {
@@ -10,7 +15,7 @@ resource "null_resource" "install_kubectl" {
     endpoint                 = "${aws_eks_cluster.this.endpoint}"
   }
 
-  count = "${var.install_kubectl ? 1 : 0}"
+  count = "${var.install_kubectl && var.manage_aws_auth ? 1 : 0}"
 }
 
 resource "local_file" "kubeconfig" {

--- a/local.tf
+++ b/local.tf
@@ -12,7 +12,7 @@ locals {
   kubeconfig_aws_authenticator_command = "${var.install_kubectl ? "${path.module}/aws-iam-authenticator" : "${var.kubeconfig_aws_authenticator_command}"}"
   kubectl_command = "${var.install_kubectl ? "${path.module}/kubectl" : "kubectl"}"
 
-  kubectl_versions = map("1.11", "1.11.8", "1.12", "1.12.6")
+  kubectl_versions = "${map("1.11", "1.11.8", "1.12", "1.12.6")}"
 
   workers_group_defaults_defaults = {
     name                          = "count.index"                   # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.

--- a/local.tf
+++ b/local.tf
@@ -10,7 +10,7 @@ locals {
   kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
   kubeconfig_aws_authenticator_command = "${var.install_kubectl ? "${path.module}/aws-iam-authenticator" : "${var.kubeconfig_aws_authenticator_command}"}"
-  kubectl_command = "${var.install_kubectl ? "${path.module}/kubectl" : "kubectl"}"
+  kubectl_command                      = "${var.install_kubectl ? "${path.module}/kubectl" : "kubectl"}"
 
   kubectl_versions = "${map("1.11", "1.11.8", "1.12", "1.12.6")}"
 

--- a/local.tf
+++ b/local.tf
@@ -16,6 +16,8 @@ locals {
   && sudo chmod +x aws-iam-authenticator
   EOH
 
+  kubectl_command = "${var.install_kubectl ? "${path.module}/kubectl" : "kubectl"}"
+
   workers_group_defaults_defaults = {
     name                          = "count.index"                   # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
     ami_id                        = "${data.aws_ami.eks_worker.id}" # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.

--- a/local.tf
+++ b/local.tf
@@ -9,14 +9,10 @@ locals {
   default_iam_role_id      = "${element(concat(aws_iam_role.workers.*.id, list("")), 0)}"
   kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
-  install_kubectl_command = <<EOH
-  sudo curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl \
-  && sudo chmod +x kubectl
-  sudo curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator \
-  && sudo chmod +x aws-iam-authenticator
-  EOH
-
+  kubeconfig_aws_authenticator_command = "${var.install_kubectl ? "${path.module}/aws-iam-authenticator" : "${var.kubeconfig_aws_authenticator_command}"}"
   kubectl_command = "${var.install_kubectl ? "${path.module}/kubectl" : "kubectl"}"
+
+  kubectl_versions = map("1.11", "1.11.8", "1.12", "1.12.6")
 
   workers_group_defaults_defaults = {
     name                          = "count.index"                   # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.

--- a/local.tf
+++ b/local.tf
@@ -9,6 +9,13 @@ locals {
   default_iam_role_id      = "${element(concat(aws_iam_role.workers.*.id, list("")), 0)}"
   kubeconfig_name          = "${var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name}"
 
+  install_kubectl_command = <<EOH
+  sudo curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl \
+  && sudo chmod +x kubectl
+  sudo curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator \
+  && sudo chmod +x aws-iam-authenticator
+  EOH
+
   workers_group_defaults_defaults = {
     name                          = "count.index"                   # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
     ami_id                        = "${data.aws_ami.eks_worker.id}" # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "manage_aws_auth" {
   default     = true
 }
 
+variable "install_kubectl" {
+  default     = false
+  description = "Installs the kubectl in module-local"
+  type        = "string"
+}
+
 variable "write_aws_auth_config" {
   description = "Whether to write the aws-auth configmap file."
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,6 @@ variable "manage_aws_auth" {
 variable "install_kubectl" {
   default     = false
   description = "Installs the kubectl in module-local"
-  type        = "string"
 }
 
 variable "write_aws_auth_config" {


### PR DESCRIPTION
# PR o'clock

Added a option to install kubectl and aws-iam-authenticator, this will help users running their infrastructure from CI/CD or Terraform enterprise. Helps us to not bother about invoking installation from outside the module.
Variable **install_kubectl** defaults to false. If true installs both of them in module path and uses them to apply configMap

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] I've added my change to CHANGELOG.md
- [ ] Any breaking changes are highlighted above
