### PR TITLE
chore: fix README.md worker_groups tags syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ module "my-cluster" {
     {
       instance_type = "m4.large"
       asg_max_size  = 5
-      tags = {
+      tags = [{
         key                 = "foo"
         value               = "bar"
         propagate_at_launch = true
-      }
+      }]
     }
   ]
 


### PR DESCRIPTION
# PR o'clock

## Description

Currently the example usage is an object, where in `local.tf` the default is defined as a list (https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/local.tf#L35), and `workers.tf` is using a list of objects (https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/workers.tf#L68).

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
