### PR TITLE
Add Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - **Breaking:** Allow for specifying a custom AMI for the worker nodes. (by @bmcstdio)
+- Added support for Windows workers AMIs (by @hodduc)
 - Write your awesome addition here (by @you)
 
 ### Changed
@@ -19,7 +20,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 -  **Breaking:** The `kubectl` configuration file can now be fully-specified using `config_output_path`. Previously it was assumed that `config_output_path` referred to a directory and always ended with a forward slash. This is a breaking change if `config_output_path` does **not** end with a forward slash (which was advised against by the documentation).
 - Changed logic for setting default ebs_optimized to only require maintaining a list of instance types that don't support it (by @jeffmhastings)
 - Bumped minimum terraform version to 0.12.2 to prevent an error on yamlencode function (by @toadjaune)
-- Added support for Windows workers AMIs (by @hodduc)
 
 # History
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 -  **Breaking:** The `kubectl` configuration file can now be fully-specified using `config_output_path`. Previously it was assumed that `config_output_path` referred to a directory and always ended with a forward slash. This is a breaking change if `config_output_path` does **not** end with a forward slash (which was advised against by the documentation).
 - Changed logic for setting default ebs_optimized to only require maintaining a list of instance types that don't support it (by @jeffmhastings)
 - Bumped minimum terraform version to 0.12.2 to prevent an error on yamlencode function (by @toadjaune)
+- Added support for Windows workers AMIs (by @hodduc)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
 | worker\_ami\_name\_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
+| worker\_ami\_name\_filter\_windows | Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
 | worker\_ami\_owner\_id | The ID of the owner for the AMI to use for the AWS EKS workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"602401143452"` | no |
+| worker\_ami\_owner\_id\_windows | The ID of the owner for the AMI to use for the AWS EKS Windows workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"801119661308"` | no |
 | worker\_create\_initial\_lifecycle\_hooks | Whether to create initial lifecycle hooks provided in worker groups. | bool | `"false"` | no |
 | worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | bool | `"true"` | no |
 | worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -47,6 +47,11 @@ data "template_file" "launch_template_worker_role_arns" {
       ),
       count.index,
     )}"
+    platform = lookup(
+      var.worker_groups_launch_template[count.index],
+      "platform",
+      local.workers_group_defaults["platform"]
+    )
   }
 }
 
@@ -63,6 +68,11 @@ data "template_file" "worker_role_arns" {
       ),
       count.index,
     )}"
