### PR TITLE
added market options to request spot instances without pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
  - Option to set a KMS key for the log group and encrypt it (by @till-krauss)
  - Output the name of the cloudwatch log group (by @gbooth27)
+ - Option to use spot instances with launch templates without defining pools, especially useful for GPU instance types (@onur-sam-gtn-ai)
  - Write your awesome addition here (by @you)
 
 ### Changed

--- a/local.tf
+++ b/local.tf
@@ -80,6 +80,7 @@ locals {
     spot_allocation_strategy                 = "lowest-price"                                   # The only valid value is lowest-price, which is also the default value. The Auto Scaling group selects the cheapest Spot pools and evenly allocates your Spot capacity across the number of Spot pools that you specify.
     spot_instance_pools                      = 10                                               # "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify."
     spot_max_price                           = ""                                               # Maximum price per unit hour that the user is willing to pay for the Spot instances. Default is the on-demand price
+    use_spot_instances                       = false                                            # set to true to use spot instances with a LAUNCH TEMPLATE
   }
 
   workers_group_defaults = merge(

--- a/local.tf
+++ b/local.tf
@@ -80,7 +80,7 @@ locals {
     spot_allocation_strategy                 = "lowest-price"                                       # The only valid value is lowest-price, which is also the default value. The Auto Scaling group selects the cheapest Spot pools and evenly allocates your Spot capacity across the number of Spot pools that you specify.
     spot_instance_pools                      = 10                                                   # "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify."
     spot_max_price                           = ""                                                   # Maximum price per unit hour that the user is willing to pay for the Spot instances. Default is the on-demand price
-    market_type                              = null                                             # set to "spot" to use spot instances without defining pools
+    market_type                              = null                                                 # set to "spot" to use spot instances without defining pools
   }
 
   workers_group_defaults = merge(

--- a/local.tf
+++ b/local.tf
@@ -80,7 +80,7 @@ locals {
     spot_allocation_strategy                 = "lowest-price"                                   # The only valid value is lowest-price, which is also the default value. The Auto Scaling group selects the cheapest Spot pools and evenly allocates your Spot capacity across the number of Spot pools that you specify.
     spot_instance_pools                      = 10                                               # "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify."
     spot_max_price                           = ""                                               # Maximum price per unit hour that the user is willing to pay for the Spot instances. Default is the on-demand price
-    use_spot_instances                       = false                                            # set to true to use spot instances with a LAUNCH TEMPLATE
+    market_type                              = null                                             # set to "spot" to use spot instances without defining pools
   }
 
   workers_group_defaults = merge(

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -222,10 +222,10 @@ resource "aws_launch_template" "workers_launch_template" {
   }
 
   instance_market_options {
-    market_type =   lookup(
-        var.worker_groups_launch_template[count.index],
-        "use_spot_instances",
-        local.workers_group_defaults["use_spot_instances"]) ? "spot" : null
+    market_type = lookup(
+      var.worker_groups_launch_template[count.index],
+      "use_spot_instances",
+    local.workers_group_defaults["use_spot_instances"]) ? "spot" : null
   }
 
   block_device_mappings {

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -224,8 +224,9 @@ resource "aws_launch_template" "workers_launch_template" {
   instance_market_options {
     market_type = lookup(
       var.worker_groups_launch_template[count.index],
-      "use_spot_instances",
-    local.workers_group_defaults["use_spot_instances"]) ? "spot" : null
+      "market_type",
+      local.workers_group_defaults["market_type"],
+    )
   }
 
   block_device_mappings {

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -221,6 +221,13 @@ resource "aws_launch_template" "workers_launch_template" {
     )
   }
 
+  instance_market_options {
+    market_type =   lookup(
+        var.worker_groups_launch_template[count.index],
+        "use_spot_instances",
+        local.workers_group_defaults["use_spot_instances"]) ? "spot" : null
+  }
+
   block_device_mappings {
     device_name = lookup(
       var.worker_groups_launch_template[count.index],


### PR DESCRIPTION
# PR o'clock

## Description
Correct me if I'm wrong: Currently, the only way to request spot instances in a launch template is by specifying pools. The change here may be not ideal, but it seems to have worked for me. 
Going by this:
https://www.terraform.io/docs/providers/aws/r/launch_template.html#market-options

It should be possible to implement this, maybe not ideally with this PR but with a similar approach. This is more a feature request than a full PR.

Reference: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotMarketOptions.html