### PR TITLE
Configure 'cpu_credits' for workers (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
  - Option to set a KMS key for the log group and encrypt it (by @till-krauss)
  - Output the name of the cloudwatch log group (by @gbooth27)
+ - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` (by @a-shink)
  - Write your awesome addition here (by @you)
 
 ### Changed

--- a/local.tf
+++ b/local.tf
@@ -49,7 +49,6 @@ locals {
     bootstrap_extra_args          = ""                         # Extra arguments passed to the bootstrap.sh script from the EKS AMI.
     additional_userdata           = ""                         # userdata to append to the default userdata.
     ebs_optimized                 = true                       # sets whether to use ebs optimization on supported types.
-    cpu_credits                   = "standard"                 # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     enable_monitoring             = true                       # Enables/disables detailed monitoring.
     public_ip                     = false                      # Associate a public ip address with a worker
     kubelet_extra_args            = ""                         # This string is passed directly to kubelet if set. Useful for adding labels or taints.
@@ -73,6 +72,7 @@ locals {
     launch_template_placement_group   = ""                                       # The name of the placement group into which to launch the instances, if any.
     root_encrypted                    = ""                                       # Whether the volume should be encrypted or not
     eni_delete                        = true                                     # Delete the ENI on termination (if set to false you will have to manually delete before destroying)
+    cpu_credits                       = "standard"                               # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     # Settings for launch templates with mixed instances policy
     override_instance_types                  = ["m5.large", "c5.large", "t3.large", "r5.large"] # A list of override instance types for mixed instances policy
     on_demand_allocation_strategy            = "prioritized"                                    # Strategy to use when launching on-demand instances. Valid values: prioritized.

--- a/local.tf
+++ b/local.tf
@@ -49,6 +49,7 @@ locals {
     bootstrap_extra_args          = ""                         # Extra arguments passed to the bootstrap.sh script from the EKS AMI.
     additional_userdata           = ""                         # userdata to append to the default userdata.
     ebs_optimized                 = true                       # sets whether to use ebs optimization on supported types.
+    cpu_credits                   = "standard"                 # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     enable_monitoring             = true                       # Enables/disables detailed monitoring.
     public_ip                     = false                      # Associate a public ip address with a worker
     kubelet_extra_args            = ""                         # This string is passed directly to kubelet if set. Useful for adding labels or taints.

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -200,6 +200,14 @@ resource "aws_launch_template" "workers_launch_template" {
     ),
   )
 
+  credit_specification {
+    cpu_credits = lookup(
+      var.worker_groups_launch_template[count.index],
+      "cpu_credits",
+      local.workers_group_defaults["cpu_credits"]
+    )
+  }
+
   monitoring {
     enabled = lookup(
       var.worker_groups_launch_template[count.index],

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -250,6 +250,14 @@ resource "aws_launch_template" "workers_launch_template_mixed" {
     ),
   )
 
+  credit_specification {
+    cpu_credits = lookup(
+      var.worker_groups_launch_template_mixed[count.index],
+      "cpu_credits",
+      local.workers_group_defaults["cpu_credits"]
+    )
+  }
+
   monitoring {
     enabled = lookup(
       var.worker_groups_launch_template_mixed[count.index],


### PR DESCRIPTION
# PR o'clock

## Description

This PR makes configurable 'T2/T3 unlimited' param for workers.
Used 'standard' mode as default to avoid unexpected paying higher costs.
This parameter can be configured for Launch Templates only, don't work for Launch Configuration even via AWS API.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [X] CI tests are passing
- [X] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
