### PR TITLE
Fix IAM instance profile toggle for mixed launch templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Write your awesome change here (by @you)
+- Fix toggle for IAM instance profile creation for mixed launch templates (by @jnozo)
 
 # History
 

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -115,7 +115,7 @@ resource "aws_launch_template" "workers_launch_template_mixed" {
 }
 
 resource "aws_iam_instance_profile" "workers_launch_template_mixed" {
-  count       = "${var.worker_group_launch_template_mixed_count}"
+  count       = "${var.manage_worker_iam_resources ? var.worker_group_launch_template_mixed_count : 0}"
   name_prefix = "${aws_eks_cluster.this.name}"
   role        = "${lookup(var.worker_groups_launch_template_mixed[count.index], "iam_role_id",  lookup(local.workers_group_defaults, "iam_role_id"))}"
   path        = "${var.iam_path}"


### PR DESCRIPTION
# PR o'clock

## Description

Seems like the variable `manage_worker_iam_resources` to toggle the worker instance profile creation was not added to the mixed worker launch template. Without this change, I can't use that launch template in environments where AWS IAM changes are restricted.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
