### PR TITLE
GitHub Actions when forked - Quick test before sleep

### DIFF
--- a/.github/workflows/autofixes.yml
+++ b/.github/workflows/autofixes.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@master
-        with:
-          fetch-depth: 1
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/autofixes.yml
+++ b/.github/workflows/autofixes.yml
@@ -1,0 +1,46 @@
+name: Autofixers
+
+on: [pull_request_review]
+
+jobs:
+  precommit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.12'
+      - name: Install dependencies
+        run: |
+          pip3 install pre-commit
+          go get github.com/segmentio/terraform-docs
+      - name: Terraform init
+        run: |
+          terraform init
+      - name: Run pre-commit
+        run: |
+          export PATH=${PATH}:`go env GOPATH`/bin
+          pre-commit run --show-diff-on-failure --all-files
+      - name: Auto-commit changes, if any
+        if: contains(github.event.review.body, '/fix') && failure()
+        uses: stefanzweifel/git-auto-commit-action@v2.1.0
+        with:
+          commit_message: Apply pre-commit fixes
+          branch: ${{ github.event.pull_request.head.ref }}
+        env:
+          # If the default GitHub Provided token is used then a new
+          #  check run will not be triggered. This is bad because
+          #  checks are required for merging. A workaround is to
+          #  use a personal token. Ugly, but eh. Fixes it
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autofixes.yml
+++ b/.github/workflows/autofixes.yml
@@ -13,8 +13,7 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-      - name: Clone repo
-        uses: actions/checkout@master
+      - uses: actions/checkout@master
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/autofixes.yml
+++ b/.github/workflows/autofixes.yml
@@ -9,6 +9,10 @@ jobs:
     container:
       image: hashicorp/terraform:latest
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Clone repo
         uses: actions/checkout@master
       - name: Setup Python

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -1,0 +1,24 @@
+name: Terraform
+
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: Terraform init
+        run: |
+          terraform init
+      - name: Run tflint with review comment on PR
+        uses: reviewdog/action-tflint@v1.0.0
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
 | worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
-| worker\_ami\_name\_filter\_prefix | Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. "amazon-eks-gpu-node", or custom AMI | string | `"amazon-eks-node"` | no |
+| bad-value-here | Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. "amazon-eks-gpu-node", or custom AMI | string | `"amazon-eks-node"` | no |
 | worker\_create\_initial\_lifecycle\_hooks | Whether to create initial lifecycle hooks provided in worker groups. | bool | `"false"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | bool | `"true"` | no |
 | worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |


### PR DESCRIPTION
# PR o'clock

## Description

Quick testing of some GitHub actions before sleep. I really want to see if this works and I apologize for the spam.

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
