### PR TITLE
[IO-2697] updating EKS module to work with terragrunt

### DIFF
--- a/blueowl.tf
+++ b/blueowl.tf
@@ -51,14 +51,14 @@ resource "random_string" "suffix" {
 }
 
 resource "kubernetes_namespace" "datascience_namespace" {
-  depends_on = [aws_eks_cluster.eks]
+  depends_on = [aws_eks_cluster.this]
   metadata {
     name = "datascience"
   }
 }
 
 resource "kubernetes_role_binding" "datascience_dev_admin_rolebinding" {
-  depends_on = [aws_eks_cluster.eks, kubernetes_namespace.datascience_namespace]
+  depends_on = [aws_eks_cluster.this, kubernetes_namespace.datascience_namespace]
 
   metadata {
     name      = "allow-dev-admins"
@@ -77,25 +77,24 @@ resource "kubernetes_role_binding" "datascience_dev_admin_rolebinding" {
 }
 
 resource "kubernetes_namespace" "monitoring_namespace" {
-  depends_on = [aws_eks_cluster.eks]
+  depends_on = [aws_eks_cluster.this]
   metadata {
     name = "monitoring"
   }
 }
 
 resource "kubernetes_priority_class" "monitoring_critical_priority_class" {
-  depends_on = ["kubernetes_namespace.monitoring_namespace"]
+  depends_on = [kubernetes_namespace.monitoring_namespace]
   metadata {
     name = "log-node-critical"
   }
-
   value = 1000000
-  globalDefault = false
+  global_default = false
   description = "These pods must be running to support logging"
 }
 
 resource "kubernetes_role" "monitoring_port_forwarding_role" {
-  depends_on = ["kubernetes_namespace.monitoring_namespace"]
+  depends_on = [kubernetes_namespace.monitoring_namespace]
   metadata {
     name = "allow-port-forwarding"
     namespace = "monitoring"
@@ -109,51 +108,20 @@ resource "kubernetes_role" "monitoring_port_forwarding_role" {
 }
 
 resource "kubernetes_role_binding" "dev_admin_rolebinding" {
-  count = "${var.environment == "production" ? 0 : 1 }"
-  depends_on = ["kubernetes_namespace.monitoring_namespace"]
+  count = var.aws_profile == "production" ? 0 : 1
+  depends_on = [kubernetes_role.monitoring_port_forwarding_role]
   metadata {
-    name      = "terraform-example"
-    namespace = "default"
+    name      = "allow-dev-admins"
+    namespace = "monitoring"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "Role"
-    name      = "admin"
-  }
-  subject {
-    kind      = "User"
-    name      = "admin"
-    api_group = "rbac.authorization.k8s.io"
-  }
-  subject {
-    kind      = "ServiceAccount"
-    name      = "default"
-    namespace = "kube-system"
+    name      = "allow-port-forwarding"
   }
   subject {
     kind      = "Group"
-    name      = "system:masters"
+    name      = "dev-admin"
     api_group = "rbac.authorization.k8s.io"
   }
-}
-
-resource "k8s_manifest" "dev_admin_rolebinding" {
-
-  depends_on = ["k8s_manifest.monitoring_namespace"]
-
-  content = <<EOF
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: allow-dev-admins
-  namespace: monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: allow-port-forwarding
-subjects:
-- kind: Group
-  name: dev-admin
-  apiGroup: rbac.authorization.k8s.io
-EOF
 }

--- a/blueowl.tf
+++ b/blueowl.tf
@@ -1,0 +1,51 @@
+# Changes made on top of the community module to fit BlueOwl needs and terragrunt configruation.
+
+provider "aws" {
+  region = var.aws_region
+  profile = var.aws_profile
+}
+
+terraform {
+  # The configuration for this backend will be filled in by Terragrunt
+  backend "s3" {}
+
+  # The latest version of Terragrunt (v0.19.0 and above) requires Terraform 0.12.0 or above.
+  required_version = ">= 0.12.2"
+}
+
+provider "random" {
+  version = "~> 2.1"
+}
+
+provider "local" {
+  version = "~> 1.2"
+}
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = element(concat(aws_eks_cluster.this.*.id, list("")), 0)
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = element(concat(aws_eks_cluster.this.*.id, list("")), 0)
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+  load_config_file       = false
+  version                = "~> 1.10"
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,28 @@
+
+variable "aws_profile" {
+  description = "AWS Profile to use for provider"
+  type = string
+  default = "sandbox"
+}
+
+variable "aws_region" {
+  description = "Target region"
+  type = string
+  default = "us-east-1"
+}
+
 variable "cluster_enabled_log_types" {
   default     = []
   description = "A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
   type        = list(string)
 }
+
 variable "cluster_log_kms_key_id" {
   default     = ""
   description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
   type        = string
 }
+
 variable "cluster_log_retention_in_days" {
   default     = 90
   description = "Number of days to retain log events. Default retention - 90 days."

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,16 @@
 
+variable "promotion_registry" {
+    description = "Promotion Docker Registry (ECR) to pull image from"
+    type = string
+    default = "077588356682.dkr.ecr.us-east-1.amazonaws.com"
+}
+
+variable "private_proxy" {
+    description = "private_proxy hostname. Used for k8s dashboard ingress"
+    type = string
+    default = ""
+}
+
 variable "aws_profile" {
   description = "AWS Profile to use for provider"
   type = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,3 @@
-
-variable "promotion_registry" {
-    description = "Promotion Docker Registry (ECR) to pull image from"
-    type = string
-    default = "077588356682.dkr.ecr.us-east-1.amazonaws.com"
-}
-
-variable "private_proxy" {
-    description = "private_proxy hostname. Used for k8s dashboard ingress"
-    type = string
-    default = ""
-}
-
 variable "aws_profile" {
   description = "AWS Profile to use for provider"
   type = string


### PR DESCRIPTION
This change makes the module to be compatible with terragrunt, and creates a few k8s resources that's specific to blueowl.
Not all k8s resources are ported over yet, as k8s provider we are using are incompatible with terraform 12 at the moment.