### PR TITLE
Add Action check against minimum versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - name: TFLint
         uses: docker://wata727/tflint
-  
+
   fmt:
     name: Code Format
     runs-on: ubuntu-latest
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - run: terraform fmt --recursive -check=true
-  
+
   docs:
     name: Docs
     runs-on: macOS-latest
@@ -51,3 +51,19 @@ jobs:
             terraform validate
             cd -
           done
+
+  minimum:
+    name: Minimum version check
+    runs-on: ubuntu-latest
+    container:
+      image: hashicorp/terraform:0.12.2
+    steps:
+      - uses: actions/checkout@master
+      - name: Validate Code
+        env:
+          AWS_REGION: 'us-east-1'
+          TF_WARN_OUTPUT_ERRORS: 1
+        run: |
+          sed -i -e 's/>=/=/' -e 's/ \(\d\+\.\d\+\)"/ \1.0"/' versions.tf
+          terraform init
+          terraform validate -var "region=${AWS_REGION}" -var "vpc_id=vpc-123456" -var "subnets=[\"subnet-12345a\"]" -var "workers_ami_id=ami-123456" -var "cluster_ingress_cidrs=[]" -var "cluster_name=test_cluster"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Write your awesome addition here (by @you)
+- Test against minimum versions specified in `versions.tf` (by @dpiddockcmp)
 
 ### Changed
 


### PR DESCRIPTION
# PR o'clock

## Description

Add a Github Action check to try to validation the minimum versions listed. This won't catch everything but it does catch the two recent cases:
- `yamlencode()` use from terraform 0.12.2 #570 
- tags on `aws_eks_cluster` in aws 2.31.0 #550 

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
