### PR TITLE
Fix errors from usage of coalesce (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+ - Fixed errors sometimes happening during destroy due to usage of coalesce() in local.tf (by @petrikero)
  - Write your awesome change here (by @you)
 
 # History

--- a/local.tf
+++ b/local.tf
@@ -2,9 +2,9 @@ locals {
   asg_tags = null_resource.tags_as_list_of_maps.*.triggers
 
   cluster_security_group_id = var.cluster_create_security_group ? aws_security_group.cluster[0].id : var.cluster_security_group_id
-  cluster_iam_role_name = var.manage_cluster_iam_resources ? aws_iam_role.cluster[0].name : var.cluster_iam_role_name
-  cluster_iam_role_arn = var.manage_cluster_iam_resources ? aws_iam_role.cluster[0].arn : data.aws_iam_role.custom_cluster_iam_role[0].arn
-  worker_security_group_id = var.worker_create_security_group ? aws_security_group.workers[0].id : var.worker_security_group_id
+  cluster_iam_role_name     = var.manage_cluster_iam_resources ? aws_iam_role.cluster[0].name : var.cluster_iam_role_name
+  cluster_iam_role_arn      = var.manage_cluster_iam_resources ? aws_iam_role.cluster[0].arn : data.aws_iam_role.custom_cluster_iam_role[0].arn
+  worker_security_group_id  = var.worker_create_security_group ? aws_security_group.workers[0].id : var.worker_security_group_id
 
   default_iam_role_id = concat(aws_iam_role.workers.*.id, [""])[0]
   kubeconfig_name     = var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name

--- a/local.tf
+++ b/local.tf
@@ -1,28 +1,11 @@
 locals {
   asg_tags = null_resource.tags_as_list_of_maps.*.triggers
 
-  # Followed recommendation http://67bricks.com/blog/?p=85
-  # to workaround terraform not supporting short circut evaluation
-  cluster_security_group_id = coalesce(
-    join("", aws_security_group.cluster.*.id),
-    var.cluster_security_group_id,
-  )
+  cluster_security_group_id = var.cluster_create_security_group ? aws_security_group.cluster[0].id : var.cluster_security_group_id
+  cluster_iam_role_name = var.manage_cluster_iam_resources ? aws_iam_role.cluster[0].name : var.cluster_iam_role_name
+  cluster_iam_role_arn = var.manage_cluster_iam_resources ? aws_iam_role.cluster[0].arn : data.aws_iam_role.custom_cluster_iam_role[0].arn
+  worker_security_group_id = var.worker_create_security_group ? aws_security_group.workers[0].id : var.worker_security_group_id
 
-  cluster_iam_role_name = coalesce(
-    join("", aws_iam_role.cluster.*.name),
-    var.cluster_iam_role_name,
-    "aws-eks"
-  )
-  cluster_iam_role_arn = coalesce(
-    join("", aws_iam_role.cluster.*.arn),
-    join("", data.aws_iam_role.custom_cluster_iam_role.*.arn),
-    "aws-eks"
-  )
-
-  worker_security_group_id = coalesce(
-    join("", aws_security_group.workers.*.id),
-    var.worker_security_group_id,
-  )
   default_iam_role_id = concat(aws_iam_role.workers.*.id, [""])[0]
   kubeconfig_name     = var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name
 


### PR DESCRIPTION
# PR o'clock

## Description

Fixes #402.

Replace the calls to coalesce() in local.tf with the ternary operator to avoid the errors when both arguments to coalesce() are empty (this is a breaking change in Terraform v0.12). The usage of the coalesce()s seemed to be to emulate the then-missing ternary operator, so it the intent in the code should also now be clearer.

### Checklist

- [X] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [X] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
