### PR TITLE
Gpu workers support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+ - Added support for different workers AMI's, i.e. with GPU support (by @rvoitenko)
 
 ### Changed
 
@@ -49,7 +49,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
  - Added new tag in `worker.tf` with autoscaling_enabled = true flag (by @insider89)
- - Added support for different workers AMI's, i.e. with GPU support (by @rvoitenko)
 
 ## [[v5.1.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v5.0.0...v5.1.0)] - 2019-07-30]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
  - Added new tag in `worker.tf` with autoscaling_enabled = true flag (by @insider89)
+ - Added support for different workers AMI's, i.e. with GPU support (by @rvoitenko)
 
 ## [[v5.1.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v5.0.0...v5.1.0)] - 2019-07-30]
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | tags | A map of tags to add to all resources. | map(string) | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
-| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
+| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster\_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
+| worker\_ami\_name\_filter\_prefix | Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. "amazon-eks-gpu-node", or custom AMI | string | `"amazon-eks-node"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | bool | `"true"` | no |
 | worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |
 | worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | any | `[]` | no |

--- a/data.tf
+++ b/data.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
 data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-${var.worker_ami_name_filter}"]
+    values = ["${worker_ami_name_filter_prefix}-${var.cluster_version}-${var.worker_ami_name_filter}"]
   }
 
   most_recent = true

--- a/data.tf
+++ b/data.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
 data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
-    values = ["${worker_ami_name_filter_prefix}-${var.cluster_version}-${var.worker_ami_name_filter}"]
+    values = ["${var.worker_ami_name_filter_prefix}-${var.cluster_version}-${var.worker_ami_name_filter}"]
   }
 
   most_recent = true

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,12 @@ variable "worker_ami_name_filter" {
   default     = "v*"
 }
 
+variable "worker_ami_name_filter_prefix" {
+  description = "Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. \"amazon-eks-gpu-node\", or custom AMI"
+  type        = string
+  default     = "amazon-eks-node"
+}
+
 variable "worker_additional_security_group_ids" {
   description = "A list of additional security group ids to attach to worker instances"
   type        = list(string)


### PR DESCRIPTION
# PR o'clock

## Description

Current implementation doesn't allow to use Amazon EKS-Optimized AMI with GPU Support(https://docs.aws.amazon.com/eks/latest/userguide/gpu-ami.html), because of hardcoded AMI filter prefix "amazon-eks-node".
This patch allow to define different AMI filter prefix, i.e. "amazon-eks-gpu-node", but default is still set to "amazon-eks-node"

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
