### PR TITLE
Fix typos in spot instances document

### DIFF
--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -79,7 +79,7 @@ Launch Template support is a recent addition to both AWS and this module. It mig
 
   worker_group_launch_template_mixed_count = 1
 
-  worker_group_launch_template_mixed = [
+  worker_groups_launch_template_mixed = [
     {
       name                     = "spot-1"
       override_instance_type_1 = "m5.large"


### PR DESCRIPTION
# PR o'clock

## Description
Fix typos in spot instances document in example of section `Using Launch Templates`

`worker_group_launch_template_mixed` should be `worker_groups_launch_template_mixed` (group -> groups)

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
