### PR TITLE
Add `required_providers` to set minimum versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
  - Write your awesome addition here (by @you)
+ - Added `required_providers` to enforce provider minimum versions (by @dpiddockcmp)
 
 ### Changed
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws      = ">= 2.8"
+    local    = ">= 1.2"
+    null     = ">= 2.1"
+    template = ">= 2.1"
+  }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Inform terraform of the providers' minimum version requirements. An error will be thrown at `init` if the including plan does not request high enough versions.

This would have helped a little with my recent upgrade. And if kept up to date will reduce the number of issues caused by the user's provider being out of date. Something seen occassionally with the 0.11 version of the module.

I successfully did an apply and destroy of the basic example with the following versions:
```
$ terraform -version
Terraform v0.12.6
+ provider.aws v2.8.0
+ provider.local v1.2.2
+ provider.null v2.1.2
+ provider.random v2.1.2
+ provider.template v2.1.2
```

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories.
- [x] CI tests are passing.
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
