### PR TITLE
Add AWS profile variable to examples

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -5,6 +5,7 @@ terraform {
 provider "aws" {
   version = ">= 2.11"
   region  = var.region
+  profile = var.profile
 }
 
 provider "random" {
@@ -119,6 +120,10 @@ module "eks" {
     Environment = "test"
     GithubRepo  = "terraform-aws-eks"
     GithubOrg   = "terraform-aws-modules"
+  }
+
+  kubeconfig_aws_authenticator_env_variables = {
+    AWS_PROFILE = "${var.profile}"
   }
 
   vpc_id = module.vpc.vpc_id

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -2,6 +2,10 @@ variable "region" {
   default = "us-west-2"
 }
 
+variable "profile" {
+  default = "default"
+}
+
 variable "map_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap."
   type        = list(string)

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -5,6 +5,7 @@ terraform {
 provider "aws" {
   version = ">= 2.11"
   region  = var.region
+  profile = var.profile
 }
 
 provider "random" {

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -56,6 +56,10 @@ module "eks" {
   subnets      = module.vpc.public_subnets
   vpc_id       = module.vpc.vpc_id
 
+  kubeconfig_aws_authenticator_env_variables = {
+    AWS_PROFILE = "${var.profile}"
+  }
+
   worker_groups_launch_template = [
     {
       name                 = "worker-group-1"

--- a/examples/launch_templates/variables.tf
+++ b/examples/launch_templates/variables.tf
@@ -2,3 +2,6 @@ variable "region" {
   default = "us-west-2"
 }
 
+variable "profile" {
+  default = "default"
+}

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -5,6 +5,7 @@ terraform {
 provider "aws" {
   version = ">= 2.11"
   region  = var.region
+  profile = var.profile
 }
 
 provider "random" {

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -56,6 +56,10 @@ module "eks" {
   subnets      = module.vpc.public_subnets
   vpc_id       = module.vpc.vpc_id
 
+  kubeconfig_aws_authenticator_env_variables = {
+    AWS_PROFILE = "${var.profile}"
+  }
+
   worker_groups_launch_template_mixed = [
     {
       name                    = "spot-1"

--- a/examples/spot_instances/variables.tf
+++ b/examples/spot_instances/variables.tf
@@ -2,3 +2,6 @@ variable "region" {
   default = "us-west-2"
 }
 
+variable "profile" {
+  default = "default"
+}


### PR DESCRIPTION
# PR o'clock

## Description

When trying to run the examples I ran into issues creating the
`aws_auth_configmap.yaml` file:

```
module.eks.null_resource.update_config_map_aws_auth[0] (local-exec): error: unable to recognize "aws_auth_configmap.yaml": Unauthorized
```

In https://github.com/terraform-aws-modules/terraform-aws-eks/issues/101#issuecomment-415323404
@max-rocket-internet explains that the `AWS_PROFILE` should be set in
`kubeconfig_aws_authenticator_env_variables`. Doing that solved my
issues locally, so I decided to add this bit to the examples so that it
is clear for others as well.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
