### PR TITLE
Adding tags for Log groups and workers IAM role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
  - Option to set a KMS key for the log group and encrypt it (by @till-krauss)
  - Output the name of the cloudwatch log group (by @gbooth27)
- - Option to use spot instances with launch templates without defining pools, especially useful for GPU instance types (@onur-sam-gtn-ai)
  - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` (by @a-shink)
  - Added support for EBS Volumes tag in `worker_groups_launch_template` and `workers_launch_template_mixed.tf` (by @sppwf)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+ - Added support for log group tag in `./cluster.tf` (@lucas-giaco)
+ - Added support for workers iam role tag in `./workers.tf` (@lucas-giaco)
  - Write your awesome addition here (by @you)
 
 ### Changed
@@ -25,6 +27,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
  - Option to set a KMS key for the log group and encrypt it (by @till-krauss)
  - Output the name of the cloudwatch log group (by @gbooth27)
+ - Option to use spot instances with launch templates without defining pools, especially useful for GPU instance types (@onur-sam-gtn-ai)
  - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` (by @a-shink)
  - Added support for EBS Volumes tag in `worker_groups_launch_template` and `workers_launch_template_mixed.tf` (by @sppwf)
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -27,8 +27,8 @@ EOS
 
   triggers = {
     kube_config_map_rendered = data.template_file.kubeconfig.rendered
-    config_map_rendered = data.template_file.config_map_aws_auth.rendered
-    endpoint = aws_eks_cluster.this.endpoint
+    config_map_rendered      = data.template_file.config_map_aws_auth.rendered
+    endpoint                 = aws_eks_cluster.this.endpoint
   }
 }
 
@@ -36,7 +36,7 @@ data "aws_caller_identity" "current" {
 }
 
 data "template_file" "launch_template_mixed_worker_role_arns" {
-  count = local.worker_group_launch_template_mixed_count
+  count    = local.worker_group_launch_template_mixed_count
   template = file("${path.module}/templates/worker-role.tpl")
 
   vars = {
@@ -51,7 +51,7 @@ data "template_file" "launch_template_mixed_worker_role_arns" {
 }
 
 data "template_file" "launch_template_worker_role_arns" {
-  count = local.worker_group_launch_template_count
+  count    = local.worker_group_launch_template_count
   template = file("${path.module}/templates/worker-role.tpl")
 
   vars = {
@@ -66,7 +66,7 @@ data "template_file" "launch_template_worker_role_arns" {
 }
 
 data "template_file" "worker_role_arns" {
-  count = local.worker_group_count
+  count    = local.worker_group_count
   template = file("${path.module}/templates/worker-role.tpl")
 
   vars = {
@@ -95,8 +95,8 @@ data "template_file" "config_map_aws_auth" {
         ),
       ),
     )
-    map_users = join("", data.template_file.map_users.*.rendered)
-    map_roles = join("", data.template_file.map_roles.*.rendered)
+    map_users    = join("", data.template_file.map_users.*.rendered)
+    map_roles    = join("", data.template_file.map_roles.*.rendered)
     map_accounts = join("", data.template_file.map_accounts.*.rendered)
   }
 }
@@ -110,7 +110,7 @@ data "template_file" "map_users" {
   vars = {
     user_arn = var.map_users[count.index]["user_arn"]
     username = var.map_users[count.index]["username"]
-    group = var.map_users[count.index]["group"]
+    group    = var.map_users[count.index]["group"]
   }
 }
 
@@ -123,7 +123,7 @@ data "template_file" "map_roles" {
   vars = {
     role_arn = var.map_roles[count.index]["role_arn"]
     username = var.map_roles[count.index]["username"]
-    group = var.map_roles[count.index]["group"]
+    group    = var.map_roles[count.index]["group"]
   }
 }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -3,6 +3,7 @@ resource "aws_cloudwatch_log_group" "this" {
   name              = "/aws/eks/${var.cluster_name}/cluster"
   retention_in_days = var.cluster_log_retention_in_days
   kms_key_id        = var.cluster_log_kms_key_id
+  tags              = var.tags
 }
 
 resource "aws_eks_cluster" "this" {

--- a/data.tf
+++ b/data.tf
@@ -81,17 +81,17 @@ EOF
 
   vars = {
     value = values(var.kubeconfig_aws_authenticator_env_variables)[count.index]
-    key = keys(var.kubeconfig_aws_authenticator_env_variables)[count.index]
+    key   = keys(var.kubeconfig_aws_authenticator_env_variables)[count.index]
   }
 }
 
 data "template_file" "userdata" {
-  count = local.worker_group_count
+  count    = local.worker_group_count
   template = file("${path.module}/templates/userdata.sh.tpl")
 
   vars = {
-    cluster_name = aws_eks_cluster.this.name
-    endpoint = aws_eks_cluster.this.endpoint
+    cluster_name        = aws_eks_cluster.this.name
+    endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
     pre_userdata = lookup(
       var.worker_groups[count.index],
@@ -117,12 +117,12 @@ data "template_file" "userdata" {
 }
 
 data "template_file" "launch_template_userdata" {
-  count = local.worker_group_launch_template_count
+  count    = local.worker_group_launch_template_count
   template = file("${path.module}/templates/userdata.sh.tpl")
 
   vars = {
-    cluster_name = aws_eks_cluster.this.name
-    endpoint = aws_eks_cluster.this.endpoint
+    cluster_name        = aws_eks_cluster.this.name
+    endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
     pre_userdata = lookup(
       var.worker_groups_launch_template[count.index],
@@ -148,12 +148,12 @@ data "template_file" "launch_template_userdata" {
 }
 
 data "template_file" "workers_launch_template_mixed" {
-  count = local.worker_group_launch_template_mixed_count
+  count    = local.worker_group_launch_template_mixed_count
   template = file("${path.module}/templates/userdata.sh.tpl")
 
   vars = {
-    cluster_name = aws_eks_cluster.this.name
-    endpoint = aws_eks_cluster.this.endpoint
+    cluster_name        = aws_eks_cluster.this.name
+    endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
     pre_userdata = lookup(
       var.worker_groups_launch_template_mixed[count.index],
@@ -180,7 +180,7 @@ data "template_file" "workers_launch_template_mixed" {
 
 data "aws_iam_role" "custom_cluster_iam_role" {
   count = var.manage_cluster_iam_resources ? 0 : 1
-  name = var.cluster_iam_role_name
+  name  = var.cluster_iam_role_name
 }
 
 data "aws_iam_instance_profile" "custom_worker_group_iam_instance_profile" {

--- a/workers.tf
+++ b/workers.tf
@@ -281,6 +281,7 @@ resource "aws_iam_role" "workers" {
   permissions_boundary  = var.permissions_boundary
   path                  = var.iam_path
   force_detach_policies = true
+  tags                  = var.tags
 }
 
 resource "aws_iam_instance_profile" "workers" {


### PR DESCRIPTION
# PR o'clock

## Description
Add tags for the log group, the workers IAM role and the workers root volume when using a launch template.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [X] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
