### PR TITLE
Basic example: correct ELB tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  - Output the name of the cloudwatch log group (by @gbooth27)
  - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` (by @a-shink)
  - Added support for EBS Volumes tag in `worker_groups_launch_template` and `workers_launch_template_mixed.tf` (by @sppwf)
+ - Basic example now tags networks correctly, as per [ELB documentation](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html) and [ALB documentation](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html) (by @karolinepauls)
 
 ### Changed
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -101,11 +101,12 @@ module "vpc" {
 
   public_subnet_tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
   }
 
   private_subnet_tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
-    "kubernetes.io/role/internal-elb"             = "true"
+    "kubernetes.io/role/internal-elb"             = "1"
   }
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Added the "kubernetes.io/role/elb" tag to the public subnets in the
basic example.

Per documentation, ELB tag values are supposed to be "1". ELB tag values
being "true" are known not to work with aws-alb-ingress-controller.

https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html
https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
