### PR TITLE
Update default override instance types to work with Cluster Autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+ - Update default override instance types to work with Cluster Autoscaler (by @nauxliu on behalf of RightCapital)
  - Write your awesome change here (by @you)
 
 # History

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -27,3 +27,7 @@ To install the chart, simply run helm with the `--values` option:
 ```
 helm install stable/cluster-autoscaler --values=path/to/your/values-file.yaml
 ```
+
+## See More
+
+[Using AutoScalingGroup MixedInstancesPolicy](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-autoscalinggroup-mixedinstancespolicy)

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -58,7 +58,7 @@ module "eks" {
   worker_groups_launch_template_mixed = [
     {
       name                    = "spot-1"
-      override_instance_types = ["m5.large", "c5.large", "t3.large", "r5.large"]
+      override_instance_types = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"]
       spot_instance_pools     = 4
       asg_max_size            = 5
       asg_desired_capacity    = 5

--- a/local.tf
+++ b/local.tf
@@ -73,13 +73,13 @@ locals {
     root_encrypted                    = ""                                       # Whether the volume should be encrypted or not
     eni_delete                        = true                                     # Delete the ENI on termination (if set to false you will have to manually delete before destroying)
     # Settings for launch templates with mixed instances policy
-    override_instance_types                  = ["m5.large", "c5.large", "t3.large", "r5.large"] # A list of override instance types for mixed instances policy
-    on_demand_allocation_strategy            = "prioritized"                                    # Strategy to use when launching on-demand instances. Valid values: prioritized.
-    on_demand_base_capacity                  = "0"                                              # Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances
-    on_demand_percentage_above_base_capacity = "0"                                              # Percentage split between on-demand and Spot instances above the base on-demand capacity
-    spot_allocation_strategy                 = "lowest-price"                                   # The only valid value is lowest-price, which is also the default value. The Auto Scaling group selects the cheapest Spot pools and evenly allocates your Spot capacity across the number of Spot pools that you specify.
-    spot_instance_pools                      = 10                                               # "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify."
-    spot_max_price                           = ""                                               # Maximum price per unit hour that the user is willing to pay for the Spot instances. Default is the on-demand price
+    override_instance_types                  = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"] # A list of override instance types for mixed instances policy
+    on_demand_allocation_strategy            = "prioritized"                                        # Strategy to use when launching on-demand instances. Valid values: prioritized.
+    on_demand_base_capacity                  = "0"                                                  # Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances
+    on_demand_percentage_above_base_capacity = "0"                                                  # Percentage split between on-demand and Spot instances above the base on-demand capacity
+    spot_allocation_strategy                 = "lowest-price"                                       # The only valid value is lowest-price, which is also the default value. The Auto Scaling group selects the cheapest Spot pools and evenly allocates your Spot capacity across the number of Spot pools that you specify.
+    spot_instance_pools                      = 10                                                   # "Number of Spot pools per availability zone to allocate capacity. EC2 Auto Scaling selects the cheapest Spot pools and evenly allocates Spot capacity across the number of Spot pools that you specify."
+    spot_max_price                           = ""                                                   # Maximum price per unit hour that the user is willing to pay for the Spot instances. Default is the on-demand price
   }
 
   workers_group_defaults = merge(


### PR DESCRIPTION
# PR o'clock

## Description

According to the CA's [document](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/aws/README.md#using-autoscalinggroup-mixedinstancespolicy),  that the instance types should have the same amount of RAM and number of CPU cores, since this is fundamental to CA's scaling calculations. Using mismatched instances types can produce unintended results.

I and #422 was bitten by this

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
