### PR TITLE
WIP: Fix Provider produced inconsistent final plan

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -75,7 +75,7 @@ resource "aws_autoscaling_group" "workers" {
   )
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = length(lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])) > 0 ? lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
       name                    = lookup(initial_lifecycle_hook.value, "name", null)
       lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -83,7 +83,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   }
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = length(lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])) > 0 ? lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
       name                    = lookup(initial_lifecycle_hook.value, "name", null)
       lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -134,7 +134,7 @@ resource "aws_autoscaling_group" "workers_launch_template_mixed" {
   }
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups_launch_template_mixed[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = length(lookup(var.worker_groups_launch_template_mixed[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])) > 0 ? lookup(var.worker_groups_launch_template_mixed[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
       name                    = lookup(initial_lifecycle_hook.value, "name", null)
       default_result          = lookup(initial_lifecycle_hook.value, "default_result", null)


### PR DESCRIPTION
# PR o'clock

## Description

compute length of initial lifecycle hooks in dynamic blocks.

Resolves #481

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
