### PR TITLE
VPC: `enable_dns_hostnames = true` in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
  - Update default override instance types to work with Cluster Autoscaler (by @nauxliu on behalf of RightCapital)
+ - Examples now specify `enable_dns_hostnames = true`, as per [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) (by @karolinepauls)
  - Write your awesome change here (by @you)
 
 # History

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read the [AWS docs on EKS to get connected to the k8s dashboard](https://docs.aw
 
 * You want to create an EKS cluster and an autoscaling group of workers for the cluster.
 * You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
-* You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources.
+* You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources. The VPC satisfies [EKS requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html).
 * If `manage_aws_auth = true`, it's required that both [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) (>=1.10) and [`aws-iam-authenticator`](https://github.com/kubernetes-sigs/aws-iam-authenticator#4-set-up-kubectl-to-use-authentication-tokens-provided-by-aws-iam-authenticator-for-kubernetes) are installed and on your shell's PATH.
 
 ## Usage example
@@ -141,7 +141,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `""` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list(string) | n/a | yes |
 | tags | A map of tags to add to all resources. | map(string) | `{}` | no |
-| vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
+| vpc\_id | VPC where the cluster and workers will be deployed. It must satisfy [EKS requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html). | string | n/a | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
 | worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | bool | `"true"` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -86,13 +86,14 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.6.0"
 
-  name               = "test-vpc"
-  cidr               = "10.0.0.0/16"
-  azs                = data.aws_availability_zones.available.names
-  private_subnets    = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  name                 = "test-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
 
   tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -39,10 +39,11 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.6.0"
 
-  name           = "test-vpc-lt"
-  cidr           = "10.0.0.0/16"
-  azs            = data.aws_availability_zones.available.names
-  public_subnets = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  name                 = "test-vpc-lt"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_dns_hostnames = true
 
   tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -39,10 +39,11 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.6.0"
 
-  name           = "test-vpc-spot"
-  cidr           = "10.0.0.0/16"
-  azs            = data.aws_availability_zones.available.names
-  public_subnets = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  name                 = "test-vpc-spot"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_dns_hostnames = true
 
   tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"


### PR DESCRIPTION
# PR o'clock

## Description

AWS docs state:

> Your VPC must have DNS hostname and DNS resolution support. Otherwise, your worker nodes cannot register with your cluster. For more information, see Using DNS with Your VPC in the Amazon VPC User Guide. 

- https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html

From that it seems like it should always be enabled, no matter what kind of VPC is used. I added it to the basic example which I used and had error messages with DNS resolution appearing in the logs on the nodes. Interestingly enough, without DNS resolution the cluster appears to sometimes work and sometimes not. It's hard to run experiments though, so as per the docs, it should be enabled.

Question: do we want to play it safe and enable DNS resolution in all examples (even public VPC)?

### Checklist

- [v] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [v] I've added my change to CHANGELOG.md and highlighted any breaking changes
