### PR TITLE
Update kubeconfig file write to flag sensitive content

### DIFF
--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,6 +1,6 @@
 resource "local_file" "kubeconfig" {
-  count    = var.write_kubeconfig ? 1 : 0
-  content  = data.template_file.kubeconfig.rendered
-  filename = "${var.config_output_path}kubeconfig_${var.cluster_name}"
+  count              = var.write_kubeconfig ? 1 : 0
+  sensitive_content  = data.template_file.kubeconfig.rendered
+  filename           = "${var.config_output_path}kubeconfig_${var.cluster_name}"
 }
 


### PR DESCRIPTION
This will suppress the CLI output of the kubeconfig file. Useful when run by CI/CD and some may have access to pipeline jobs.

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
