### PR TITLE
Add name field on node_groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## [[v8.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v8.0.0...HEAD)] - 2019-12-11]
 
 - Write your awesome change here (by @you)
+- Added lookup `name` field on node_groups (by @jinh574)
 
 # History
 

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -17,6 +17,7 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 
 | Name | Description | Type | If unset |
 |------|-------------|:----:|:-----:|
+| name | Node group name | string | Node group index key |
 | additional\_tags | Additional tags to apply to node group | map(string) | Only `var.tags` applied |
 | ami\_release\_version | AMI version of workers | string | Provider default behavior |
 | ami\_type | AMI Type. See Terraform or AWS docs | string | Provider default behavior |

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_eks_node_group" "workers" {
   for_each = local.node_groups_expanded
 
-  node_group_name = join("-", [var.cluster_name, each.key, random_pet.node_groups[each.key].id])
+  node_group_name = join("-", [var.cluster_name, lookup(each.value, "name", each.key), random_pet.node_groups[each.key].id])
 
   cluster_name  = var.cluster_name
   node_role_arn = each.value["iam_role_arn"]


### PR DESCRIPTION
# PR o'clock

## Description
- Resolves #670 
- Add lookup `name` field on `node_group_name` attribute.
- Put `each.key` as default value

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
