### PR TITLE
Add option to enable lifecycle hooks creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
- - Write your awesome change here (by @you)
+ - Add option to enable lifecycle hooks creation (by @barryib)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
 | worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
 | worker\_ami\_name\_filter\_prefix | Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. "amazon-eks-gpu-node", or custom AMI | string | `"amazon-eks-node"` | no |
+| worker\_create\_initial\_lifecycle\_hooks | Whether to create initial lifecycle hooks provided in worker groups. | bool | `"false"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | bool | `"true"` | no |
 | worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |
 | worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | any | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -210,6 +210,12 @@ variable "worker_create_security_group" {
   default     = true
 }
 
+variable "worker_create_initial_lifecycle_hooks" {
+  description = "Whether to create initial lifecycle hooks provided in worker groups."
+  type        = bool
+  default     = false
+}
+
 variable "permissions_boundary" {
   description = "If provided, all IAM roles will be created with this permissions boundary attached."
   type        = string

--- a/workers.tf
+++ b/workers.tf
@@ -75,10 +75,10 @@ resource "aws_autoscaling_group" "workers" {
   )
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = var.worker_create_initial_lifecycle_hooks ? lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
-      name                    = lookup(initial_lifecycle_hook.value, "name", null)
-      lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)
+      name                    = initial_lifecycle_hook.value["name"]
+      lifecycle_transition    = initial_lifecycle_hook.value["lifecycle_transition"]
       notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
       heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
       notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -151,10 +151,10 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   }
 
   dynamic "initial_lifecycle_hook" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"])
+    for_each = var.worker_create_initial_lifecycle_hooks ? lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
     content {
-      name                    = lookup(initial_lifecycle_hook.value, "name", null)
-      lifecycle_transition    = lookup(initial_lifecycle_hook.value, "lifecycle_transition", null)
+      name                    = initial_lifecycle_hook.value["name"]
+      lifecycle_transition    = initial_lifecycle_hook.value["lifecycle_transition"]
       notification_metadata   = lookup(initial_lifecycle_hook.value, "notification_metadata", null)
       heartbeat_timeout       = lookup(initial_lifecycle_hook.value, "heartbeat_timeout", null)
       notification_target_arn = lookup(initial_lifecycle_hook.value, "notification_target_arn", null)


### PR DESCRIPTION
# PR o'clock

## Description

Related to https://github.com/terraform-aws-modules/terraform-aws-eks/issues/527

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
