### PR TITLE
add cloudwatch log group access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
  - Option to set a KMS key for the log group and encrypt it (by @till-krauss)
+ - Output the name of the cloudwatch log group (by @gbooth27)
  - Write your awesome addition here (by @you)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_id | The name/id of the EKS cluster. |
 | cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
 | cluster\_version | The Kubernetes server version for the EKS cluster. |
+| cloudwatch\_log\_group\_name | The name of the cloudwatch log group created for the EKS cluster. |
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,7 +45,7 @@ output "cluster_iam_role_arn" {
 
 output "cloudwatch_log_group_name" {
   description = "Name of cloudwatch log group created"
-  value       = aws_cloudwatch_log_group.this.name
+  value       = aws_cloudwatch_log_group.this.*.name
 }
 
 output "kubeconfig" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,7 +43,7 @@ output "cluster_iam_role_arn" {
   value       = local.cluster_iam_role_arn
 }
 
-output "cloudwatch_log_group_name"{
+output "cloudwatch_log_group_name" {
   description = "Name of cloudwatch log group created"
   value       = aws_cloudwatch_log_group.this.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,7 +44,7 @@ output "cluster_iam_role_arn" {
 }
 
 output "cloudwatch_log_group_name"{
-  description = ""
+  description = "Name of cloudwatch log group created"
   value       = aws_cloudwatch_log_group.this.name
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,6 +43,11 @@ output "cluster_iam_role_arn" {
   value       = local.cluster_iam_role_arn
 }
 
+output "cloudwatch_log_group_name"{
+  description = ""
+  value       = aws_cloudwatch_log_group.this.name
+}
+
 output "kubeconfig" {
   description = "kubectl config file contents for this EKS cluster."
   value       = data.template_file.kubeconfig.rendered


### PR DESCRIPTION
# PR o'clock

## Description

Adds the name of the created Cloudwatch log group to the outputs of the module

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
