### PR TITLE
Enabling up to 10 instance types in Spot Fleet request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
- - Write your awesome change here (by @you)
+ - Enable launch template to specify up to 10 Instance types for Spot Fleet (by @JasonCarter80)
 
 # History
 

--- a/examples/eks_test_fixture/main.tf
+++ b/examples/eks_test_fixture/main.tf
@@ -75,7 +75,7 @@ locals {
       additional_userdata                      = "echo foo bar"
       subnets                                  = "${join(",", module.vpc.private_subnets)}"
       additional_security_group_ids            = "${aws_security_group.worker_group_mgmt_one.id},${aws_security_group.worker_group_mgmt_two.id}"
-      override_instance_type                   = "t3.small"
+      override_instance_type                   = "t3.small,c4.large,t2.medium"
       asg_desired_capacity                     = "2"
       spot_instance_pools                      = 10
       on_demand_percentage_above_base_capacity = "0"

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -29,7 +29,43 @@ resource "aws_autoscaling_group" "workers_launch_template" {
       }
 
       override {
-        instance_type = "${lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"])}"
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 0))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 1))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 2))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 3))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 4))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 5))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 6))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 7))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 8))}"
+      }
+
+      override {
+        instance_type = "${trimspace(element(concat(distinct(split(",", lookup(var.worker_groups_launch_template[count.index], "override_instance_type", local.workers_group_launch_template_defaults["override_instance_type"]))), split("", "          ")), 9))}"
       }
     }
   }


### PR DESCRIPTION
# PR o'clock

## Description
Enabling up to 10 instance types in Spot Fleet request

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [X] I've added my change to CHANGELOG.md
- [X] Any breaking changes are highlighted above
