### PR TITLE
Add the 'create_cluster' variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Test against minimum versions specified in `versions.tf` (by @dpiddockcmp)
+- Allow for conditionally creating the AWS EKS cluster and associated resources via `create_cluster` (by @bmcstdio)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers | string | `""` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.14"` | no |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | string | `"./"` | no |
+| create\_cluster | Whether to actually create the AWS EKS cluster and the associated resources (can be thought of as a 'count' attribute). | bool | `"true"` | no |
 | iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list(string) | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,6 +1,6 @@
 resource "local_file" "kubeconfig" {
-  count    = var.write_kubeconfig ? 1 : 0
-  content  = data.template_file.kubeconfig.rendered
+  count    = var.create_cluster && var.write_kubeconfig ? 1 : 0
+  content  = data.template_file.kubeconfig.0.rendered
   filename = "${substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path}"
 }
 

--- a/local.tf
+++ b/local.tf
@@ -19,8 +19,8 @@ locals {
   worker_group_count                 = length(var.worker_groups)
   worker_group_launch_template_count = length(var.worker_groups_launch_template)
 
-  default_ami_id_linux   = data.aws_ami.eks_worker.id
-  default_ami_id_windows = data.aws_ami.eks_worker_windows.id
+  default_ami_id_linux   = data.aws_ami.eks_worker.0.id
+  default_ami_id_windows = data.aws_ami.eks_worker_windows.0.id
 
   workers_group_defaults_defaults = {
     name                          = "count.index"               # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
@@ -62,14 +62,14 @@ locals {
     termination_policies          = []                          # A list of policies to decide how the instances in the auto scale group should be terminated.
     platform                      = "linux"                     # Platform of workers. either "linux" or "windows"
     # Settings for launch templates
-    root_block_device_name            = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
-    root_kms_key_id                   = ""                                       # The KMS key to use when encrypting the root storage device
-    launch_template_version           = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
-    launch_template_placement_tenancy = "default"                                # The placement tenancy for instances
-    launch_template_placement_group   = ""                                       # The name of the placement group into which to launch the instances, if any.
-    root_encrypted                    = ""                                       # Whether the volume should be encrypted or not
-    eni_delete                        = true                                     # Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying)
-    cpu_credits                       = "standard"                               # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
+    root_block_device_name            = data.aws_ami.eks_worker.0.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
+    root_kms_key_id                   = ""                                         # The KMS key to use when encrypting the root storage device
+    launch_template_version           = "$Latest"                                  # The lastest version of the launch template to use in the autoscaling group
+    launch_template_placement_tenancy = "default"                                  # The placement tenancy for instances
+    launch_template_placement_group   = ""                                         # The name of the placement group into which to launch the instances, if any.
+    root_encrypted                    = ""                                         # Whether the volume should be encrypted or not
+    eni_delete                        = true                                       # Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying)
+    cpu_credits                       = "standard"                                 # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     market_type                       = null
     # Settings for launch templates with mixed instances policy
     override_instance_types                  = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"] # A list of override instance types for mixed instances policy

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,26 +1,26 @@
 output "cluster_id" {
   description = "The name/id of the EKS cluster."
-  value       = aws_eks_cluster.this.id
+  value       = aws_eks_cluster.this.0.id
 }
 
 output "cluster_arn" {
   description = "The Amazon Resource Name (ARN) of the cluster."
-  value       = aws_eks_cluster.this.arn
+  value       = aws_eks_cluster.this.0.arn
 }
 
 output "cluster_certificate_authority_data" {
   description = "Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster."
-  value       = aws_eks_cluster.this.certificate_authority[0].data
+  value       = aws_eks_cluster.this.0.certificate_authority[0].data
 }
 
 output "cluster_endpoint" {
   description = "The endpoint for your EKS Kubernetes API."
-  value       = aws_eks_cluster.this.endpoint
+  value       = aws_eks_cluster.this.0.endpoint
 }
 
 output "cluster_version" {
   description = "The Kubernetes server version for the EKS cluster."
-  value       = aws_eks_cluster.this.version
+  value       = aws_eks_cluster.this.0.version
 }
 
 output "cluster_security_group_id" {
@@ -30,7 +30,7 @@ output "cluster_security_group_id" {
 
 output "config_map_aws_auth" {
   description = "A kubernetes configuration to authenticate to this EKS cluster."
-  value       = data.template_file.config_map_aws_auth.rendered
+  value       = data.template_file.config_map_aws_auth.0.rendered
 }
 
 output "cluster_iam_role_name" {
@@ -45,7 +45,7 @@ output "cluster_iam_role_arn" {
 
 output "cluster_oidc_issuer_url" {
   description = "The URL on the EKS cluster OIDC Issuer"
-  value       = concat(aws_eks_cluster.this.identity.*.oidc.0.issuer, [""])[0]
+  value       = concat(aws_eks_cluster.this.0.identity.*.oidc.0.issuer, [""])[0]
 }
 
 output "cloudwatch_log_group_name" {
@@ -55,7 +55,7 @@ output "cloudwatch_log_group_name" {
 
 output "kubeconfig" {
   description = "kubectl config file contents for this EKS cluster."
-  value       = data.template_file.kubeconfig.rendered
+  value       = data.template_file.kubeconfig.0.rendered
 }
 
 output "kubeconfig_filename" {
@@ -89,7 +89,7 @@ output "workers_user_data" {
 
 output "workers_default_ami_id" {
   description = "ID of the default worker group AMI"
-  value       = data.aws_ami.eks_worker.id
+  value       = data.aws_ami.eks_worker.0.id
 }
 
 output "workers_launch_template_ids" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "config_output_path" {
   default     = "./"
 }
 
+variable "create_cluster" {
+  default     = true
+  description = "Whether to actually create the AWS EKS cluster and the associated resources (can be thought of as a 'count' attribute)."
+  type        = bool
+}
+
 variable "write_kubeconfig" {
   description = "Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`."
   type        = bool


### PR DESCRIPTION
# PR o'clock

## Description

Sometimes one needs to have a way to create an AWS EKS cluster conditionally, but Terraform does not allow the usage of `count` inside a `module` block. The workaround (inspired by [`terraform-aws-vpc`](https://github.com/terraform-aws-modules/terraform-aws-vpc#conditional-creation)) is to support a `create_cluster` variable which can be set to `false` to disable the creation of the AWS EKS cluster and its associated resources.

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
