### PR TITLE
Fix fmt for v0.12.6

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -27,8 +27,8 @@ EOS
 
   triggers = {
     kube_config_map_rendered = data.template_file.kubeconfig.rendered
-    config_map_rendered = data.template_file.config_map_aws_auth.rendered
-    endpoint = aws_eks_cluster.this.endpoint
+    config_map_rendered      = data.template_file.config_map_aws_auth.rendered
+    endpoint                 = aws_eks_cluster.this.endpoint
   }
 }
 
@@ -36,7 +36,7 @@ data "aws_caller_identity" "current" {
 }
 
 data "template_file" "launch_template_mixed_worker_role_arns" {
-  count = local.worker_group_launch_template_mixed_count
+  count    = local.worker_group_launch_template_mixed_count
   template = file("${path.module}/templates/worker-role.tpl")
 
   vars = {
@@ -51,7 +51,7 @@ data "template_file" "launch_template_mixed_worker_role_arns" {
 }
 
 data "template_file" "launch_template_worker_role_arns" {
-  count = local.worker_group_launch_template_count
+  count    = local.worker_group_launch_template_count
   template = file("${path.module}/templates/worker-role.tpl")
 
   vars = {
@@ -66,7 +66,7 @@ data "template_file" "launch_template_worker_role_arns" {
 }
 
 data "template_file" "worker_role_arns" {
-  count = local.worker_group_count
+  count    = local.worker_group_count
   template = file("${path.module}/templates/worker-role.tpl")
 
   vars = {
@@ -95,8 +95,8 @@ data "template_file" "config_map_aws_auth" {
         ),
       ),
     )
-    map_users = join("", data.template_file.map_users.*.rendered)
-    map_roles = join("", data.template_file.map_roles.*.rendered)
+    map_users    = join("", data.template_file.map_users.*.rendered)
+    map_roles    = join("", data.template_file.map_roles.*.rendered)
     map_accounts = join("", data.template_file.map_accounts.*.rendered)
   }
 }
@@ -110,7 +110,7 @@ data "template_file" "map_users" {
   vars = {
     user_arn = var.map_users[count.index]["user_arn"]
     username = var.map_users[count.index]["username"]
-    group = var.map_users[count.index]["group"]
+    group    = var.map_users[count.index]["group"]
   }
 }
 
@@ -123,7 +123,7 @@ data "template_file" "map_roles" {
   vars = {
     role_arn = var.map_roles[count.index]["role_arn"]
     username = var.map_roles[count.index]["username"]
-    group = var.map_roles[count.index]["group"]
+    group    = var.map_roles[count.index]["group"]
   }
 }
 

--- a/data.tf
+++ b/data.tf
@@ -81,17 +81,17 @@ EOF
 
   vars = {
     value = values(var.kubeconfig_aws_authenticator_env_variables)[count.index]
-    key = keys(var.kubeconfig_aws_authenticator_env_variables)[count.index]
+    key   = keys(var.kubeconfig_aws_authenticator_env_variables)[count.index]
   }
 }
 
 data "template_file" "userdata" {
-  count = local.worker_group_count
+  count    = local.worker_group_count
   template = file("${path.module}/templates/userdata.sh.tpl")
 
   vars = {
-    cluster_name = aws_eks_cluster.this.name
-    endpoint = aws_eks_cluster.this.endpoint
+    cluster_name        = aws_eks_cluster.this.name
+    endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
     pre_userdata = lookup(
       var.worker_groups[count.index],
@@ -117,12 +117,12 @@ data "template_file" "userdata" {
 }
 
 data "template_file" "launch_template_userdata" {
-  count = local.worker_group_launch_template_count
+  count    = local.worker_group_launch_template_count
   template = file("${path.module}/templates/userdata.sh.tpl")
 
   vars = {
-    cluster_name = aws_eks_cluster.this.name
-    endpoint = aws_eks_cluster.this.endpoint
+    cluster_name        = aws_eks_cluster.this.name
+    endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
     pre_userdata = lookup(
       var.worker_groups_launch_template[count.index],
@@ -148,12 +148,12 @@ data "template_file" "launch_template_userdata" {
 }
 
 data "template_file" "workers_launch_template_mixed" {
-  count = local.worker_group_launch_template_mixed_count
+  count    = local.worker_group_launch_template_mixed_count
   template = file("${path.module}/templates/userdata.sh.tpl")
 
   vars = {
-    cluster_name = aws_eks_cluster.this.name
-    endpoint = aws_eks_cluster.this.endpoint
+    cluster_name        = aws_eks_cluster.this.name
+    endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
     pre_userdata = lookup(
       var.worker_groups_launch_template_mixed[count.index],
@@ -180,7 +180,7 @@ data "template_file" "workers_launch_template_mixed" {
 
 data "aws_iam_role" "custom_cluster_iam_role" {
   count = var.manage_cluster_iam_resources ? 0 : 1
-  name = var.cluster_iam_role_name
+  name  = var.cluster_iam_role_name
 }
 
 data "aws_iam_instance_profile" "custom_worker_group_iam_instance_profile" {


### PR DESCRIPTION
# PR o'clock

## Description

Fixed formatting, so it passes with v0.12.6.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing