### PR TITLE
Fix this object does not have an attribute named "latest_version"

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -239,15 +239,7 @@ resource "random_pet" "workers" {
   length    = 2
 
   keepers = {
-    lt_name = join(
-      "-",
-      compact(
-        [
-          aws_launch_configuration.workers[count.index].name,
-          aws_launch_configuration.workers[count.index].latest_version
-        ]
-      )
-    )
+    lc_name = aws_launch_configuration.workers[count.index].name
   }
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Launch configuration doesn't have version.

Resolves #479

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
