### PR TITLE
Userdata parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Test against minimum versions specified in `versions.tf` (by @dpiddockcmp)
+- Added support for customizing userdata with `userdata_parts` list in `worker_groups` and `worker_groups_launch_template` (by @thomas_brx)
 
 ### Changed
 

--- a/data.tf
+++ b/data.tf
@@ -217,3 +217,25 @@ data "aws_iam_instance_profile" "custom_worker_group_launch_template_iam_instanc
     local.workers_group_defaults["iam_instance_profile_name"],
   )
 }
+
+data "template_cloudinit_config" "worker_group_cloudinit_config" {
+  count         = local.worker_group_count
+  base64_encode = true
+  gzip          = false
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = data.template_file.userdata.*.rendered[count.index]
+  }
+}
+
+data "template_cloudinit_config" "worker_group_launch_template_cloudinit_config" {
+  count         = local.worker_group_launch_template_count
+  base64_encode = true
+  gzip          = false
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = data.template_file.launch_template_userdata.*.rendered[count.index]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -227,6 +227,20 @@ data "template_cloudinit_config" "worker_group_cloudinit_config" {
     content_type = "text/x-shellscript"
     content      = data.template_file.userdata.*.rendered[count.index]
   }
+
+  dynamic "part" {
+    for_each = lookup(
+      var.worker_groups[count.index],
+      "userdata_parts",
+      local.workers_group_defaults["userdata_parts"],
+    )
+    content {
+      content      = lookup(part.value, "content", null)
+      content_type = lookup(part.value, "content_type", null)
+      filename     = lookup(part.value, "filename", null)
+      merge_type   = lookup(part.value, "merge_type", null)
+    }
+  }
 }
 
 data "template_cloudinit_config" "worker_group_launch_template_cloudinit_config" {
@@ -237,5 +251,19 @@ data "template_cloudinit_config" "worker_group_launch_template_cloudinit_config"
   part {
     content_type = "text/x-shellscript"
     content      = data.template_file.launch_template_userdata.*.rendered[count.index]
+  }
+
+  dynamic "part" {
+    for_each = lookup(
+      var.worker_groups_launch_template[count.index],
+      "userdata_parts",
+      local.workers_group_defaults["userdata_parts"],
+    )
+    content {
+      content      = lookup(part.value, "content", null)
+      content_type = lookup(part.value, "content_type", null)
+      filename     = lookup(part.value, "filename", null)
+      merge_type   = lookup(part.value, "merge_type", null)
+    }
   }
 }

--- a/local.tf
+++ b/local.tf
@@ -42,6 +42,7 @@ locals {
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
     userdata_template_file        = ""                          # alternate template to use for userdata
     userdata_template_extra_args  = {}                          # Additional arguments to use when expanding the userdata template file
+    userdata_parts                = []                          # List of additional userdata parts as defined in template_cloudinit_config.
     bootstrap_extra_args          = ""                          # Extra arguments passed to the bootstrap.sh script from the EKS AMI (Amazon Machine Image).
     additional_userdata           = ""                          # userdata to append to the default userdata.
     ebs_optimized                 = true                        # sets whether to use ebs optimization on supported types.

--- a/workers.tf
+++ b/workers.tf
@@ -178,7 +178,7 @@ resource "aws_launch_configuration" "workers" {
     "key_name",
     local.workers_group_defaults["key_name"],
   )
-  user_data_base64 = base64encode(data.template_file.userdata.*.rendered[count.index])
+  user_data_base64 = data.template_cloudinit_config.worker_group_cloudinit_config.*.rendered[count.index]
   ebs_optimized = lookup(
     var.worker_groups[count.index],
     "ebs_optimized",

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -269,9 +269,7 @@ resource "aws_launch_template" "workers_launch_template" {
     "key_name",
     local.workers_group_defaults["key_name"],
   )
-  user_data = base64encode(
-    data.template_file.launch_template_userdata.*.rendered[count.index],
-  )
+  user_data = data.template_cloudinit_config.worker_group_launch_template_cloudinit_config.*.rendered[count.index]
 
   ebs_optimized = lookup(
     var.worker_groups_launch_template[count.index],


### PR DESCRIPTION
# PR o'clock

## Description

Support added for `userdata_parts` in both `worker_groups` and `worker_groups_launch_template`. This changes the `user_data` to use [multipart MIME configuration](https://www.terraform.io/docs/providers/template/d/cloudinit_config.html), instead of a single script.

This allows for a finer control of all the phases of cloud-init.
```
 worker_groups = [
    {
      ...
      userdata_parts = [
        {
          content_type = "text/cloud-config"
          filename = "cloud-config"
          merge_type = "list(append)+dict(recurse_array)+str()"

          content = <<CLOUD_CONFIG
packages:
  - strace

bootcmd:
  - echo "ENVIROMNET=${var.environment}" >> /etc/environment
CLOUD_CONFIG
        },
      ]
    }
  ]
```
### Checklist

- [X] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
