### PR TITLE
Support for tagging EBS Volumes created by "workers_launch_template*.tf"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  - Output the name of the cloudwatch log group (by @gbooth27)
  - Option to use spot instances with launch templates without defining pools, especially useful for GPU instance types (@onur-sam-gtn-ai)
  - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` (by @a-shink)
+ - Added support for EBS Volumes tag in `worker_groups_launch_template` and `workers_launch_template_mixed.tf` (by @sppwf)
  - Write your awesome addition here (by @you)
 
 ### Changed

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -283,7 +283,7 @@ resource "aws_launch_template" "workers_launch_template" {
           var.worker_groups_launch_template[count.index],
           "name",
           count.index,
-          )}-eks_asg"
+        )}-eks_asg"
       },
       var.tags,
     )

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -274,6 +274,21 @@ resource "aws_launch_template" "workers_launch_template" {
     }
   }
 
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(
+      {
+        "Name" = "${aws_eks_cluster.this.name}-${lookup(
+          var.worker_groups_launch_template[count.index],
+          "name",
+          count.index,
+          )}-eks_asg"
+      },
+      var.tags,
+    )
+  }
+
   tags = var.tags
 
   lifecycle {

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -316,6 +316,21 @@ resource "aws_launch_template" "workers_launch_template_mixed" {
     }
   }
 
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(
+      {
+        "Name" = "${aws_eks_cluster.this.name}-${lookup(
+          var.worker_groups_launch_template[count.index],
+          "name",
+          count.index,
+          )}-eks_asg"
+      },
+      var.tags,
+    )
+  }
+
   tags = var.tags
 
   lifecycle {

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -325,7 +325,7 @@ resource "aws_launch_template" "workers_launch_template_mixed" {
           var.worker_groups_launch_template[count.index],
           "name",
           count.index,
-          )}-eks_asg"
+        )}-eks_asg"
       },
       var.tags,
     )


### PR DESCRIPTION
# PR o'clock

## Description

EKS Nodes created by "workers_launch_template*.tf" do not have EBS Volumes tags. 

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
