### PR TITLE
Increase minimum terraform version to include yamlencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 -  **Breaking:** The `kubectl` configuration file can now be fully-specified using `config_output_path`. Previously it was assumed that `config_output_path` referred to a directory and always ended with a forward slash. This is a breaking change if `config_output_path` does **not** end with a forward slash (which was advised against by the documentation).
 - Changed logic for setting default ebs_optimized to only require maintaining a list of instance types that don't support it (by @jeffmhastings)
+- Bumped minimum terraform version to 0.12.2 to prevent an error on yamlencode function (by @toadjaune)
 
 # History
 

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.2"
 }
 
 provider "aws" {

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.2"
 }
 
 provider "aws" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.2"
 
   required_providers {
     aws      = ">= 2.31.0"


### PR DESCRIPTION
https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#0122-june-12-2019

# PR o'clock

## Description

Bump minimum terraform version in order to avoid the following errors :
```
Error: Call to unknown function

  on .terraform/modules/my-cluster/terraform-aws-modules-terraform-aws-eks-1be1a02/aws_auth.tf line 82, in data "template_file" "config_map_aws_auth":
  82:     map_users    = yamlencode(var.map_users),

There is no function named "yamlencode".


Error: Call to unknown function

  on .terraform/modules/my-cluster/terraform-aws-modules-terraform-aws-eks-1be1a02/aws_auth.tf line 83, in data "template_file" "config_map_aws_auth":
  83:     map_roles    = yamlencode(var.map_roles),

There is no function named "yamlencode".


Error: Call to unknown function

  on .terraform/modules/my-cluster/terraform-aws-modules-terraform-aws-eks-1be1a02/aws_auth.tf line 84, in data "template_file" "config_map_aws_auth":
  84:     map_accounts = yamlencode(var.map_accounts)

There is no function named "yamlencode".
```

### Checklist

- [ ] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [x] CI tests are passing
- [ ] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
