### PR TITLE
Allow to set user defined workers role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
 | manage\_cluster\_iam\_resources | Whether to let the module manage cluster IAM resources. If set to false, cluster_iam_role_name must be specified. | bool | `"true"` | no |
 | manage\_worker\_iam\_resources | Whether to let the module manage worker IAM resources. If set to false, iam_instance_profile_name must be specified for workers. | bool | `"true"` | no |
+| override\_workers\_role\_name | Whether to allow set the workers role name. If set to false, name_prefix is being used. | bool | `"false"` | no |
+| workers\_role\_name | User defined workers role name, has effect only when override_workers_role_name set to true. | sting | `""` | no |
 | map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list(string) | `[]` | no |
 | map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list(map(string)) | `[]` | no |
 | map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list(map(string)) | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -251,3 +251,15 @@ variable "manage_worker_iam_resources" {
   type        = bool
   default     = true
 }
+
+variable "override_workers_role_name" {
+  description = "Whether to allow set the workers role name. If set to false, name_prefix is being used."
+  type        = bool
+  default     = false
+}
+
+variable "workers_role_name" {
+  description = "User defined workers role name, has effect only when override_workers_role_name set to true."
+  type        = string
+  default     = ""
+}

--- a/workers.tf
+++ b/workers.tf
@@ -314,7 +314,8 @@ resource "aws_security_group_rule" "workers_ingress_cluster_https" {
 
 resource "aws_iam_role" "workers" {
   count                 = var.manage_worker_iam_resources ? 1 : 0
-  name_prefix           = aws_eks_cluster.this.name
+  name_prefix           = var.override_workers_role_name ? null : aws_eks_cluster.this.name
+  name                  = var.override_workers_role_name ? var.workers_role_name : null
   assume_role_policy    = data.aws_iam_policy_document.workers_assume_role_policy.json
   permissions_boundary  = var.permissions_boundary
   path                  = var.iam_path


### PR DESCRIPTION
# PR o'clock

## Description
Allow to set workers role name. Use case is a cross account policies where predictable role names are required.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
