### PR TITLE
Wait cluster responsive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[v8.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v7.0.0...HEAD)] - 2019-??-??]
 
+- Wait for cluster to respond to kubectl before applying auth map_config (@shaunc)
 - Added flag `create_eks` to conditionally create resources (by @syst0m / @tbeijen)
 - Support for AWS EKS Managed Node Groups. (by @wmorgan6796)
 - Added a if check on `aws-auth` configmap when `map_roles` is empty (by @shanmugakarna)

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -63,7 +63,7 @@ resource "null_resource" "wait_for_kubernetes" {
 
 resource "kubernetes_config_map" "aws_auth" {
   depends_on = [null_resource.wait_for_kubernetes]
-  count = var.create_eks && var.manage_aws_auth ? 1 : 0
+  count      = var.create_eks && var.manage_aws_auth ? 1 : 0
 
   metadata {
     name      = "aws-auth"

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -41,6 +41,7 @@ data "template_file" "worker_role_arns" {
     )
   }
 }
+<<<<<<< HEAD
 
 data "template_file" "node_group_arns" {
   count    = var.create_eks ? local.worker_group_managed_node_group_count : 0
@@ -52,6 +53,11 @@ data "template_file" "node_group_arns" {
   }
 }
 
+=======
+locals {
+  kubeconfig_filename = concat(local_file.kubeconfig.*.filename, [""])[0]
+}
+>>>>>>> fixup missing local for kubeconfig_filename
 resource "null_resource" "wait_for_kubernetes" {
   depends_on = [local_file.kubeconfig]
   provisioner "local-exec" {

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -41,7 +41,6 @@ data "template_file" "worker_role_arns" {
     )
   }
 }
-<<<<<<< HEAD
 
 data "template_file" "node_group_arns" {
   count    = var.create_eks ? local.worker_group_managed_node_group_count : 0
@@ -53,22 +52,8 @@ data "template_file" "node_group_arns" {
   }
 }
 
-=======
-locals {
-  kubeconfig_filename = concat(local_file.kubeconfig.*.filename, [""])[0]
-}
->>>>>>> fixup missing local for kubeconfig_filename
-resource "null_resource" "wait_for_kubernetes" {
-  depends_on = [local_file.kubeconfig]
-  provisioner "local-exec" {
-    command = <<EOT
-    until kubectl version --kubeconfig ${local.kubeconfig_filename} >/dev/null; do sleep 4; done
-  EOT
-  }
-}
-
 resource "kubernetes_config_map" "aws_auth" {
-  depends_on = [null_resource.wait_for_kubernetes]
+  depends_on = [aws_eks_cluster.this]
   count      = var.create_eks && var.manage_aws_auth ? 1 : 0
 
   metadata {

--- a/cluster.tf
+++ b/cluster.tf
@@ -31,6 +31,11 @@ resource "aws_eks_cluster" "this" {
     aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy,
     aws_cloudwatch_log_group.this
   ]
+  provisioner "local-exec" {
+    command = <<EOT
+    until curl -k ${aws_eks_cluster.this[0].endpoint}/healthz >/dev/null; do sleep 4; done
+  EOT
+  }
 }
 
 resource "aws_security_group" "cluster" {

--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,6 @@ terraform {
     null       = ">= 2.1"
     template   = ">= 2.1"
     random     = ">= 2.1"
-    kubernetes = "~> 1.10"
+    kubernetes = ">= 1.6.2"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,10 +2,11 @@ terraform {
   required_version = ">= 0.12.9"
 
   required_providers {
-    aws      = ">= 2.38.0"
-    local    = ">= 1.2"
-    null     = ">= 2.1"
-    template = ">= 2.1"
-    random   = ">= 2.1"
+    aws        = ">= 2.38.0"
+    local      = ">= 1.2"
+    null       = ">= 2.1"
+    template   = ">= 2.1"
+    random     = ">= 2.1"
+    kubernetes = "~> 1.10"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

I experience intermittent problems applying config_map as cluster is not immediately ready to respond to kubectl after create. This PR adds a null resource that sleeps until the cluster responds to kubectl.

### Checklist

- [X] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
