### PR TITLE
adding cluster arn to outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512) 
+- Added support for custom service linked role for Auto Scaling group (by @voanhduy1512)
+- Add cluster arn to outputs (by @alexsn)
 - Write your awesome addition here (by @you)
 
 ### Changed

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,11 +3,10 @@ output "cluster_id" {
   value       = "${aws_eks_cluster.this.id}"
 }
 
-# Though documented, not yet supported
-# output "cluster_arn" {
-#   description = "The Amazon Resource Name (ARN) of the cluster."
-#   value       = "${aws_eks_cluster.this.arn}"
-# }
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster."
+  value       = "${aws_eks_cluster.this.arn}"
+}
 
 output "cluster_certificate_authority_data" {
   description = "Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster."


### PR DESCRIPTION
# PR o'clock

## Description

Add cluster arn to outputs

### Checklist

- [x ] `terraform fmt` and `terraform validate` both work from the root and `examples/eks_test_fixture` directories (look in CI for an example)
- [x ] Tests for the changes have been added and passing (for bug fixes/features)
- [x ] Test results are pasted in this PR (in lieu of CI)
- [x ] I've added my change to CHANGELOG.md
- [x ] Any breaking changes are highlighted above
