### PR TITLE
Fix launch template market option expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ project adheres to [Semantic Versioning](http://semver.org/).
  - Fixed errors sometimes happening during destroy due to usage of coalesce() in local.tf (by @petrikero)
  - Removed historical mention of adding caller's IPv4 to cluster security group (by @dpiddockcmp)
  - Wrapped `kubelet_extra_args` in double quotes instead of singe quotes (by @nxf5025)
- - Write your awesome change here (by @you)
  - Make terraform plan more consistent and avoid unnecessary "(known after apply)" (by @barryib)
+ - Made sure that `market_type` was correctly passed to `workers_launch_template` (by @to266)
+ - Write your awesome change here (by @you)
 
 # History
 

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -248,10 +248,9 @@ resource "aws_launch_template" "workers_launch_template" {
   }
 
   dynamic instance_market_options {
-    iterator = item
     for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : list(lookup(var.worker_groups_launch_template[count.index], "market_type", null))
     content {
-      market_type = item.value
+      market_type = instance_market_options.value
     }
   }
 


### PR DESCRIPTION
# PR o'clock

## Description

This fixes the `market_type` passing when generating the `workers_launch_template`. The previous version would not populate the `instance_market_options.market_type` even if the corresponding value was passed.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
