### PR TITLE
Revert recent changes to aws-auth.tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Test against minimum versions specified in `versions.tf` (by @dpiddockcmp)
 - Support for AWS EKS Managed Node Groups. (by @wmorgan6796)
 - Updated instance_profile_names and instance_profile_arns outputs to also consider launch template as well as asg (by @ankitwal)
-- Added a if check on `aws-auth` configmap when map_roles is empty. 
 - **Breaking:** Configure the aws-auth configmap using the terraform kubernetes providers. Read the [docs](docs/upgrading-to-aws-auth-kubernetes-provider.md) for more info (by @sdehaes)
 - Updated application of `aws-auth` configmap to create `kube_config.yaml` and `aws_auth_configmap.yaml` in sequence (and not parallel) to `kubectl apply` (by @knittingdev)
 - Exit with error code when `aws-auth` configmap is unable to be updated (by @knittingdev)

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -53,7 +53,7 @@ resource "kubernetes_config_map" "aws_auth" {
   data = {
     mapRoles    = <<EOF
 ${join("", distinct(concat(data.template_file.launch_template_worker_role_arns.*.rendered, data.template_file.worker_role_arns.*.rendered)))}
-%{if var.map_roles != []}${yamlencode(var.map_roles)}%{endif}
+${yamlencode(var.map_roles)}
     EOF
     mapUsers    = yamlencode(var.map_users)
     mapAccounts = yamlencode(var.map_accounts)

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -53,7 +53,7 @@ resource "kubernetes_config_map" "aws_auth" {
   data = {
     mapRoles    = <<EOF
 ${join("", distinct(concat(data.template_file.launch_template_worker_role_arns.*.rendered, data.template_file.worker_role_arns.*.rendered)))}
-%{if var.map_roles == []}${yamlencode(var.map_roles)}%{endif}
+%{if var.map_roles != []}${yamlencode(var.map_roles)}%{endif}
     EOF
     mapUsers    = yamlencode(var.map_users)
     mapAccounts = yamlencode(var.map_accounts)


### PR DESCRIPTION
# PR o'clock

## Description

This logic is broken. Looks like there's a Terraform bug related to not handling complex Object types. https://github.com/hashicorp/terraform/issues/23562

Revert to the previous state instead of wiping out roles from aws-auth ConfigMaps.

See https://github.com/terraform-aws-modules/terraform-aws-eks/pull/606#issuecomment-562658290

Another solution needs to be found for @shanmugakarna 's use case.

### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
