### PR TITLE
Add file extension for kubeconfig default name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
  - Removed historical mention of adding caller's IPv4 to cluster security group (by @dpiddockcmp)
  - Write your awesome change here (by @you)
  - Wrapped `kubelet_extra_args` in double quotes instead of singe quotes (by @nxf5025)
+ - **Breaking Change** Default kubeconfig name has `.yaml` extension now (by @marocchino)
 
 # History
 

--- a/local.tf
+++ b/local.tf
@@ -7,7 +7,7 @@ locals {
   worker_security_group_id  = var.worker_create_security_group ? aws_security_group.workers[0].id : var.worker_security_group_id
 
   default_iam_role_id = concat(aws_iam_role.workers.*.id, [""])[0]
-  kubeconfig_name     = var.kubeconfig_name == "" ? "eks_${var.cluster_name}" : var.kubeconfig_name
+  kubeconfig_name     = var.kubeconfig_name == "" ? "eks_${var.cluster_name}.yaml" : var.kubeconfig_name
 
   worker_group_count                       = length(var.worker_groups)
   worker_group_launch_template_count       = length(var.worker_groups_launch_template)


### PR DESCRIPTION
# PR o'clock

## Description
When I applied it, two files came out.
- `config-map-aws-auth_<some-spot-name>.yaml`
- `kubeconfig_<some-spot-name>`

One side has an extension and the other side does not. This is inconsistent.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
