### PR TITLE
Fix issue 527 that was previously fixed

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -75,7 +75,7 @@ resource "aws_autoscaling_group" "workers" {
   )
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = length(lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])) > 0 ? lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
       name                    = lookup(initial_lifecycle_hook.value, "name", null)
       lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -151,7 +151,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   }
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = length(lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])) > 0 ? lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
       name                    = lookup(initial_lifecycle_hook.value, "name", null)
       lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)


### PR DESCRIPTION
# PR o'clock
Provider produced inconsistent final plan described in [](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/527)

## Description
This issue previously has been address in: [9882](https://github.com/terraform-providers/terraform-provider-aws/issues/9882) and [481](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/481) but in version 6.X it missed. 
Fix was previously created by @barryib in [489](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/489) and somehow missed.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
