### PR TITLE
Additional tag for autoscaling enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 # History
 
+## [[v5.1.1](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v5.1.0...v5.1.1)] - 2019-07-30]
+
+### Added
+
+ - Added new tag in `worker.tf` with autoscaling_enabled = true flag (by @insider89)
+
 ## [[v5.1.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v5.0.0...v5.1.0)] - 2019-07-30]
 
 ### Added

--- a/workers.tf
+++ b/workers.tf
@@ -78,6 +78,11 @@ resource "aws_autoscaling_group" "workers" {
         "propagate_at_launch" = true
       },
       {
+        "key"                 = "k8s.io/cluster/${aws_eks_cluster.this.name}"
+        "value"               = "owned"
+        "propagate_at_launch" = true
+      },
+      {
         "key" = "k8s.io/cluster-autoscaler/${lookup(
           var.worker_groups[count.index],
           "autoscaling_enabled",


### PR DESCRIPTION
# PR o'clock

## Description

Added new tag to worker.tf with `autoscaling_enabled = true` flag due to recent changes in [helm chart]((https://github.com/helm/charts/commit/9587fab922920a33247f3f2b815ce0585a995562#diff-0b4714d45280a44e975e49e088149d8a)).

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
