### PR TITLE
[conceding to 653] add output for aws_iam_openid_connect_provider arn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fix aws-auth config map for managed node groups (by @wbertelsen)
 - Added support to create IAM OpenID Connect Identity Provider to enable EKS Identity Roles for Service Accounts (IRSA). (by @alaa)
 - Adding node group iam role arns to outputs. (by @mukgupta)
+- Adding `cluster_oidc_connect_provider_arn` to outputs. (by @jonathancolby-olx)
 - **Breaking:** Change logic of security group whitelisting. Will always whitelist worker security group on control plane security group either provide one or create new one. See Important notes below for upgrade notes (by @ryanooi)
 
 #### Important notes

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "my-cluster" {
 ```
 ## Conditional creation
 
-Sometimes you need to have a way to create EKS resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_eks`. 
+Sometimes you need to have a way to create EKS resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_eks`.
 
 Using this feature _and_ having `manage_aws_auth=true` (the default) requires to set up the kubernetes provider in a way that allows the data sources to not exist.
 
@@ -212,6 +212,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_iam\_role\_arn | IAM role ARN of the EKS cluster. |
 | cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
 | cluster\_id | The name/id of the EKS cluster. |
+| cluster\_oidc\_connect\_provider\_arn | The ARN of the IAM OpenID Connect provider |
 | cluster\_oidc\_issuer\_url | The URL on the EKS cluster OIDC Issuer |
 | cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
 | cluster\_version | The Kubernetes server version for the EKS cluster. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,11 @@ output "cluster_oidc_issuer_url" {
   value       = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
 }
 
+output "cluster_oidc_connect_provider_arn" {
+  description = "The ARN of the IAM OpenID Connect provider"
+  value       = flatten(concat(aws_iam_openid_connect_provider.oidc_provider[*].arn, [""]))[0]
+}
+
 output "cloudwatch_log_group_name" {
   description = "Name of cloudwatch log group created"
   value       = aws_cloudwatch_log_group.this[*].name


### PR DESCRIPTION
# PR o'clock

## Description

The OIDC provider ARN is required for the assume role policy as the "Federated" principal of the iam-for-pods role.  This change adds the OIDC provider ARN as a module output.

usage example:

```
data "aws_iam_policy_document" "this" {
  statement {
    actions = ["sts:AssumeRoleWithWebIdentity"]

    principals {
      type        = "Federated"
      identifiers = [module.eks.aws_iam_openid_connect_provider_arn]
    }
```

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [X] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [X] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
