### PR TITLE
Ignore changes to desired_size of node_groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Write your awesome change here (by @you)
 - Fix index reference on destroy for output `oidc_provider_arn` (@stevie-)
 - Add support for restricting access to the public API endpoint (@sidprak)
+- Add an `ignore_lifecycle` rule to prevent Terraform from scaling down ASG behind AWS EKS Managed Node Group (by @davidalger)
 
 # History
 

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -45,5 +45,6 @@ resource "aws_eks_node_group" "workers" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [scaling_config.0.desired_size]
   }
 }


### PR DESCRIPTION
# PR o'clock
Resolves #681

## Description

Add an `ignore_lifecycle` rule to prevent Terraform from scaling down ASG behind AWS EKS Managed Node Group. This is important as the ASG will be scaled up by a deployed cluster autoscaler, and shortly thereafter the Managed Node Group will reflect the new desired size. This brings the functional behavior of `desired_capacity` (or `desired_size` in the actual `aws_eks_node_group` resource) in line with the current behaviour of ASGs `desired_capacity` on worker groups managed by this module: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/workers.tf#L139-L142

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
