### PR TITLE
Fix deprecated interpolation-only expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Updated instance_profile_names and instance_profile_arns outputs to also consider launch template as well as asg (by @ankitwal)
+- Fix deprecated interpolation-only expression (by @angelabad)
 
 # History
 

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,6 +1,6 @@
 resource "local_file" "kubeconfig" {
   count    = var.write_kubeconfig ? 1 : 0
   content  = data.template_file.kubeconfig.rendered
-  filename = "${substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path}"
+  filename = substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

Fix warning with interpolation-only expresions with terraform 0.12.14,

fixes #593

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
