### PR TITLE
Add the OIDC provider ARN to outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Fix aws-auth config map for managed node groups (by @wbertelsen)
 - Added support to create IAM OpenID Connect Identity Provider to enable EKS Identity Roles for Service Accounts (IRSA). (by @alaa)
 - Adding node group iam role arns to outputs. (by @mukgupta)
+- Added the OIDC Provider ARN to outputs. (by @eytanhanig)
 - **Breaking:** Change logic of security group whitelisting. Will always whitelist worker security group on control plane security group either provide one or create new one. See Important notes below for upgrade notes (by @ryanooi)
 
 #### Important notes

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
 | node\_groups\_iam\_role\_arns | IAM role ARNs for EKS node groups |
+| oidc\_provider\_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
 | worker\_autoscaling\_policy\_arn | ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
 | worker\_autoscaling\_policy\_name | Name of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,6 +63,11 @@ output "kubeconfig_filename" {
   value       = concat(local_file.kubeconfig.*.filename, [""])[0]
 }
 
+output "oidc_provider_arn" {
+  description = "The ARN of the OIDC Provider if `enable_irsa = true`."
+  value       = var.enable_irsa ? aws_iam_openid_connect_provider.oidc_provider[0].arn : null
+}
+
 output "workers_asg_arns" {
   description = "IDs of the autoscaling groups containing workers."
   value = concat(


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the [changes](url) you made here and link to any relevant issues.

This PR adds the OICD Provider ARN to outputs when `enable_irsa = true`. This needed when creating IAM policy documents/roles for Service Accounts, an example of which can be seen [here](https://www.terraform.io/docs/providers/aws/r/eks_cluster.html#enabling-iam-roles-for-service-accounts).

Note: The output is conditionally generated only when `enable_irsa = true`. When `enable_irsa = false` no output will be given, which [is preferable](https://github.com/hashicorp/terraform/issues/23222#issuecomment-547421898) to it returning a bad value, such as the empty string, which could then lead to misconfigured downstream resources.

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
