### PR TITLE
Use null as default value for target group ARNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Write your awesome change here (by @you)
+- Use null as default value for `target_group_arns` attribute of worker autoscaling group (by @tatusl)
 
 # History
 

--- a/local.tf
+++ b/local.tf
@@ -50,7 +50,7 @@ locals {
     iam_instance_profile_name     = ""                          # A custom IAM instance profile name. Used when manage_worker_iam_resources is set to false. Incompatible with iam_role_id.
     iam_role_id                   = "local.default_iam_role_id" # A custom IAM role id. Incompatible with iam_instance_profile_name.  Literal local.default_iam_role_id will never be used but if iam_role_id is not set, the local.default_iam_role_id interpolation will be used.
     suspended_processes           = ["AZRebalance"]             # A list of processes to suspend. i.e. ["AZRebalance", "HealthCheck", "ReplaceUnhealthy"]
-    target_group_arns             = []                          # A list of ALB target group ARNs to be associated to the ASG
+    target_group_arns             = null                        # A list of ALB target group ARNs to be associated to the ASG
     enabled_metrics               = []                          # A list of metrics to be collected i.e. ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity"]
     placement_group               = ""                          # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                          # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS


### PR DESCRIPTION
# PR o'clock

## Description

Setting `null` as default for `target_group_arns` attribute of worker autoscaling group prevents Terraform from overwriting `aws_autoscaling_attachment`s created in other modules targeting worker ASG. In my opinion, this is more desirable default compared to `[]`, which overwrites autoscaling group attachments created in other modules.

Related issue: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/499

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
