### PR TITLE
Allow for specifying a custom AMI for the worker nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- **Breaking:** Allow for specifying a custom AMI for the worker nodes. (by @bmcstdio)
 - Write your awesome addition here (by @you)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | tags | A map of tags to add to all resources. | map(string) | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
-| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
-| worker\_ami\_name\_filter\_prefix | Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. "amazon-eks-gpu-node", or custom AMI | string | `"amazon-eks-node"` | no |
+| worker\_ami\_name\_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
+| worker\_ami\_owner\_id | The ID of the owner for the AMI to use for the AWS EKS workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"602401143452"` | no |
 | worker\_create\_initial\_lifecycle\_hooks | Whether to create initial lifecycle hooks provided in worker groups. | bool | `"false"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | bool | `"true"` | no |
 | worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,7 @@
+locals {
+  worker_ami_name_filter = var.worker_ami_name_filter != "" ? var.worker_ami_name_filter : "amazon-eks-node-${var.cluster_version}-v*"
+}
+
 data "aws_region" "current" {
 }
 
@@ -19,13 +23,12 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
 data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
-    values = ["${var.worker_ami_name_filter_prefix}-${var.cluster_version}-${var.worker_ami_name_filter}"]
+    values = [local.worker_ami_name_filter]
   }
 
   most_recent = true
 
-  # Owner ID of AWS EKS team
-  owners = ["602401143452"]
+  owners = [var.worker_ami_owner_id]
 }
 
 data "aws_iam_policy_document" "cluster_assume_role_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -121,15 +121,15 @@ variable "worker_security_group_id" {
 }
 
 variable "worker_ami_name_filter" {
-  description = "Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. \"v20190220\""
+  description = "Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used."
   type        = string
-  default     = "v*"
+  default     = ""
 }
 
-variable "worker_ami_name_filter_prefix" {
-  description = "Name prefix filter for AWS EKS worker AMI. Default behaviour will get regular EKS-Optimized AMI but could be set to a EKS-Optimized AMI with GPU Support, e.g. \"amazon-eks-gpu-node\", or custom AMI"
+variable "worker_ami_owner_id" {
+  description = "The ID of the owner for the AMI to use for the AWS EKS workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft')."
   type        = string
-  default     = "amazon-eks-node"
+  default     = "602401143452" // The ID of the owner of the official AWS EKS AMIs.
 }
 
 variable "worker_additional_security_group_ids" {


### PR DESCRIPTION
# PR o'clock

## Description

In some environments one may be required to customise the AMI used by the worker nodes.
This PR allows for specifying a custom AMI to use for the worker nodes in a backwards-compatible way (and I think it closes #540).

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
