### PR TITLE
add option to recreate ASG when LT or LC changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  - Added support for workers iam role tag in `./workers.tf` (@lucas-giaco)
  - Added `required_providers` to enforce provider minimum versions (by @dpiddockcmp)
  - Updated `local.spot_allocation_strategy` docstring to indicate availability of new `capacity-optimized` option. (by @sc250024)
+ - Added option to recreate ASG when LT or LC changes (by @barryib)
 
 ### Changed
 

--- a/local.tf
+++ b/local.tf
@@ -21,6 +21,7 @@ locals {
     asg_max_size                  = "3"                        # Maximum worker capacity in the autoscaling group.
     asg_min_size                  = "1"                        # Minimum worker capacity in the autoscaling group.
     asg_force_delete              = false                      # Enable forced deletion for the autoscaling group.
+    asg_recreate_on_change        = false                      # Recreate the autoscaling group when LT or LC change.
     instance_type                 = "m4.large"                 # Size of the workers instances.
     spot_price                    = ""                         # Cost of spot instance.
     placement_tenancy             = ""                         # The tenancy of the instance. Valid values are "default" or "dedicated".

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,6 @@ terraform {
     local    = ">= 1.2"
     null     = ">= 2.1"
     template = ">= 2.1"
+    random   = ">= 2.1"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

This PR will allow user to recreate autoscalling groups when launch template or launch configuration changes.

Related to https://github.com/terraform-aws-modules/terraform-aws-eks/issues/462

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
