### PR TITLE
Remove region from vars mapping for kubeconfig

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -2,9 +2,6 @@ locals {
   worker_ami_name_filter = var.worker_ami_name_filter != "" ? var.worker_ami_name_filter : "amazon-eks-node-${var.cluster_version}-v*"
 }
 
-data "aws_region" "current" {
-}
-
 data "aws_iam_policy_document" "workers_assume_role_policy" {
   statement {
     sid = "EKSWorkerAssumeRole"
@@ -52,7 +49,6 @@ data "template_file" "kubeconfig" {
   vars = {
     kubeconfig_name           = local.kubeconfig_name
     endpoint                  = aws_eks_cluster.this.endpoint
-    region                    = data.aws_region.current.name
     cluster_auth_base64       = aws_eks_cluster.this.certificate_authority[0].data
     aws_authenticator_command = var.kubeconfig_aws_authenticator_command
     aws_authenticator_command_args = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? "        - ${join(


### PR DESCRIPTION
# PR o'clock

## Description

The template file data source was injecting a region variable that is not defined in the template. Once removed the variable the aws region data source was not used anywhere else, so it is removed as well.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
