### PR TITLE
Bump minimum Terraform to 0.12.9

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
     name: Minimum version check
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:0.12.6
+      image: hashicorp/terraform:0.12.9
     steps:
       - uses: actions/checkout@master
       - name: Validate Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fix deprecated interpolation-only expression (by @angelabad)
 - Fix broken terraform plan/apply on a cluster < 1.14 (by @hodduc)
 - Updated required version of AWS Provider to >= v2.38.0 for Managed Node Groups (by @wmorgan6796)
+- Updated minimum version of Terraform to avoid a bug (by @dpiddockcmp)
 
 #### Important notes
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.9"
 
   required_providers {
     aws      = ">= 2.38.0"


### PR DESCRIPTION
# PR o'clock

## Description

Additions in #602 trigger a bug in older terraforms. It was fixed in 0.12.9.

```
Error: Invalid for_each set argument

  on ../../node_groups.tf line 30, in resource "aws_iam_role_policy_attachment" "node_groups_additional_policies":
  30:   for_each = toset(var.workers_additional_policies)

The given "for_each" argument value is unsuitable: "for_each" supports maps
and sets of strings, but you have provided a set containing type dynamic.
```

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
