### PR TITLE
Adding EKS Control Plane logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+- Added support for cluster logging via the `cluster_enabled_log_types` variable (by @sc250024)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added outputs for worker IAM instance profile(s) (by @soapergem)
 - Added support for cluster logging via the `cluster_enabled_log_types` variable (by @sc250024)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
+| worker\_iam\_instance\_profile\_arns | default IAM instance profile ARNs for EKS worker group |
+| worker\_iam\_instance\_profile\_names | default IAM instance profile names for EKS worker group |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
 | worker\_iam\_role\_name | default IAM role name for EKS worker groups |
 | worker\_security\_group\_id | Security group ID attached to the EKS workers. |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
 | cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
+| cluster\_enabled\_log\_types | The types of CloudWatch logs to enable for the cluster control plane | list | `[]` | no |
 | cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `"false"` | no |
 | cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `"true"` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
 | cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
-| cluster\_enabled\_log\_types | The types of CloudWatch logs to enable for the cluster control plane | list | `[]` | no |
+| cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | list | `[]` | no |
 | cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `"false"` | no |
 | cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `"true"` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_cluster" "this" {
-  enabled_cluster_log_types = "${var.cluster_enabled_log_types}"
   name                      = "${var.cluster_name}"
+  enabled_cluster_log_types = "${var.cluster_enabled_log_types}"
   role_arn                  = "${aws_iam_role.cluster.arn}"
   version                   = "${var.cluster_version}"
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,7 +1,8 @@
 resource "aws_eks_cluster" "this" {
-  name     = "${var.cluster_name}"
-  role_arn = "${aws_iam_role.cluster.arn}"
-  version  = "${var.cluster_version}"
+  enabled_cluster_log_types = "${var.cluster_enabled_log_types}"
+  name                      = "${var.cluster_name}"
+  role_arn                  = "${aws_iam_role.cluster.arn}"
+  version                   = "${var.cluster_version}"
 
   vpc_config {
     security_group_ids      = ["${local.cluster_security_group_id}"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,6 +69,16 @@ output "worker_security_group_id" {
   value       = "${local.worker_security_group_id}"
 }
 
+output "worker_iam_instance_profile_arns" {
+  description = "default IAM instance profile ARN for EKS worker groups"
+  value       = "${aws_iam_instance_profile.workers.*.arn}"
+}
+
+output "worker_iam_instance_profile_names" {
+  description = "default IAM instance profile name for EKS worker groups"
+  value       = "${aws_iam_instance_profile.workers.*.name}"
+}
+
 output "worker_iam_role_name" {
   description = "default IAM role name for EKS worker groups"
   value       = "${aws_iam_role.workers.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "cluster_enabled_log_types" {
+  default     = []
+  description = "(Optional) A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
+  type        = "list"
+}
+
 variable "cluster_name" {
   description = "Name of the EKS cluster. Also used as a prefix in names of related resources."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "cluster_enabled_log_types" {
   default     = []
-  description = "(Optional) A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
+  description = "A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
   type        = "list"
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Adding EKS Control Plane logging options to this module.

This PR https://github.com/terraform-providers/terraform-provider-aws/pull/8216 was merged, allowing for the `enabled_cluster_log_types` option in the `aws_eks_cluster` resource.

**UPDATE: The terraform-aws-provider has relased [v2.6.0](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v2.6.0), so the option `enabled_cluster_log_types` is now available.**

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above
