### PR TITLE
Make "dangerous" policy attachments optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
  - Add option to enable lifecycle hooks creation (by @barryib)
  - Remove helm chart value `sslCertPath` described in `docs/autoscaling.md` (by @wi1dcard)
+ - Attaching of IAM policies for autoscaler and CNI to the worker nodes now optional (by @dpiddockcmp)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| attach\_worker\_autoscaling\_policy | Whether to attach the module managed cluster autoscaling iam policy to the default worker IAM role. This requires `manage_worker_autoscaling_policy = true` | bool | `"true"` | no |
+| attach\_worker\_cni\_policy | Whether to attach the Amazon managed `AmazonEKS_CNI_Policy` IAM policy to the default worker IAM role. WARNING: If set `false` the permissions must be assigned to the `aws-node` DaemonSet pods via another method or nodes will not be able to join the cluster. | bool | `"true"` | no |
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | bool | `"true"` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
 | cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
@@ -131,6 +133,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list(string) | `[ "/bin/sh", "-c" ]` | no |
 | manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
 | manage\_cluster\_iam\_resources | Whether to let the module manage cluster IAM resources. If set to false, cluster_iam_role_name must be specified. | bool | `"true"` | no |
+| manage\_worker\_autoscaling\_policy | Whether to let the module manage the cluster autoscaling iam policy. | bool | `"true"` | no |
 | manage\_worker\_iam\_resources | Whether to let the module manage worker IAM resources. If set to false, iam_instance_profile_name must be specified for workers. | bool | `"true"` | no |
 | map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list(string) | `[]` | no |
 | map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | object | `[]` | no |
@@ -171,6 +174,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
+| worker\_autoscaling\_policy\_arn | ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
+| worker\_autoscaling\_policy\_name | Name of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
 | worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |

--- a/outputs.tf
+++ b/outputs.tf
@@ -142,3 +142,12 @@ output "worker_iam_role_arn" {
   )[0]
 }
 
+output "worker_autoscaling_policy_name" {
+  description = "Name of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true`"
+  value       = concat(aws_iam_policy.worker_autoscaling[*].name, [""])[0]
+}
+
+output "worker_autoscaling_policy_arn" {
+  description = "ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true`"
+  value       = concat(aws_iam_policy.worker_autoscaling[*].arn, [""])[0]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -263,3 +263,21 @@ variable "workers_role_name" {
   type        = string
   default     = ""
 }
+
+variable "manage_worker_autoscaling_policy" {
+  description = "Whether to let the module manage the cluster autoscaling iam policy."
+  type        = bool
+  default     = true
+}
+
+variable "attach_worker_autoscaling_policy" {
+  description = "Whether to attach the module managed cluster autoscaling iam policy to the default worker IAM role. This requires `manage_worker_autoscaling_policy = true`"
+  type        = bool
+  default     = true
+}
+
+variable "attach_worker_cni_policy" {
+  description = "Whether to attach the Amazon managed `AmazonEKS_CNI_Policy` IAM policy to the default worker IAM role. WARNING: If set `false` the permissions must be assigned to the `aws-node` DaemonSet pods via another method or nodes will not be able to join the cluster."
+  type        = bool
+  default     = true
+}

--- a/workers.tf
+++ b/workers.tf
@@ -342,7 +342,7 @@ resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKS_CNI_Policy" {
-  count      = var.manage_worker_iam_resources ? 1 : 0
+  count      = var.manage_worker_iam_resources && var.attach_worker_cni_policy ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = aws_iam_role.workers[0].name
 }
@@ -360,13 +360,13 @@ resource "aws_iam_role_policy_attachment" "workers_additional_policies" {
 }
 
 resource "aws_iam_role_policy_attachment" "workers_autoscaling" {
-  count      = var.manage_worker_iam_resources ? 1 : 0
+  count      = var.manage_worker_iam_resources && var.manage_worker_autoscaling_policy && var.attach_worker_autoscaling_policy ? 1 : 0
   policy_arn = aws_iam_policy.worker_autoscaling[0].arn
   role       = aws_iam_role.workers[0].name
 }
 
 resource "aws_iam_policy" "worker_autoscaling" {
-  count       = var.manage_worker_iam_resources ? 1 : 0
+  count       = var.manage_worker_iam_resources && var.manage_worker_autoscaling_policy ? 1 : 0
   name_prefix = "eks-worker-autoscaling-${aws_eks_cluster.this.name}"
   description = "EKS worker node autoscaling policy for cluster ${aws_eks_cluster.this.name}"
   policy      = data.aws_iam_policy_document.worker_autoscaling.json


### PR DESCRIPTION
# PR o'clock

## Description

The IAM policies for the node autoscaler and AWS CNI have write permissions and are assigned to the nodes by default. These could potentially be dangerous to the stability of the cluster if accessed by a rogue pod as they are the default role received.

I'm currently looking at the new OIDC IAM integration. The [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/restrict-ec2-credential-access.html) has an example for using iptables to block access to the metadata service but this broke some pods like the alb-ingress-controller. Not a great situation. I could put pods that need access to the metadata service on the host network but I don't fancy that solution. The only other option is to make the default node role as harmless as possible.

Also made creation of the autoscaling policy optional for users who don't want it at all.

Greater flexibility in the module can't harm anybody.

Defaults set to current behaviour for backwards compatibility.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
