### PR TITLE
Fix broken terraform plan/apply on a cluster < 1.14 (Fix #582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updated instance_profile_names and instance_profile_arns outputs to also consider launch template as well as asg (by @ankitwal)
 - Fix deprecated interpolation-only expression (by @angelabad)
+- Fix broken terraform plan/apply on a cluster < 1.14 (by @hodduc)
 
 # History
 

--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,10 @@
 locals {
-  worker_ami_name_filter         = var.worker_ami_name_filter != "" ? var.worker_ami_name_filter : "amazon-eks-node-${var.cluster_version}-v*"
-  worker_ami_name_filter_windows = var.worker_ami_name_filter_windows != "" ? var.worker_ami_name_filter_windows : "Windows_Server-2019-English-Core-EKS_Optimized-${var.cluster_version}-*"
+  worker_ami_name_filter = var.worker_ami_name_filter != "" ? var.worker_ami_name_filter : "amazon-eks-node-${var.cluster_version}-v*"
+
+  # Windows nodes are available from k8s 1.14. If cluster version is less than 1.14, fix ami filter to some constant to not fail on 'terraform plan'.
+  worker_ami_name_filter_windows = (var.worker_ami_name_filter_windows != "" ?
+    var.worker_ami_name_filter_windows : "Windows_Server-2019-English-Core-EKS_Optimized-${tonumber(var.cluster_version) >= 1.14 ? var.cluster_version : 1.14}-*"
+  )
 }
 
 data "aws_iam_policy_document" "workers_assume_role_policy" {


### PR DESCRIPTION
# PR o'clock

## Description

Fix issue #582. I followed suggestion [here](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/582#issuecomment-550387472) with some modification.

Also, I checked every AWS region to check existence of that image.
```
aws ec2 describe-images --owners 801119661308 --filters "Name=platform,Values=windows" "Name=name,Values=Windows_Server-2019-English-Core-EKS_Optimized-1.14-*" --region=$region | jq '.Images | .[] | [.Name, .ImageId, .CreationDate]'
```

Results: `Windows_Server-2019-English-Core-EKS_Optimized-1.14-*` AMI exists on all regions except ca-central-1 and us-west-1. But EKS is not available on ca-central-1 & us-west-1, so this is OK.


### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
