### PR TITLE
Adding node group iam role arns to outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fix cluster_oidc_issuer_url output from list to string (by @chewvader)
 - Fix idempotency issues for node groups with no remote_access configuration (by @jeffmhastings)
 - Added support to create IAM OpenID Connect Identity Provider to enable EKS Identity Roles for Service Accounts (IRSA). (by @alaa)
+- Adding node group iam role arns to outputs. (by @mukgupta)
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
+| node\_groups\_iam\_role\_arns | IAM role ARNs for EKS node groups |
 | worker\_autoscaling\_policy\_arn | ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
 | worker\_autoscaling\_policy\_name | Name of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |

--- a/outputs.tf
+++ b/outputs.tf
@@ -157,3 +157,11 @@ output "worker_autoscaling_policy_arn" {
   description = "ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true`"
   value       = concat(aws_iam_policy.worker_autoscaling[*].arn, [""])[0]
 }
+
+output "node_groups_iam_role_arns" {
+  description = "IAM role ARNs for EKS node groups"
+  value = {
+    for node_group in aws_eks_node_group.workers :
+    node_group.node_group_name => node_group.node_role_arn
+  }
+}


### PR DESCRIPTION
# PR o'clock

## Description

This PR adds the IAM role ARNs of node groups in the outputs in the form of a map

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
