### PR TITLE
Don't create ingress rule if worker security group exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## [[v8.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v8.1.0...HEAD)] - YYYY-MM-DD]
 
 - Include ability to configure custom os-specific command for waiting until kube cluster is healthy (@sanjeevgiri)
+- Disable creation of ingress rules if worker nodes security groups are exists (@andjelx)
 
 # History
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -74,7 +74,7 @@ resource "aws_security_group_rule" "cluster_egress_internet" {
 }
 
 resource "aws_security_group_rule" "cluster_https_worker_ingress" {
-  count                    = var.create_eks ? 1 : 0
+  count                    = var.worker_security_group_id == "" && var.create_eks ? 1 : 0
   description              = "Allow pods to communicate with the EKS cluster API."
   protocol                 = "tcp"
   security_group_id        = local.cluster_security_group_id


### PR DESCRIPTION
Don't create ingress rule if worker security group exists

# PR o'clock

## Description

Disable creation of ingress rule on worker security group if exists

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
