### PR TITLE
Backport termination policies to 4.x releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next release
 
-## [[v4.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v4.0.0...HEAD)] - 2019-06-??]
+## [[v4.0.3](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v4.0.0...v4.0.2)] - 2019-09-03]
 
 ### Added
 
-- Write your awesome addition here (by @you)
-
-### Changed
-
-- Write your awesome change here (by @you)
+- Added support for termination policies for Auto Scaling group (by @nusnewob)
 
 # History
 

--- a/local.tf
+++ b/local.tf
@@ -44,6 +44,7 @@ locals {
     enabled_metrics               = ""                              # A comma delimited list of metrics to be collected i.e. GroupMinSize,GroupMaxSize,GroupDesiredCapacity
     placement_group               = ""                              # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                              # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
+    termination_policies          = ""                              # A list of policies to decide how the instances in the auto scale group should be terminated.
 
     # Settings for launch templates
     root_block_device_name            = "${data.aws_ami.eks_worker.root_device_name}" # Root device name for workers. If non is provided, will assume default AMI was used.

--- a/workers.tf
+++ b/workers.tf
@@ -15,6 +15,7 @@ resource "aws_autoscaling_group" "workers" {
   suspended_processes     = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "suspended_processes", ""), local.workers_group_defaults["suspended_processes"])))}"]
   enabled_metrics         = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "enabled_metrics", ""), local.workers_group_defaults["enabled_metrics"])))}"]
   placement_group         = "${lookup(var.worker_groups[count.index], "placement_group", local.workers_group_defaults["placement_group"])}"
+  termination_policies    = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "termination_policies", ""), local.workers_group_defaults["termination_policies"])))}"]
 
   tags = ["${concat(
     list(

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -14,6 +14,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   suspended_processes     = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template[count.index], "suspended_processes", ""), local.workers_group_defaults["suspended_processes"])))}"]
   enabled_metrics         = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template[count.index], "enabled_metrics", ""), local.workers_group_defaults["enabled_metrics"])))}"]
   placement_group         = "${lookup(var.worker_groups_launch_template[count.index], "placement_group", local.workers_group_defaults["placement_group"])}"
+  termination_policies    = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template[count.index], "termination_policies", ""), local.workers_group_defaults["termination_policies"])))}"]
 
   launch_template {
     id      = "${element(aws_launch_template.workers_launch_template.*.id, count.index)}"

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -14,6 +14,7 @@ resource "aws_autoscaling_group" "workers_launch_template_mixed" {
   suspended_processes     = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template_mixed[count.index], "suspended_processes", ""), local.workers_group_defaults["suspended_processes"])))}"]
   enabled_metrics         = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template_mixed[count.index], "enabled_metrics", ""), local.workers_group_defaults["enabled_metrics"])))}"]
   placement_group         = "${lookup(var.worker_groups_launch_template_mixed[count.index], "placement_group", local.workers_group_defaults["placement_group"])}"
+  termination_policies    = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template_mixed[count.index], "termination_policies", ""), local.workers_group_defaults["termination_policies"])))}"]
 
   mixed_instances_policy {
     instances_distribution {


### PR DESCRIPTION
# PR o'clock

## Description

Backport termination_policies to 4.x releases

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [?] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [N/A] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
