### PR TITLE
Add iam:GetOpenIDConnectProvider grant to docs/iam-permissions.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - [CI] Bump pre-commit-terraform version (by @barryib)
 - Added example `examples/irsa` for IAM Roles for Service Accounts (by @max-rocket-internet)
 - **Breaking:** Removal of autoscaling IAM policy and tags (by @max-rocket-internet)
+- Add `iam:GetOpenIDConnectProvider` grant to the required IAM permissions in `docs/iam-permissions.md` (by @danielelisi)
 
 #### Important notes
 

--- a/docs/iam-permissions.md
+++ b/docs/iam-permissions.md
@@ -97,6 +97,7 @@ Following IAM permissions are the minimum permissions needed for your IAM user o
                 "iam:DeleteServiceLinkedRole",
                 "iam:DetachRolePolicy",
                 "iam:GetInstanceProfile",
+		"iam:GetOpenIDConnectProvider",
                 "iam:GetPolicy",
                 "iam:GetPolicyVersion",
                 "iam:GetRole",


### PR DESCRIPTION
# PR o'clock

## Description

The suggested policy in `iam-permissions.md` is missing to include the `iam:GetOpenIDConnectProvider` permission hence Terraform plan fails to complete with the error:

```
AccessDenied: User: arn:aws:sts::<redacted>:assumed-role/<iam_role>/ is not authorized to perform: iam:GetOpenIDConnectProvider on resource: arn:aws:iam::<redacted>:oidc-provider/oidc.eks.ap-southeast-2.amazonaws.com/
``` 

After including this permission Terraform completes running the plan

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
