### PR TITLE
Adding doc about spot instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512) 
+- Added doc about spot instances (by @max-rocket-internet)
+- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512)
 - Write your awesome addition here (by @you)
 
 ### Changed
 
- - Add .prettierignore file (by @rothandrew)
- - Switch to https for the pre-commit repos (by @rothandrew)
- - Add instructions on how to enable the docker bridge network (by @rothandrew)
- - Write your awesome change here (by @you)
+- Add .prettierignore file (by @rothandrew)
+- Switch to https for the pre-commit repos (by @rothandrew)
+- Add instructions on how to enable the docker bridge network (by @rothandrew)
+- Write your awesome change here (by @you)
 
 # History
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Add .prettierignore file (by @rothandrew)
-- Switch to https for the pre-commit repos (by @rothandrew)
-- Add instructions on how to enable the docker bridge network (by @rothandrew)
-- Write your awesome change here (by @you)
+ - Add .prettierignore file (by @rothandrew)
+ - Switch to https for the pre-commit repos (by @rothandrew)
+ - Add instructions on how to enable the docker bridge network (by @rothandrew)
+ - Write your awesome change here (by @you)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ module "my-cluster" {
 
 - [Autoscaling](docs/autoscaling.md): How to enabled worker node autoscaling.
 - [Enable Docker Bridge Network](docs/enable-docker-bridge-network.md): How to enable the docker bridge network when using the EKS-optimized AMI, which disables it by default.
+- [Spot instances](docs/spot-instances.md): How to use spot instances with this module.
 
 ## Release schedule
 

--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -1,0 +1,100 @@
+# Using spot instances
+
+Spot instances usually cost around 30-60% less than an on-demand instance. So using them for your EKS workloads can save a lot of money but requires some special considerations as they will be terminated with only 2 minutes warning.
+
+You need to install a daemonset to catch the 2 minute warning before termination. This will ensure the node is gracefully drained before termination. You can install the [k8s-spot-termination-handler](https://github.com/kube-aws/kube-spot-termination-notice-handler) for this. There's a [Helm chart](https://github.com/helm/charts/tree/master/stable/k8s-spot-termination-handler):
+
+```
+helm install stable/k8s-spot-termination-handler --namespace kube-system
+```
+
+In the following examples at least 1 worker group that uses on-demand instances is included. This worker group has an added node label that can be used in scheduling. This could be used for any workload but is important for the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) as it might be end up unscheduled when spot instances are terminated. You can add this to the values of the [cluster-autoscaler helm chart](https://github.com/helm/charts/tree/master/stable/cluster-autoscaler):
+
+```yaml
+nodeSelector:
+  spot: "false"
+extraArgs:
+  expander: "most-pods"
+```
+
+Notes:
+
+- The `spot_price` is set to the on-demand price so that the spot instances will run as long as they are the cheaper.
+- It's best to have a broad range of instance types to ensure there's always some instances to run when prices fluctuate.
+- If the instance size of the spot worker groups is larger then the cluster-autoscaler will prefer it due to its [expander](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) being set to `most-pods`
+- Using an [AWS Spot Fleet](https://www.terraform.io/docs/providers/aws/r/spot_fleet_request.html) is the best option but is not supported by this module.
+
+## Using Launch Configuration
+
+Example Terraform worker group configuration that use an ASG with launch configuration:
+
+```hcl
+worker_group_count = 3
+
+worker_groups = [
+  {
+    name                = "on-demand-1"
+    instance_type       = "m4.xlarge"
+    asg_max_size        = 10
+    autoscaling_enabled = true
+    kubelet_extra_args  = "--node-labels=spot=false"
+    suspended_processes = "AZRebalance"
+  },
+  {
+    name                = "spot-1"
+    spot_price          = "0.39"
+    instance_type       = "c4.2xlarge"
+    asg_max_size        = 20
+    autoscaling_enabled = true
+    kubelet_extra_args  = "--node-labels=spot=true"
+    suspended_processes = "AZRebalance"
+  },
+  {
+    name                = "spot-2"
+    spot_price          = "0.40"
+    instance_type       = "m4.2xlarge"
+    asg_max_size        = 20
+    autoscaling_enabled = true
+    kubelet_extra_args  = "--node-labels=spot=true"
+    suspended_processes = "AZRebalance"
+  }
+]
+```
+
+## Using Launch Templates
+
+Launch Template support is a recent addition to both AWS and this module. It might not be as tried and tested.
+
+Example Terraform worker group configuration that use an ASG with a launch template:
+
+```hcl
+
+worker_group_count = 1
+
+worker_groups = [
+  {
+    name                = "on-demand-1"
+    instance_type       = "m4.xlarge"
+    asg_max_size        = 10
+    autoscaling_enabled = true
+    kubelet_extra_args  = "--node-labels=spot=false"
+    suspended_processes = "AZRebalance"
+  }
+]
+
+worker_group_launch_template_count = 1
+
+worker_groups_launch_template = [
+  {
+    name                = "lt-1"
+    instance_type       = "m5.large"
+    kubelet_extra_args  = "--node-labels=spot=true"
+  }
+]
+```
+
+## Important issues
+
+- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/360
+- https://github.com/terraform-providers/terraform-provider-aws/issues/8475
+- https://github.com/kubernetes/autoscaler/issues/1133

--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -1,6 +1,6 @@
 # Using spot instances
 
-Spot instances usually cost around 30-60% less than an on-demand instance. So using them for your EKS workloads can save a lot of money but requires some special considerations as they will be terminated with only 2 minutes warning.
+Spot instances usually cost around 30-70% less than an on-demand instance. So using them for your EKS workloads can save a lot of money but requires some special considerations as they will be terminated with only 2 minutes warning.
 
 You need to install a daemonset to catch the 2 minute warning before termination. This will ensure the node is gracefully drained before termination. You can install the [k8s-spot-termination-handler](https://github.com/kube-aws/kube-spot-termination-notice-handler) for this. There's a [Helm chart](https://github.com/helm/charts/tree/master/stable/k8s-spot-termination-handler):
 
@@ -8,21 +8,20 @@ You need to install a daemonset to catch the 2 minute warning before termination
 helm install stable/k8s-spot-termination-handler --namespace kube-system
 ```
 
-In the following examples at least 1 worker group that uses on-demand instances is included. This worker group has an added node label that can be used in scheduling. This could be used for any workload but is important for the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) as it might be end up unscheduled when spot instances are terminated. You can add this to the values of the [cluster-autoscaler helm chart](https://github.com/helm/charts/tree/master/stable/cluster-autoscaler):
+In the following examples at least 1 worker group that uses on-demand instances is included. This worker group has an added node label that can be used in scheduling. This could be used to schedule any workload but is important for the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) as it might be end up unscheduled when spot instances are terminated. You can add this to the values of the [cluster-autoscaler helm chart](https://github.com/helm/charts/tree/master/stable/cluster-autoscaler):
 
 ```yaml
 nodeSelector:
   spot: "false"
-extraArgs:
-  expander: "most-pods"
 ```
 
 Notes:
 
 - The `spot_price` is set to the on-demand price so that the spot instances will run as long as they are the cheaper.
 - It's best to have a broad range of instance types to ensure there's always some instances to run when prices fluctuate.
-- If the instance size of the spot worker groups is larger then the cluster-autoscaler will prefer it due to its [expander](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) being set to `most-pods`
-- Using an [AWS Spot Fleet](https://www.terraform.io/docs/providers/aws/r/spot_fleet_request.html) is the best option but is not supported by this module.
+- Using an [AWS Spot Fleet](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-requests.html) is the best option but is not supported by this module yet.
+- There is an AWS blog article about this [here](https://aws.amazon.com/blogs/compute/run-your-kubernetes-workloads-on-amazon-ec2-spot-instances-with-amazon-eks/).
+- Consider using [k8s-spot-rescheduler](https://github.com/pusher/k8s-spot-rescheduler) to move pods from on-demand to spot instances.
 
 ## Using Launch Configuration
 
@@ -35,7 +34,7 @@ worker_groups = [
   {
     name                = "on-demand-1"
     instance_type       = "m4.xlarge"
-    asg_max_size        = 10
+    asg_max_size        = 1
     autoscaling_enabled = true
     kubelet_extra_args  = "--node-labels=spot=false"
     suspended_processes = "AZRebalance"

--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -86,9 +86,15 @@ worker_group_launch_template_count = 1
 
 worker_groups_launch_template = [
   {
-    name                = "lt-1"
-    instance_type       = "m5.large"
-    kubelet_extra_args  = "--node-labels=spot=true"
+    name                                     = "spot-1"
+    instance_type                            = "m5.xlarge"
+    override_instance_type                   = "m4.xlarge"
+    spot_instance_pools                      = 2
+    on_demand_percentage_above_base_capacity = 0
+    spot_max_price                           = "0.384"
+    asg_max_size                             = 10
+    autoscaling_enabled                      = true
+    kubelet_extra_args                       = "--node-labels=spot=true"
   }
 ]
 ```


### PR DESCRIPTION
# PR o'clock

Adding some detailed documentation about using this module to run EKS workloads on spot instances. Spot instances can save a lot of money but there's quite a few details that are required.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [x] I've added my change to CHANGELOG.md
- [x] Any breaking changes are highlighted above
