### PR TITLE
Run aws-auth Update Commands in Sequence and not Parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Updated instance_profile_names and instance_profile_arns outputs to also consider launch template as well as asg (by @ankitwal)
+- Updated application of `aws-auth` configmap to create `kube_config.yaml` and `aws_auth_configmap.yaml` in sequence (and not parallel) to `kubectl apply` (by @knittingdev)
+- Exit with error code when `aws-auth` configmap is unable to be updated (by @knittingdev)
 
 # History
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -12,13 +12,16 @@ resource "null_resource" "update_config_map_aws_auth" {
     working_dir = path.module
 
     command = <<EOS
+completed_apply=0
 for i in `seq 1 10`; do \
-echo "${null_resource.update_config_map_aws_auth[0].triggers.kube_config_map_rendered}" > kube_config.yaml & \
-echo "${null_resource.update_config_map_aws_auth[0].triggers.config_map_rendered}" > aws_auth_configmap.yaml & \
-kubectl apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && break || \
+echo "${null_resource.update_config_map_aws_auth[0].triggers.kube_config_map_rendered}" > kube_config.yaml && \
+echo "${null_resource.update_config_map_aws_auth[0].triggers.config_map_rendered}" > aws_auth_configmap.yaml && \
+kubectl apply -f aws_auth_configmap.yaml --kubeconfig kube_config.yaml && \
+completed_apply=1 && break || \
 sleep 10; \
 done; \
 rm aws_auth_configmap.yaml kube_config.yaml;
+if [ "$completed_apply" = "0" ]; then exit 1; fi;
 EOS
 
 


### PR DESCRIPTION
# PR o'clock

## Description

As mentioned in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/591
The current script utilized to update the `aws-auth` ConfigMap runs the creation of the `kube_config.yaml` and `aws_auth_configmap.yaml` in parallel to the `kubectl apply` command being run. 

As mentioned in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/341
Upon failure, the current script does not provide an exit code. 

This PR seeks to solve both of these issues.

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] ~README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation~ Not Applicable
