### PR TITLE
Update config_map_aws_auth local file write to sensitive content

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -1,7 +1,7 @@
 resource "local_file" "config_map_aws_auth" {
-  count    = var.write_aws_auth_config ? 1 : 0
-  content  = data.template_file.config_map_aws_auth.rendered
-  filename = "${var.config_output_path}config-map-aws-auth_${var.cluster_name}.yaml"
+  count              = var.write_aws_auth_config ? 1 : 0
+  sensitive_content  = data.template_file.config_map_aws_auth.rendered
+  filename           = "${var.config_output_path}config-map-aws-auth_${var.cluster_name}.yaml"
 }
 
 resource "null_resource" "update_config_map_aws_auth" {


### PR DESCRIPTION
Use sensitive_content flag to update local_file.config_map_aws_auth to suppress CLI output of file data. Useful if run by CI/CD and users have access to job logs.

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
