### PR TITLE
Re-generate docs with terraform-docs 0.7.0 and bump pre-commit-terraform version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
+repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.19.0
+  rev: v1.22.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
+      args: [--args=--with-aggregate-type-defaults --no-escape]
     - id: terraform_validate
     - id: terraform_tflint

--- a/README.md
+++ b/README.md
@@ -150,91 +150,91 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| attach\_worker\_autoscaling\_policy | Whether to attach the module managed cluster autoscaling iam policy to the default worker IAM role. This requires `manage_worker_autoscaling_policy = true` | bool | `"true"` | no |
-| attach\_worker\_cni\_policy | Whether to attach the Amazon managed `AmazonEKS_CNI_Policy` IAM policy to the default worker IAM role. WARNING: If set `false` the permissions must be assigned to the `aws-node` DaemonSet pods via another method or nodes will not be able to join the cluster. | bool | `"true"` | no |
-| cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
-| cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
-| cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | list(string) | `[]` | no |
-| cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | bool | `"false"` | no |
-| cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | bool | `"true"` | no |
-| cluster\_endpoint\_public\_access\_cidrs | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | list(string) | `[ "0.0.0.0/0" ]` | no |
-| cluster\_iam\_role\_name | IAM role name for the cluster. Only applicable if manage_cluster_iam_resources is set to false. | string | `""` | no |
-| cluster\_log\_kms\_key\_id | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | string | `""` | no |
-| cluster\_log\_retention\_in\_days | Number of days to retain log events. Default retention - 90 days. | number | `"90"` | no |
-| cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
-| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | string | `""` | no |
-| cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.14"` | no |
-| config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | string | `"./"` | no |
-| create\_eks | Controls if EKS resources should be created (it affects almost all resources) | bool | `"true"` | no |
-| eks\_oidc\_root\_ca\_thumbprint | Thumbprint of Root CA for EKS OIDC, Valid until 2037 | string | `"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"` | no |
-| enable\_irsa | Whether to create OpenID Connect Provider for EKS to enable IRSA | bool | `"false"` | no |
-| iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
-| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list(string) | `[]` | no |
-| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
-| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list(string) | `[]` | no |
-| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map(string) | `{}` | no |
-| kubeconfig\_name | Override the default name used for items kubeconfig. | string | `""` | no |
-| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list(string) | `[ "/bin/sh", "-c" ]` | no |
-| manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
-| manage\_cluster\_iam\_resources | Whether to let the module manage cluster IAM resources. If set to false, cluster_iam_role_name must be specified. | bool | `"true"` | no |
-| manage\_worker\_autoscaling\_policy | Whether to let the module manage the cluster autoscaling iam policy. | bool | `"true"` | no |
-| manage\_worker\_iam\_resources | Whether to let the module manage worker IAM resources. If set to false, iam_instance_profile_name must be specified for workers. | bool | `"true"` | no |
-| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list(string) | `[]` | no |
-| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | object | `[]` | no |
-| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | object | `[]` | no |
-| node\_groups | Map of map of node groups to create. See `node_groups` module's documentation for more details | any | `{}` | no |
-| node\_groups\_defaults | Map of values to be applied to all node groups. See `node_groups` module's documentaton for more details | any | `{}` | no |
-| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `"null"` | no |
+| attach_worker_autoscaling_policy | Whether to attach the module managed cluster autoscaling iam policy to the default worker IAM role. This requires `manage_worker_autoscaling_policy = true` | bool | `"true"` | no |
+| attach_worker_cni_policy | Whether to attach the Amazon managed `AmazonEKS_CNI_Policy` IAM policy to the default worker IAM role. WARNING: If set `false` the permissions must be assigned to the `aws-node` DaemonSet pods via another method or nodes will not be able to join the cluster. | bool | `"true"` | no |
+| cluster_create_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
+| cluster_delete_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
+| cluster_enabled_log_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | list(string) | `[]` | no |
+| cluster_endpoint_private_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | bool | `"false"` | no |
+| cluster_endpoint_public_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | bool | `"true"` | no |
+| cluster_endpoint_public_access_cidrs | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | list(string) | `[ "0.0.0.0/0" ]` | no |
+| cluster_iam_role_name | IAM role name for the cluster. Only applicable if manage_cluster_iam_resources is set to false. | string | `""` | no |
+| cluster_log_kms_key_id | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | string | `""` | no |
+| cluster_log_retention_in_days | Number of days to retain log events. Default retention - 90 days. | number | `"90"` | no |
+| cluster_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
+| cluster_security_group_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | string | `""` | no |
+| cluster_version | Kubernetes version to use for the EKS cluster. | string | `"1.14"` | no |
+| config_output_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | string | `"./"` | no |
+| create_eks | Controls if EKS resources should be created (it affects almost all resources) | bool | `"true"` | no |
+| eks_oidc_root_ca_thumbprint | Thumbprint of Root CA for EKS OIDC, Valid until 2037 | string | `"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"` | no |
+| enable_irsa | Whether to create OpenID Connect Provider for EKS to enable IRSA | bool | `"false"` | no |
+| iam_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
+| kubeconfig_aws_authenticator_additional_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list(string) | `[]` | no |
+| kubeconfig_aws_authenticator_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
+| kubeconfig_aws_authenticator_command_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list(string) | `[]` | no |
+| kubeconfig_aws_authenticator_env_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map(string) | `{}` | no |
+| kubeconfig_name | Override the default name used for items kubeconfig. | string | `""` | no |
+| local_exec_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list(string) | `[ "/bin/sh", "-c" ]` | no |
+| manage_aws_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
+| manage_cluster_iam_resources | Whether to let the module manage cluster IAM resources. If set to false, cluster_iam_role_name must be specified. | bool | `"true"` | no |
+| manage_worker_autoscaling_policy | Whether to let the module manage the cluster autoscaling iam policy. | bool | `"true"` | no |
+| manage_worker_iam_resources | Whether to let the module manage worker IAM resources. If set to false, iam_instance_profile_name must be specified for workers. | bool | `"true"` | no |
+| map_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list(string) | `[]` | no |
+| map_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | object | `[]` | no |
+| map_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | object | `[]` | no |
+| node_groups | Map of map of node groups to create. See `node_groups` module's documentation for more details | any | `{}` | no |
+| node_groups_defaults | Map of values to be applied to all node groups. See `node_groups` module's documentaton for more details | any | `{}` | no |
+| permissions_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `"null"` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | list(string) | n/a | yes |
 | tags | A map of tags to add to all resources. | map(string) | `{}` | no |
-| vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
-| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
-| worker\_ami\_name\_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
-| worker\_ami\_name\_filter\_windows | Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
-| worker\_ami\_owner\_id | The ID of the owner for the AMI to use for the AWS EKS workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"602401143452"` | no |
-| worker\_ami\_owner\_id\_windows | The ID of the owner for the AMI to use for the AWS EKS Windows workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"801119661308"` | no |
-| worker\_create\_initial\_lifecycle\_hooks | Whether to create initial lifecycle hooks provided in worker groups. | bool | `"false"` | no |
-| worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |
-| worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | any | `[]` | no |
-| worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the EKS cluster. | string | `""` | no |
-| worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | number | `"1025"` | no |
-| workers\_additional\_policies | Additional policies to be added to workers | list(string) | `[]` | no |
-| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | any | `{}` | no |
-| workers\_role\_name | User defined workers role name. | string | `""` | no |
-| write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | bool | `"true"` | no |
+| vpc_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
+| worker_additional_security_group_ids | A list of additional security group ids to attach to worker instances | list(string) | `[]` | no |
+| worker_ami_name_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
+| worker_ami_name_filter_windows | Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster_version' is used. | string | `""` | no |
+| worker_ami_owner_id | The ID of the owner for the AMI to use for the AWS EKS workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"602401143452"` | no |
+| worker_ami_owner_id_windows | The ID of the owner for the AMI to use for the AWS EKS Windows workers. Valid values are an AWS account ID, 'self' (the current account), or an AWS owner alias (e.g. 'amazon', 'aws-marketplace', 'microsoft'). | string | `"801119661308"` | no |
+| worker_create_initial_lifecycle_hooks | Whether to create initial lifecycle hooks provided in worker groups. | bool | `"false"` | no |
+| worker_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | any | `[]` | no |
+| worker_groups_launch_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | any | `[]` | no |
+| worker_security_group_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the EKS cluster. | string | `""` | no |
+| worker_sg_ingress_from_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | number | `"1025"` | no |
+| workers_additional_policies | Additional policies to be added to workers | list(string) | `[]` | no |
+| workers_group_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | any | `{}` | no |
+| workers_role_name | User defined workers role name. | string | `""` | no |
+| write_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | bool | `"true"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| cloudwatch\_log\_group\_name | Name of cloudwatch log group created |
-| cluster\_arn | The Amazon Resource Name (ARN) of the cluster. |
-| cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
-| cluster\_endpoint | The endpoint for your EKS Kubernetes API. |
-| cluster\_iam\_role\_arn | IAM role ARN of the EKS cluster. |
-| cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
-| cluster\_id | The name/id of the EKS cluster. |
-| cluster\_oidc\_issuer\_url | The URL on the EKS cluster OIDC Issuer |
-| cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
-| cluster\_version | The Kubernetes server version for the EKS cluster. |
-| config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
+| cloudwatch_log_group_name | Name of cloudwatch log group created |
+| cluster_arn | The Amazon Resource Name (ARN) of the cluster. |
+| cluster_certificate_authority_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |
+| cluster_endpoint | The endpoint for your EKS Kubernetes API. |
+| cluster_iam_role_arn | IAM role ARN of the EKS cluster. |
+| cluster_iam_role_name | IAM role name of the EKS cluster. |
+| cluster_id | The name/id of the EKS cluster. |
+| cluster_oidc_issuer_url | The URL on the EKS cluster OIDC Issuer |
+| cluster_security_group_id | Security group ID attached to the EKS cluster. |
+| cluster_version | The Kubernetes server version for the EKS cluster. |
+| config_map_aws_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
-| kubeconfig\_filename | The filename of the generated kubectl config. |
-| node\_groups | Outputs from EKS node groups. Map of maps, keyed by var.node_groups keys |
-| oidc\_provider\_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
-| worker\_autoscaling\_policy\_arn | ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
-| worker\_autoscaling\_policy\_name | Name of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
-| worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
-| worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
-| worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |
-| worker\_iam\_role\_name | default IAM role name for EKS worker groups |
-| worker\_security\_group\_id | Security group ID attached to the EKS workers. |
-| workers\_asg\_arns | IDs of the autoscaling groups containing workers. |
-| workers\_asg\_names | Names of the autoscaling groups containing workers. |
-| workers\_default\_ami\_id | ID of the default worker group AMI |
-| workers\_launch\_template\_arns | ARNs of the worker launch templates. |
-| workers\_launch\_template\_ids | IDs of the worker launch templates. |
-| workers\_launch\_template\_latest\_versions | Latest versions of the worker launch templates. |
-| workers\_user\_data | User data of worker groups |
+| kubeconfig_filename | The filename of the generated kubectl config. |
+| node_groups | Outputs from EKS node groups. Map of maps, keyed by var.node_groups keys |
+| oidc_provider_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
+| worker_autoscaling_policy_arn | ARN of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
+| worker_autoscaling_policy_name | Name of the worker autoscaling IAM policy if `manage_worker_autoscaling_policy = true` |
+| worker_iam_instance_profile_arns | default IAM instance profile ARN for EKS worker groups |
+| worker_iam_instance_profile_names | default IAM instance profile name for EKS worker groups |
+| worker_iam_role_arn | default IAM role ARN for EKS worker groups |
+| worker_iam_role_name | default IAM role name for EKS worker groups |
+| worker_security_group_id | Security group ID attached to the EKS workers. |
+| workers_asg_arns | IDs of the autoscaling groups containing workers. |
+| workers_asg_names | Names of the autoscaling groups containing workers. |
+| workers_default_ami_id | ID of the default worker group AMI |
+| workers_launch_template_arns | ARNs of the worker launch templates. |
+| workers_launch_template_ids | IDs of the worker launch templates. |
+| workers_launch_template_latest_versions | Latest versions of the worker launch templates. |
+| workers_user_data | User data of worker groups |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -37,19 +37,19 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| cluster\_name | Name of parent cluster | string | n/a | yes |
-| create\_eks | Controls if EKS resources should be created (it affects almost all resources) | bool | `"true"` | no |
-| default\_iam\_role\_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | string | n/a | yes |
-| node\_groups | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | any | `{}` | no |
-| node\_groups\_defaults | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | any | n/a | yes |
+| cluster_name | Name of parent cluster | string | n/a | yes |
+| create_eks | Controls if EKS resources should be created (it affects almost all resources) | bool | `"true"` | no |
+| default_iam_role_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | string | n/a | yes |
+| node_groups | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | any | `{}` | no |
+| node_groups_defaults | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | any | n/a | yes |
 | tags | A map of tags to add to all resources | map(string) | n/a | yes |
-| workers\_group\_defaults | Workers group defaults from parent | any | n/a | yes |
+| workers_group_defaults | Workers group defaults from parent | any | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| aws\_auth\_roles | Roles for use in aws-auth ConfigMap |
-| node\_groups | Outputs from EKS node groups. Map of maps, keyed by `var.node_groups` keys. See `aws_eks_node_group` Terraform documentation for values |
+| aws_auth_roles | Roles for use in aws-auth ConfigMap |
+| node_groups | Outputs from EKS node groups. Map of maps, keyed by `var.node_groups` keys. See `aws_eks_node_group` Terraform documentation for values |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
1. Re-geneate docs with the latest version of terraform-docs [0.7.0](https://github.com/segmentio/terraform-docs/releases/tag/v0.7.0) to escape underscores (`variable\_with\_underscore`).
Should resolves docs generation issues for https://github.com/terraform-aws-modules/terraform-aws-eks/pull/667 and https://github.com/terraform-aws-modules/terraform-aws-eks/pull/666

1. Update pre-commit-terraform version