### PR TITLE
Fixes for Launch Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512) 
+- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512)
 - Write your awesome addition here (by @you)
 
 ### Changed
 
- - Add .prettierignore file (by @rothandrew)
- - Switch to https for the pre-commit repos (by @rothandrew)
- - Add instructions on how to enable the docker bridge network (by @rothandrew)
- - Write your awesome change here (by @you)
+- 4 small changes to `aws_launch_template` resource (by @max-rocket-internet)
+- Add .prettierignore file (by @rothandrew)
+- Switch to https for the pre-commit repos (by @rothandrew)
+- Add instructions on how to enable the docker bridge network (by @rothandrew)
+- Write your awesome change here (by @you)
 
 # History
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512)
+- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512) 
 - Write your awesome addition here (by @you)
 
 ### Changed
 
-- 4 small changes to `aws_launch_template` resource (by @max-rocket-internet)
-- Add .prettierignore file (by @rothandrew)
-- Switch to https for the pre-commit repos (by @rothandrew)
-- Add instructions on how to enable the docker bridge network (by @rothandrew)
-- Write your awesome change here (by @you)
+ - 4 small changes to `aws_launch_template` resource (by @max-rocket-internet)
+ - Add .prettierignore file (by @rothandrew)
+ - Switch to https for the pre-commit repos (by @rothandrew)
+ - Add instructions on how to enable the docker bridge network (by @rothandrew)
+ - Write your awesome change here (by @you)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -171,12 +171,15 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
-| worker\_iam\_instance\_profile\_arns | default IAM instance profile ARNs for EKS worker group |
-| worker\_iam\_instance\_profile\_names | default IAM instance profile names for EKS worker group |
+| worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
+| worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
 | worker\_iam\_role\_name | default IAM role name for EKS worker groups |
 | worker\_security\_group\_id | Security group ID attached to the EKS workers. |
 | workers\_asg\_arns | IDs of the autoscaling groups containing workers. |
 | workers\_asg\_names | Names of the autoscaling groups containing workers. |
+| workers\_launch\_template\_arns | ARNs of the worker launch templates. |
+| workers\_launch\_template\_ids | IDs of the worker launch templates. |
+| workers\_launch\_template\_latest\_versions | Latest versions of the worker launch templates. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/local.tf
+++ b/local.tf
@@ -64,7 +64,7 @@ locals {
     root_volume_size                         = "100"                                         # root volume size of workers instances.
     root_volume_type                         = "gp2"                                         # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops                                = "0"                                           # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
-    root_encrypted                           = false                                         # root volume encryption for workers.
+    root_encrypted                           = ""                                            # root volume encryption for workers.
     kms_key_id                               = ""                                            # KMS key ID used for encrypted block device. ASG must have access to this key. If not specified, the default KMS key will be used.
     key_name                                 = ""                                            # The key name that should be used for the instances in the autoscaling group
     pre_userdata                             = ""                                            # userdata to pre-append to the default userdata.

--- a/outputs.tf
+++ b/outputs.tf
@@ -64,6 +64,21 @@ output "workers_asg_names" {
   value       = "${concat(aws_autoscaling_group.workers.*.id, aws_autoscaling_group.workers_launch_template.*.id)}"
 }
 
+output "workers_launch_template_ids" {
+  description = "IDs of the worker launch templates."
+  value       = "${aws_launch_template.workers_launch_template.*.id}"
+}
+
+output "workers_launch_template_arns" {
+  description = "ARNs of the worker launch templates."
+  value       = "${aws_launch_template.workers_launch_template.*.arn}"
+}
+
+output "workers_launch_template_latest_versions" {
+  description = "Latest versions of the worker launch templates."
+  value       = "${aws_launch_template.workers_launch_template.*.latest_version}"
+}
+
 output "worker_security_group_id" {
   description = "Security group ID attached to the EKS workers."
   value       = "${local.worker_security_group_id}"

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -66,10 +66,15 @@ resource "aws_launch_template" "workers_launch_template" {
   network_interfaces {
     associate_public_ip_address = "${lookup(var.worker_groups_launch_template[count.index], "public_ip", local.workers_group_launch_template_defaults["public_ip"])}"
     delete_on_termination       = "${lookup(var.worker_groups_launch_template[count.index], "eni_delete", local.workers_group_launch_template_defaults["eni_delete"])}"
-    security_groups             = ["${local.worker_security_group_id}", "${var.worker_additional_security_group_ids}", "${compact(split(",",lookup(var.worker_groups_launch_template[count.index],"additional_security_group_ids", local.workers_group_launch_template_defaults["additional_security_group_ids"])))}"]
+
+    security_groups = [
+      "${local.worker_security_group_id}",
+      "${var.worker_additional_security_group_ids}",
+      "${compact(split(",",lookup(var.worker_groups_launch_template[count.index],"additional_security_group_ids", local.workers_group_launch_template_defaults["additional_security_group_ids"])))}",
+    ]
   }
 
-  iam_instance_profile = {
+  iam_instance_profile {
     name = "${element(aws_iam_instance_profile.workers_launch_template.*.name, count.index)}"
   }
 
@@ -106,6 +111,8 @@ resource "aws_launch_template" "workers_launch_template" {
       delete_on_termination = true
     }
   }
+
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_instance_profile" "workers_launch_template" {


### PR DESCRIPTION
# PR o'clock

## Description

Minor fixes related to Launch Templates.

1. Set `root_encrypted` to `""`

    Otherwise I get this error with the default EKS AMI:

    ```
    Launching a new EC2 instance. Status Reason: Could not launch On-Demand Instances. InvalidBlockDeviceMapping - the encrypted flag cannot be specified since device /dev/xvda has a snapshot specified. Launching EC2 instance failed.
    ```

2. Split `aws_launch_template.workers_launch_template.security_groups` across multiple lines

    For readability.

3. Add tags to `aws_launch_template.workers_launch_template`

4. Remove `=` from `iam_instance_profile` parameter. 

    It's not supposed to be there: https://www.terraform.io/docs/providers/aws/r/launch_template.html#example-usage

5. Added outputs for 3 launch template attributes

    - workers_launch_template_ids
    - workers_launch_template_arns
    - workers_launch_template_latest_versions

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
