### PR TITLE
Add tags to eks cluster introduced by terraform-provider-aws 2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `tags` to `aws_eks_cluster` introduced by terraform-provider-aws 2.31.0 (by @morganchristiansson)
 - Write your awesome addition here (by @you)
 
 ### Changed

--- a/cluster.tf
+++ b/cluster.tf
@@ -11,6 +11,7 @@ resource "aws_eks_cluster" "this" {
   enabled_cluster_log_types = var.cluster_enabled_log_types
   role_arn                  = local.cluster_iam_role_arn
   version                   = var.cluster_version
+  tags                      = var.tags
 
   vpc_config {
     security_group_ids      = [local.cluster_security_group_id]

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws      = ">= 2.28.1"
+    aws      = ">= 2.31.0"
     local    = ">= 1.2"
     null     = ">= 2.1"
     template = ">= 2.1"


### PR DESCRIPTION
# PR o'clock

## Description

terraform-provider-aws v2.31.0 has been released

    resource/aws_eks_cluster: Add tags argument (#10307)

https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v2.31.0
https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-supports-cluster-tagging/

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
