### PR TITLE
add initial lifecycle hooks for autosacling groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  - Added support for workers iam role tag in `./workers.tf` (@lucas-giaco)
  - Added `required_providers` to enforce provider minimum versions (by @dpiddockcmp)
  - Updated `local.spot_allocation_strategy` docstring to indicate availability of new `capacity-optimized` option. (by @sc250024)
+ - Added support for initial lifecycle hooks for autosacling groups (@barryib)
 
 ### Changed
 

--- a/local.tf
+++ b/local.tf
@@ -21,6 +21,7 @@ locals {
     asg_max_size                  = "3"                        # Maximum worker capacity in the autoscaling group.
     asg_min_size                  = "1"                        # Minimum worker capacity in the autoscaling group.
     asg_force_delete              = false                      # Enable forced deletion for the autoscaling group.
+    asg_initial_lifecycle_hooks   = []                         # Initital lifecycle hook for the autoscaling group.
     instance_type                 = "m4.large"                 # Size of the workers instances.
     spot_price                    = ""                         # Cost of spot instance.
     placement_tenancy             = ""                         # The tenancy of the instance. Valid values are "default" or "dedicated".

--- a/workers.tf
+++ b/workers.tf
@@ -65,6 +65,19 @@ resource "aws_autoscaling_group" "workers" {
     local.workers_group_defaults["termination_policies"]
   )
 
+  dynamic "initial_lifecycle_hook" {
+    for_each = lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    content {
+      name                    = lookup(initial_lifecycle_hook.value, "name", null)
+      lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)
+      notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
+      heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
+      notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)
+      role_arn                = lookup(initial_lifecycle_hook.value, "role_arn", null)
+      default_result          = lookup(initial_lifecycle_hook.value, "default_result", null)
+    }
+  }
+
   tags = concat(
     [
       {

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -77,6 +77,19 @@ resource "aws_autoscaling_group" "workers_launch_template" {
     )
   }
 
+  dynamic "initial_lifecycle_hook" {
+    for_each = lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    content {
+      name                    = lookup(initial_lifecycle_hook.value, "name", null)
+      lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)
+      notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
+      heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
+      notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)
+      role_arn                = lookup(initial_lifecycle_hook.value, "role_arn", null)
+      default_result          = lookup(initial_lifecycle_hook.value, "default_result", null)
+    }
+  }
+
   tags = concat(
     [
       {

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -127,6 +127,19 @@ resource "aws_autoscaling_group" "workers_launch_template_mixed" {
     }
   }
 
+  dynamic "initial_lifecycle_hook" {
+    for_each = lookup(var.worker_groups_launch_template_mixed[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    content {
+      name                    = lookup(initial_lifecycle_hook.value, "name", null)
+      default_result          = lookup(initial_lifecycle_hook.value, "default_result", null)
+      heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
+      lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)
+      notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
+      notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)
+      role_arn                = lookup(initial_lifecycle_hook.value, "role_arn", null)
+    }
+  }
+
   tags = concat(
     [
       {


### PR DESCRIPTION
# PR o'clock

## Description

This PR will allow user to create initial life cycle hooks for autoscaling groups.

Related to #462

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
