### PR TITLE
Add IRSA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Updated minimum version of Terraform to avoid a bug (by @dpiddockcmp)
 - Fix cluster_oidc_issuer_url output from list to string (by @chewvader)
 - Fix idempotency issues for node groups with no remote_access configuration (by @jeffmhastings)
+- Added support to create IAM OpenID Connect Identity Provider to enable EKS Identity Roles for Service Accounts (IRSA). (by @alaa)
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.14"` | no |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | string | `"./"` | no |
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | bool | `"true"` | no |
+| eks\_oidc\_root\_ca\_thumbprint | Thumbprint of Root CA for EKS OIDC, Valid until 2037 | string | `"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"` | no |
+| enable\_irsa | Whether to create OpenID Connect Provider for EKS to enable IRSA | bool | `"false"` | no |
 | iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list(string) | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |

--- a/irsa.tf
+++ b/irsa.tf
@@ -1,0 +1,15 @@
+# Enable IAM Roles for EKS Service-Accounts (IRSA).
+
+# The Root CA Thumbprint for an OpenID Connect Identity Provider is currently
+# Being passed as a default value which is the same for all regions and
+# Is valid until (Jun 28 17:39:16 2034 GMT).
+# https://crt.sh/?q=9E99A48A9960B14926BB7F3B02E22DA2B0AB7280
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+# https://github.com/terraform-providers/terraform-provider-aws/issues/10104
+
+resource "aws_iam_openid_connect_provider" "oidc_provider" {
+  count           = var.enable_irsa ? 1 : 0
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [var.eks_oidc_root_ca_thumbprint]
+  url             = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -299,3 +299,15 @@ variable "node_groups" {
   type        = any
   default     = []
 }
+
+variable "enable_irsa" {
+  description = "Whether to create OpenID Connect Provider for EKS to enable IRSA"
+  type        = bool
+  default     = false
+}
+
+variable "eks_oidc_root_ca_thumbprint" {
+  type        = string
+  description = "Thumbprint of Root CA for EKS OIDC, Valid until 2037"
+  default     = "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"
+}


### PR DESCRIPTION
# PR o'clock

## Description

Added support to create IAM OpenID Connect Identity Provider to enable EKS Identity Roles for Service Accounts (IRSA).

This should address the issue in TF: https://github.com/terraform-providers/terraform-provider-aws/issues/10104


### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
