### PR TITLE
remove empty [] to mapRoles in aws-auth (revised)

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -53,7 +53,7 @@ resource "kubernetes_config_map" "aws_auth" {
   data = {
     mapRoles    = <<EOF
 ${join("", distinct(concat(data.template_file.launch_template_worker_role_arns.*.rendered, data.template_file.worker_role_arns.*.rendered)))}
-%{if var.map_roles == []}${yamlencode(var.map_roles)}%{endif}
+%{if length(var.map_roles) != 0}${yamlencode(var.map_roles)}%{endif}
     EOF
     mapUsers    = yamlencode(var.map_users)
     mapAccounts = yamlencode(var.map_accounts)


### PR DESCRIPTION
# PR o'clock

## Description
Previous PRs (https://github.com/terraform-aws-modules/terraform-aws-eks/pull/606#issuecomment-562658290) to the same issue wiped out entire mapRoles from `aws-auth`
 
This is an alternative solution using `length()` function. See https://github.com/terraform-aws-modules/terraform-aws-eks/pull/614

Please, review PR https://github.com/terraform-aws-modules/terraform-aws-eks/pull/614 before merging this PR

### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
