### PR TITLE
WIP: Docs fixer in GitHub Actions

### DIFF
--- a/.github/workflows/autofixers.yml
+++ b/.github/workflows/autofixers.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source for the PR
-        run: git clone --branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" . && git reset --hard "$GITHUB_REV"
+        run: git clone --branch="$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" . && git reset --hard "$GITHUB_REV"
         env:
           GITHUB_REV: ${{ github.event.pull_request.head.sha }}
           GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/autofixers.yml
+++ b/.github/workflows/autofixers.yml
@@ -1,0 +1,46 @@
+name: Autofixers
+
+on: [pull_request_review]
+
+jobs:
+  precommit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source for the PR
+        run: git clone --branch=$GITHUB_BRANCH" "https://github.com/${GITHUB_REPO}" . && git reset --hard "$GITHUB_REV"
+        env:
+          GITHUB_REV: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.12'
+      - name: Install dependencies
+        run: |
+          pip install pre-commit
+          go get github.com/segmentio/terraform-docs
+      - name: Terraform init
+        uses: hashicorp/terraform-github-actions/init@v0.4.0
+      - name: Run pre-commit
+        run: |
+          export PATH=${PATH}:`go env GOPATH`/bin
+          pre-commit run --show-diff-on-failure --all-files
+      - name: Auto-commit changes, if any
+        if: contains(github.event.review.body, '/fix') && failure()
+        uses: stefanzweifel/git-auto-commit-action@v2.1.0
+        with:
+          commit_message: Apply pre-commit fixes
+          branch: ${{ github.event.pull_request.head.ref }}
+        env:
+          # If the default GitHub Provided token is used then a new
+          #  check run will not be triggered. This is bad because
+          #  checks are required for merging.
+          # A workaround is to use a personal token.
+          #  Ugly, but eh. Fixes it
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autofixers.yml
+++ b/.github/workflows/autofixers.yml
@@ -13,23 +13,23 @@ jobs:
           GITHUB_REV: ${{ github.event.pull_request.head.sha }}
           GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
           GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-      - name: Setup Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.12'
-      - name: Install dependencies
+      - name: Install brew
         run: |
-          pip install pre-commit
-          go get github.com/segmentio/terraform-docs
+          HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew
+          sudo mkdir -p /home/linuxbrew
+          sudo git clone https://github.com/Homebrew/brew "$HOMEBREW_REPOSITORY"
+          sudo mkdir -p "$HOMEBREW_REPOSITORY/Library/Taps/homebrew"
+          sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-formula-analytics"
+          sudo chown -R "$USER" "$HOMEBREW_REPOSITORY"
+          export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:$PATH"
+          echo ::set-env name=PATH::$PATH
+      - name: Install Deps
+        run: |
+          brew install pre-commit terraform-docs terraform
       - name: Terraform init
         uses: hashicorp/terraform-github-actions/init@v0.4.0
       - name: Run pre-commit
         run: |
-          export PATH=${PATH}:`go env GOPATH`/bin
           pre-commit run --show-diff-on-failure --all-files
       - name: Auto-commit changes, if any
         if: contains(github.event.review.body, '/fix') && failure()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,27 +21,13 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@master
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-      - name: Setup Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.12'
-      - name: Install dependencies
-        run: |
-          pip install pre-commit
-          go get github.com/segmentio/terraform-docs
-      - name: Terraform init
-        uses: hashicorp/terraform-github-actions/init@v0.4.0
-      - name: Run pre-commit
-        run: |
-          export PATH=${PATH}:`go env GOPATH`/bin
-          pre-commit run --show-diff-on-failure --all-files
+      - name: Install Deps
+        run: brew install pre-commit terraform-docs terraform
+      - name: Check Docs
+        run: pre-commit run --show-diff-on-failure --all-files terraform_docs
 
   validate:
     name: Validate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - name: TFLint
         uses: docker://wata727/tflint
-  
+
   fmt:
     name: Code Format
     runs-on: ubuntu-latest
@@ -18,16 +18,30 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - run: terraform fmt --recursive -check=true
-  
+
   docs:
     name: Docs
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install Deps
-        run: brew install pre-commit terraform-docs terraform
-      - name: Check Docs
-        run: pre-commit run --show-diff-on-failure --all-files terraform_docs
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.12'
+      - name: Install dependencies
+        run: |
+          pip install pre-commit
+          go get github.com/segmentio/terraform-docs
+      - name: Terraform init
+        uses: hashicorp/terraform-github-actions/init@v0.4.0
+      - name: Run pre-commit
+        run: |
+          export PATH=${PATH}:`go env GOPATH`/bin
+          pre-commit run --show-diff-on-failure --all-files
 
   validate:
     name: Validate


### PR DESCRIPTION
# PR o'clock

Creating this PR to start a discussion on wether this is desired or not. The user experience for this is not perfect.

## Description

There are checks for formatting and docs, but no easy way to fix it. To get the docs up to date/ fix formatting contributors have to setup `pre-commit` properly.

This PR adds a GitHub Action that runs `pre-commit` and commits the result back.

Example workflow:
- PR is open, all checks are green
- commits are added, docs are now out of date
- `/fix` comment on the PR Review( not on the _Conversation_ as GitHub Actions has... limitation about events and what data is in there -- like the branch name)
- new commit is added to the branch fixing the docs

There is a downside to this though: by default when using `secrets.GITHUB_TOKEN` no actions will run on commits made by GitHub Actions. This is bad especially because checks are required for merging.
An ugly but working fix is to use a _Personal Access Token_ as the secret instead of the default `GITHUB_TOKEN`. What I see in most GitHub orgs is a bot user which is used for this. 

An example with `secrets.GITHUB_TOKEN` [can be seen here](https://github.com/Castravete/repo-for-fork-testing/pull/3).
An example with `secrets.BOT_PERSONAL_ACCESS_TOKEN` [can be seen here](https://github.com/Castravete/repo-for-fork-testing/pull/6).

~~⚠️ Weirdly enough, the `terraform_docs` had different results when the check was running on macOS vs when running on Linux. I have no idea where to even start to debug this. ⚠️~~

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation