### PR TITLE
Allow the userdata template to be replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - **Breaking:** Allow for specifying a custom AMI for the worker nodes. (by @bmcstdio)
-- Allow for replacing the full userdata text with a `userdata_template_file` template in `worker_groups` (by @snstanton)
+- Allow for replacing the full userdata text with a `userdata_template_file` template and `userdata_template_extra_args` in `worker_groups` (by @snstanton)
 - Write your awesome addition here (by @you)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - **Breaking:** Allow for specifying a custom AMI for the worker nodes. (by @bmcstdio)
+- Allow for replacing the full userdata text with a `custom_userdata` template in `worker_groups` (by @snstanton)
 - Write your awesome addition here (by @you)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - **Breaking:** Allow for specifying a custom AMI for the worker nodes. (by @bmcstdio)
-- Allow for replacing the full userdata text with a `custom_userdata` template in `worker_groups` (by @snstanton)
+- Allow for replacing the full userdata text with a `userdata_template_file` template in `worker_groups` (by @snstanton)
 - Write your awesome addition here (by @you)
 
 ### Changed

--- a/data.tf
+++ b/data.tf
@@ -108,12 +108,15 @@ data "template_file" "userdata" {
   template = lookup(
     var.worker_groups[count.index],
     "userdata_template_file",
-    lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"]) == "windows"
-    ? "${path.module}/templates/userdata_windows.tpl"
-    : "${path.module}/templates/userdata.sh.tpl"
+    file(
+      lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"]) == "windows"
+      ? "${path.module}/templates/userdata_windows.tpl"
+      : "${path.module}/templates/userdata.sh.tpl"
+    )
   )
 
   vars = merge({
+    platform            = lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"])
     cluster_name        = aws_eks_cluster.this.name
     endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
@@ -141,20 +144,25 @@ data "template_file" "userdata" {
     lookup(
       var.worker_groups[count.index],
       "userdata_template_extra_args",
-      var.workers_group_defaults["userdata_template_extra_args"]
+      local.workers_group_defaults["userdata_template_extra_args"]
     )
   )
 }
 
 data "template_file" "launch_template_userdata" {
   count = local.worker_group_launch_template_count
-  template = file(
-    lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"]) == "windows"
-    ? "${path.module}/templates/userdata_windows.tpl"
-    : "${path.module}/templates/userdata.sh.tpl"
+  template = lookup(
+    var.worker_groups_launch_template[count.index],
+    "userdata_template_file",
+    file(
+      lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"]) == "windows"
+      ? "${path.module}/templates/userdata_windows.tpl"
+      : "${path.module}/templates/userdata.sh.tpl"
+    )
   )
 
-  vars = {
+  vars = merge({
+    platform            = lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"])
     cluster_name        = aws_eks_cluster.this.name
     endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
@@ -178,7 +186,13 @@ data "template_file" "launch_template_userdata" {
       "kubelet_extra_args",
       local.workers_group_defaults["kubelet_extra_args"],
     )
-  }
+    },
+    lookup(
+      var.worker_groups_launch_template[count.index],
+      "userdata_template_extra_args",
+      local.workers_group_defaults["userdata_template_extra_args"]
+    )
+  )
 }
 
 data "aws_iam_role" "custom_cluster_iam_role" {

--- a/data.tf
+++ b/data.tf
@@ -117,7 +117,11 @@ data "template_file" "userdata" {
       local.workers_group_defaults["kubelet_extra_args"],
     )
     },
-  lookup(var.worker_groups[count.index], "userdata_template_extra_args", {}))
+    lookup(
+      var.worker_groups[count.index],
+      "userdata_template_extra_args",
+      local.workers_group_defaults["userdata_template_extra_args"]
+  ))
 }
 
 data "template_file" "launch_template_userdata" {

--- a/data.tf
+++ b/data.tf
@@ -108,9 +108,9 @@ data "template_file" "userdata" {
   template = lookup(
     var.worker_groups[count.index],
     "userdata_template_file",
-    lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"]) == "windows" ?
-    "${path.module}/templates/userdata_windows.tpl" :
-    "${path.module}/templates/userdata.sh.tpl")
+    lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"]) == "windows"
+    ? "${path.module}/templates/userdata_windows.tpl"
+    : "${path.module}/templates/userdata.sh.tpl"
   )
 
   vars = merge({
@@ -141,16 +141,17 @@ data "template_file" "userdata" {
     lookup(
       var.worker_groups[count.index],
       "userdata_template_extra_args",
-      local.workers_group_defaults["userdata_template_extra_args"]
-  ))
+      var.workers_group_defaults["userdata_template_extra_args"]
+    )
+  )
 }
 
 data "template_file" "launch_template_userdata" {
   count = local.worker_group_launch_template_count
   template = file(
-    lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"]) == "windows" ?
-      "${path.module}/templates/userdata_windows.tpl" :
-      "${path.module}/templates/userdata.sh.tpl")
+    lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"]) == "windows"
+    ? "${path.module}/templates/userdata_windows.tpl"
+    : "${path.module}/templates/userdata.sh.tpl"
   )
 
   vars = {

--- a/data.tf
+++ b/data.tf
@@ -89,7 +89,7 @@ EOF
 }
 
 data "template_file" "userdata" {
-  count    = local.worker_group_count
+  count = local.worker_group_count
   template = lookup(
     var.worker_groups[count.index],
     "custom_userdata",

--- a/data.tf
+++ b/data.tf
@@ -88,7 +88,7 @@ data "template_file" "userdata" {
   count = local.worker_group_count
   template = lookup(
     var.worker_groups[count.index],
-    "custom_userdata",
+    "userdata_template_file",
     file("${path.module}/templates/userdata.sh.tpl")
   )
 

--- a/data.tf
+++ b/data.tf
@@ -92,7 +92,7 @@ data "template_file" "userdata" {
     file("${path.module}/templates/userdata.sh.tpl")
   )
 
-  vars = {
+  vars = merge({
     cluster_name        = aws_eks_cluster.this.name
     endpoint            = aws_eks_cluster.this.endpoint
     cluster_auth_base64 = aws_eks_cluster.this.certificate_authority[0].data
@@ -116,7 +116,8 @@ data "template_file" "userdata" {
       "kubelet_extra_args",
       local.workers_group_defaults["kubelet_extra_args"],
     )
-  }
+    },
+  lookup(var.worker_groups[count.index], "userdata_template_extra_args", {}))
 }
 
 data "template_file" "launch_template_userdata" {

--- a/data.tf
+++ b/data.tf
@@ -90,7 +90,11 @@ EOF
 
 data "template_file" "userdata" {
   count    = local.worker_group_count
-  template = file("${path.module}/templates/userdata.sh.tpl")
+  template = lookup(
+    var.worker_groups[count.index],
+    "custom_userdata",
+    file("${path.module}/templates/userdata.sh.tpl")
+  )
 
   vars = {
     cluster_name        = aws_eks_cluster.this.name

--- a/local.tf
+++ b/local.tf
@@ -37,6 +37,7 @@ locals {
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                          # The key name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
+    custom_userdata               = ""                          # alternate template to use for userdata
     bootstrap_extra_args          = ""                          # Extra arguments passed to the bootstrap.sh script from the EKS AMI (Amazon Machine Image).
     additional_userdata           = ""                          # userdata to append to the default userdata.
     ebs_optimized                 = true                        # sets whether to use ebs optimization on supported types.

--- a/local.tf
+++ b/local.tf
@@ -37,7 +37,7 @@ locals {
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                          # The key name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
-    custom_userdata               = ""                          # alternate template to use for userdata
+    userdata_template_file        = ""                          # alternate template to use for userdata
     bootstrap_extra_args          = ""                          # Extra arguments passed to the bootstrap.sh script from the EKS AMI (Amazon Machine Image).
     additional_userdata           = ""                          # userdata to append to the default userdata.
     ebs_optimized                 = true                        # sets whether to use ebs optimization on supported types.

--- a/local.tf
+++ b/local.tf
@@ -38,6 +38,7 @@ locals {
     key_name                      = ""                          # The key name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
     userdata_template_file        = ""                          # alternate template to use for userdata
+    userdata_template_extra_args  = {}                          # Additional arguments to use when expanding the userdata template file
     bootstrap_extra_args          = ""                          # Extra arguments passed to the bootstrap.sh script from the EKS AMI (Amazon Machine Image).
     additional_userdata           = ""                          # userdata to append to the default userdata.
     ebs_optimized                 = true                        # sets whether to use ebs optimization on supported types.


### PR DESCRIPTION
# PR o'clock

## Description

This addresses issue #564 

Adds a `custom_userdata` property to `worker_groups` that can be used to override the full userdata template file.

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
