### PR TITLE
Allow launch template spot instances without mixed policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
- - Write your awesome addition here (by @you)
+ - Added `market_type` to `workers_launch_template.tf` allow the usage of spot nodegroups without mixed instances policy.
 
 ### Changed
 

--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -84,6 +84,18 @@ Launch Template support is a recent addition to both AWS and this module. It mig
       kubelet_extra_args       = "--node-labels=kubernetes.io/lifecycle=spot"
     }
   ]
+
+  worker_groups_launch_template = [
+    {
+      name                     = "spot-2"
+      instance_type            = "m4.xlarge"
+      asg_max_size             = 5
+      asg_desired_size         = 5
+      autoscaling_enabled      = true
+      kubelet_extra_args       = "--node-labels=kubernetes.io/lifecycle=spot"
+      market_type              = "spot"
+    }
+  ]
 ```
 
 ## Important issues

--- a/local.tf
+++ b/local.tf
@@ -73,6 +73,7 @@ locals {
     root_encrypted                    = ""                                       # Whether the volume should be encrypted or not
     eni_delete                        = true                                     # Delete the ENI on termination (if set to false you will have to manually delete before destroying)
     cpu_credits                       = "standard"                               # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
+    market_type                       = null
     # Settings for launch templates with mixed instances policy
     override_instance_types                  = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"] # A list of override instance types for mixed instances policy
     on_demand_allocation_strategy            = "prioritized"                                        # Strategy to use when launching on-demand instances. Valid values: prioritized.

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -229,6 +229,14 @@ resource "aws_launch_template" "workers_launch_template" {
     )
   }
 
+  dynamic instance_market_options {
+    iterator = item
+    for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : list(lookup(var.worker_groups_launch_template[count.index], "market_type", null))
+    content {
+      market_type = item.value
+    }
+  }
+
   block_device_mappings {
     device_name = lookup(
       var.worker_groups_launch_template[count.index],


### PR DESCRIPTION
# PR o'clock

## Description

Allow the creation of spot nodegroups using Launch Templates without resorting to Mixed Policy (due to certain incompatibilities with cluster autoscaler, for example). 

Edit: Switched to using `dynamic` block, instead of a separate `workers_launch_template_spot`.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
