### PR TITLE
Fix accidental background filling of config files

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -13,8 +13,8 @@ resource "null_resource" "update_config_map_aws_auth" {
 
     command = <<EOS
 for i in `seq 1 10`; do \
-echo "${null_resource.update_config_map_aws_auth[0].triggers.kube_config_map_rendered}" > kube_config.yaml & \
-echo "${null_resource.update_config_map_aws_auth[0].triggers.config_map_rendered}" > aws_auth_configmap.yaml & \
+echo "${null_resource.update_config_map_aws_auth[0].triggers.kube_config_map_rendered}" > kube_config.yaml && \
+echo "${null_resource.update_config_map_aws_auth[0].triggers.config_map_rendered}" > aws_auth_configmap.yaml && \
 kubectl apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && break || \
 sleep 10; \
 done; \


### PR DESCRIPTION
# PR o'clock

## Description

It looks like someone has accidentally backgrounded the calls to fill out kube_config.yaml and aws_auth_configmap.yaml
Using a single ampersand will run the echo commands in the background and immediately run kubectl (at the same time essentially) so the config files can/will often be empty
I assume, and it makes sense to use double ampersand so that each command runs only if the previous one worked.

Also might be able to remove the 10x loop depending on why that was added.
If it was added because the code randomly worked/not (not surprised) then I have probably fixed that and removed the need for the loop

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
