### PR TITLE
Attach EBS volumes to worker nodes #233

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 -  **Breaking:** The `kubectl` configuration file can now be fully-specified using `config_output_path`. Previously it was assumed that `config_output_path` referred to a directory and always ended with a forward slash. This is a breaking change if `config_output_path` does **not** end with a forward slash (which was advised against by the documentation).
 - Changed logic for setting default ebs_optimized to only require maintaining a list of instance types that don't support it (by @jeffmhastings)
+- Changed ASG `launch_configuration` parameter to allow external LC per worker groups. 
 
 # History
 

--- a/workers.tf
+++ b/workers.tf
@@ -42,7 +42,7 @@ resource "aws_autoscaling_group" "workers" {
     "service_linked_role_arn",
     local.workers_group_defaults["service_linked_role_arn"],
   )
-  launch_configuration = aws_launch_configuration.workers.*.id[count.index]
+  launch_configuration = lookup(var.worker_groups[count.index], "launch_configuration", element(aws_launch_configuration.workers.*.id, count.index))
   vpc_zone_identifier = lookup(
     var.worker_groups[count.index],
     "subnets",


### PR DESCRIPTION
# PR o'clock

## Description

This PR updates functionality of ASG to allow external Launch Configuration to be used rather than one provided by module. 
This was requested in #233 

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/*` directories
- [ ] CI tests are passing
- [x] I've added my change to CHANGELOG.md and highlighted any breaking changes
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
