### PR TITLE
remove Warning: Interpolation-only expressions are deprecated

### DIFF
--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,6 +1,6 @@
 resource "local_file" "kubeconfig" {
   count    = var.write_kubeconfig ? 1 : 0
   content  = data.template_file.kubeconfig.rendered
-  filename = "${substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path}"
+  filename = substr(var.config_output_path, -1, 1) == "/" ? format("%skubeconfig_%s", var.config_output_path, var.cluster_name) : var.config_output_path
 }
 


### PR DESCRIPTION

# PR o'clock

## Description

This removes the following deprecated warning that was introduced around 0.12.13 or .14

```
➜  prod git:(master) ✗ terraform validate

Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/eks.eks/terraform-aws-modules-terraform-aws-eks-55ff38c/kubectl.tf line 4, in resource "local_file" "kubeconfig":
   4:   filename = "${substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
