### PR TITLE
remove the launch template mixed variable from examples

### DIFF
--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -73,6 +73,7 @@ Launch Template support is a recent addition to both AWS and this module. It mig
     }
   ]
 
+/* The variable worker_groups_launch_template_mixed is not suported from v6.0.0 onwards */
   worker_groups_launch_template_mixed = [
     {
       name                     = "spot-1"

--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -73,29 +73,17 @@ Launch Template support is a recent addition to both AWS and this module. It mig
     }
   ]
 
-/* The variable worker_groups_launch_template_mixed is not suported from v6.0.0 onwards */
-  worker_groups_launch_template_mixed = [
-    {
-      name                     = "spot-1"
-      override_instance_types  = ["m5.large", "c5.large", "t3.large", "r5.large"]
-      spot_instance_pools      = 3
-      asg_max_size             = 5
-      asg_desired_size         = 5
-      autoscaling_enabled      = true
-      kubelet_extra_args       = "--node-labels=kubernetes.io/lifecycle=spot"
-    }
-  ]
 
   worker_groups_launch_template = [
     {
-      name                     = "spot-2"
-      instance_type            = "m4.xlarge"
-      asg_max_size             = 5
-      asg_desired_size         = 5
-      autoscaling_enabled      = true
-      kubelet_extra_args       = "--node-labels=kubernetes.io/lifecycle=spot"
-      market_type              = "spot"
-    }
+      name                    = "spot-1"
+      override_instance_types = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"]
+      spot_instance_pools     = 4
+      asg_max_size            = 5
+      asg_desired_capacity    = 5
+      kubelet_extra_args      = "--node-labels=kubernetes.io/lifecycle=spot"
+      public_ip               = true
+    },
   ]
 ```
 


### PR DESCRIPTION
# PR o'clock

## Description
Removing the `worker_groups_launch_template_mixed` variable from examples.


### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
