### PR TITLE
Update worker_iam_instance_profile outputs for launch template use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Write your awesome change here (by @you)
+- Updated instance_profile_names and instance_profile_arns outputs to also consider launch template as well as asg (by @ankitwal)
 
 # History
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -114,12 +114,18 @@ output "worker_security_group_id" {
 
 output "worker_iam_instance_profile_arns" {
   description = "default IAM instance profile ARN for EKS worker groups"
-  value       = aws_iam_instance_profile.workers.*.arn
+  value = concat(
+    aws_iam_instance_profile.workers.*.arn,
+    aws_iam_instance_profile.workers_launch_template.*.arn
+  )
 }
 
 output "worker_iam_instance_profile_names" {
   description = "default IAM instance profile name for EKS worker groups"
-  value       = aws_iam_instance_profile.workers.*.name
+  value = concat(
+    aws_iam_instance_profile.workers.*.name,
+    aws_iam_instance_profile.workers_launch_template.*.name
+  )
 }
 
 output "worker_iam_role_name" {


### PR DESCRIPTION
# PR o'clock

## Description

The worker_iam_instance_profile_names, and worker_iam_instance_profile_arns would not give expected results is the EKS Cluster is created with worker_groups_launch_template or mixed options. Added concat list to output so they give results in case cluster is created with mixed or worker_group_launch_template properties. 

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
