### PR TITLE
remove empty [] to mapRoles object in aws-auth

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -53,7 +53,7 @@ resource "kubernetes_config_map" "aws_auth" {
   data = {
     mapRoles    = <<EOF
 ${join("", distinct(concat(data.template_file.launch_template_worker_role_arns.*.rendered, data.template_file.worker_role_arns.*.rendered)))}
-${yamlencode(var.map_roles)}
+%{if var.map_roles == []}${yamlencode(var.map_roles)}%{endif}
     EOF
     mapUsers    = yamlencode(var.map_users)
     mapAccounts = yamlencode(var.map_accounts)

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -53,7 +53,7 @@ resource "kubernetes_config_map" "aws_auth" {
   data = {
     mapRoles    = <<EOF
 ${join("", distinct(concat(data.template_file.launch_template_worker_role_arns.*.rendered, data.template_file.worker_role_arns.*.rendered)))}
-%{if var.map_roles == []}${yamlencode(var.map_roles)}%{endif}
+%{if var.map_roles != []}${yamlencode(var.map_roles)}%{endif}
     EOF
     mapUsers    = yamlencode(var.map_users)
     mapAccounts = yamlencode(var.map_accounts)


### PR DESCRIPTION
Simply having ${yamlencode(var.map_roles)} in mapRoles for aws-auth creates a empty [] at the end after adding the default roles.
Changing it to be added only when its not empty

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