+    platform = lookup(
+      var.worker_groups[count.index],
+      "platform",
+      local.workers_group_defaults["platform"]
+    )
   }
 }
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,3 +98,9 @@ module "eks" {
   # ...
 }
 ```
+
+## How can I use Windows workers?
+
+To enable Windows support for your EKS cluster, you should apply some configs manually. See the [Enabling Windows Support (Windows/MacOS/Linux)](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support).
+
+Windows worker nodes requires additional cluster role (eks:kube-proxy-windows). If you are adding windows workers to existing cluster, you should apply config-map-aws-auth again.

--- a/local.tf
+++ b/local.tf
@@ -19,10 +19,13 @@ locals {
   worker_group_count                 = length(var.worker_groups)
   worker_group_launch_template_count = length(var.worker_groups_launch_template)
 
+  default_ami_id_linux   = data.aws_ami.eks_worker.id
+  default_ami_id_windows = data.aws_ami.eks_worker_windows.id
+
   workers_group_defaults_defaults = {
     name                          = "count.index"               # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
     tags                          = []                          # A list of map defining extra tags to be applied to the worker group autoscaling group.
-    ami_id                        = data.aws_ami.eks_worker.id  # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI.
+    ami_id                        = ""                          # AMI ID for the eks workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
     asg_desired_capacity          = "1"                         # Desired worker capacity in the autoscaling group and changing its value will not affect the autoscaling group's desired capacity because the cluster-autoscaler manages up and down scaling of the nodes. Cluster-autoscaler add nodes when pods are in pending state and remove the nodes when they are not required by modifying the desirec_capacity of the autoscaling group. Although an issue exists in which if the value of the asg_min_size is changed it modifies the value of asg_desired_capacity.
     asg_max_size                  = "3"                         # Maximum worker capacity in the autoscaling group.
     asg_min_size                  = "1"                         # Minimum worker capacity in the autoscaling group. NOTE: Change in this paramater will affect the asg_desired_capacity, like changing its value to 2 will change asg_desired_capacity value to 2 but bringing back it to 1 will not affect the asg_desired_capacity.
@@ -55,6 +58,7 @@ locals {
     placement_group               = ""                          # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                          # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
     termination_policies          = []                          # A list of policies to decide how the instances in the auto scale group should be terminated.
+    platform                      = "linux"                     # Platform of workers. either "linux" or "windows"
     # Settings for launch templates
     root_block_device_name            = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
     root_kms_key_id                   = ""                                       # The KMS key to use when encrypting the root storage device

--- a/templates/userdata_windows.tpl
+++ b/templates/userdata_windows.tpl
@@ -4,7 +4,6 @@ ${pre_userdata}
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
 [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
-[string]$cfn_signal = "$env:ProgramFiles\Amazon\cfn-bootstrap\cfn-signal.exe"
 & $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -KubeletExtraArgs '${kubelet_extra_args}' 3>&1 4>&1 5>&1 6>&1
 $LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
 

--- a/templates/userdata_windows.tpl
+++ b/templates/userdata_windows.tpl
@@ -1,0 +1,12 @@
+<powershell>
+${pre_userdata}
+
+[string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
+[string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
+[string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
+[string]$cfn_signal = "$env:ProgramFiles\Amazon\cfn-bootstrap\cfn-signal.exe"
+& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -KubeletExtraArgs '${kubelet_extra_args}' 3>&1 4>&1 5>&1 6>&1
+$LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
+
+${additional_userdata}
+</powershell>

--- a/templates/worker-role.tpl
+++ b/templates/worker-role.tpl
@@ -3,3 +3,6 @@
       groups:
         - system:bootstrappers
         - system:nodes
+        %{~ if platform == "windows" ~}
+        - eks:kube-proxy-windows
+        %{~ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -126,10 +126,22 @@ variable "worker_ami_name_filter" {
   default     = ""
 }
 
+variable "worker_ami_name_filter_windows" {
+  description = "Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used."
+  type        = string
+  default     = ""
+}
+
 variable "worker_ami_owner_id" {
   description = "The ID of the owner for the AMI to use for the AWS EKS workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft')."
   type        = string
   default     = "602401143452" // The ID of the owner of the official AWS EKS AMIs.
+}
+
+variable "worker_ami_owner_id_windows" {
+  description = "The ID of the owner for the AMI to use for the AWS EKS Windows workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft')."
+  type        = string
+  default     = "801119661308" // The ID of the owner of the official AWS EKS Windows AMIs.
 }
 
 variable "worker_additional_security_group_ids" {

--- a/workers.tf
+++ b/workers.tf
@@ -166,7 +166,7 @@ resource "aws_launch_configuration" "workers" {
   image_id = lookup(
     var.worker_groups[count.index],
     "ami_id",
-    local.workers_group_defaults["ami_id"],
+    lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"]) == "windows" ? local.default_ami_id_windows : local.default_ami_id_linux,
   )
   instance_type = lookup(
     var.worker_groups[count.index],

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -257,7 +257,7 @@ resource "aws_launch_template" "workers_launch_template" {
   image_id = lookup(
     var.worker_groups_launch_template[count.index],
     "ami_id",
-    local.workers_group_defaults["ami_id"],
+    lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"]) == "windows" ? local.default_ami_id_windows : local.default_ami_id_linux,
   )
   instance_type = lookup(
     var.worker_groups_launch_template[count.index],


### PR DESCRIPTION
# PR o'clock

## Description

[EKS Windows container support is generally available](https://aws.amazon.com/ko/blogs/aws/amazon-eks-windows-container-support-now-generally-available/) now. This PR adds support for Windows worker nodes, by adding `platform` variable as an worker config.

I also added `worker_ami_name_filter_windows` and `worker_ami_name_filter_windows_prefix` variables, because naming pattern of EKS optimized AMI for Windows are totally different from linux AMIs.

User-data scripts are came from the equivalent CloudFormation snippet: https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2019-10-08/amazon-eks-windows-nodegroup.yaml 


### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
