### PR TITLE
Output empty string when cluster identity is empty

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -45,7 +45,7 @@ output "cluster_iam_role_arn" {
 
 output "cluster_oidc_issuer_url" {
   description = "The URL on the EKS cluster OIDC Issuer"
-  value       = aws_eks_cluster.this.identity.0.oidc.0.issuer
+  value       = concat(aws_eks_cluster.this.identity.*.oidc.0.issuer, [""])[0]
 }
 
 output "cloudwatch_log_group_name" {


### PR DESCRIPTION
# PR o'clock

## Description

More info https://github.com/terraform-aws-modules/terraform-aws-eks/pull/514#issuecomment-532654473

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
