### PR TITLE
Add instructions on how to enable the docker bridge network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+ - Add instructions on how to enable the docker bridge network (by @rothandrew)
  - Write your awesome change here (by @you)
 
 # History

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module "my-cluster" {
 ## Other documentation
 
 - [Autoscaling](docs/autoscaling.md): How to enabled worker node autoscaling.
+- [Enable Docker Bridge Network](docs/enable-docker-bridge-network.md): How to enable the docker bridge network when using the EKS-optimized AMI, which disables it by default.
 
 ## Release schedule
 

--- a/docs/enable-docker-bridge-network.md
+++ b/docs/enable-docker-bridge-network.md
@@ -1,0 +1,23 @@
+# Enable Docker Bridge Network
+
+The latest versions of the AWS EKS-optimized AMI disable the docker bridge network by default. To enable it, add the `bootstrap_extra_args` parameter to your worker group template.
+
+```hcl
+locals {
+  worker_groups = [
+    {
+      # Other parameters omitted for brevity
+      bootstrap_extra_args = "--enable-docker-bridge true"
+    }
+  ]
+}
+```
+
+Examples of when this would be necessary are:
+
+- You are running Continuous Integration in K8s, and building docker images by either mounting the docker sock as a volume or using docker in docker. Without the bridge enabled, internal routing from the inner container can't reach the outside world.
+
+## See More
+
+- [Docker in Docker no longer works without docker0 bridge](https://github.com/awslabs/amazon-eks-ami/issues/183)
+- [Add enable-docker-bridge bootstrap argument](https://github.com/awslabs/amazon-eks-ami/pull/187)


### PR DESCRIPTION
# PR o'clock

## Description

Add instructions on how to enable the docker bridge network

### Checklist

- [ NA ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ NA ] Tests for the changes have been added and passing (for bug fixes/features)
- [ NA ] Test results are pasted in this PR (in lieu of CI)
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above

Fixes #351 
