### PR TITLE
Pin version for kubernetes provider across examples to exactly 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added example `examples/irsa` for IAM Roles for Service Accounts (by @max-rocket-internet)
 - **Breaking:** Removal of autoscaling IAM policy and tags (by @max-rocket-internet)
 - Add `iam:{Create,Delete,Get}OpenIDConnectProvider` grants to the list of required IAM permissions in `docs/iam-permissions.md` (by @danielelisi)
+- Add an `name` parameter to be able to manually name EKS Managed Node Groups (by @splieth)
+- Pinned kubernetes provider version to exactly 1.10.0 across all examples and README.md's (by @andres-de-castro)
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-eks
+r# terraform-aws-eks
 
 [![Lint Status](https://github.com/terraform-aws-modules/terraform-aws-eks/workflows/Lint/badge.svg)](https://github.com/terraform-aws-modules/terraform-aws-eks/actions)
 [![LICENSE](https://img.shields.io/github/license/terraform-aws-modules/terraform-aws-eks)](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/LICENSE)
@@ -75,7 +75,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(element(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, list("")), 0))
   token                  = element(concat(data.aws_eks_cluster_auth.cluster[*].token, list("")), 0)
   load_config_file       = false
-  version                = "= 1.10"
+  version                = "1.10"
 }
 
 # This cluster will not be created

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-r# terraform-aws-eks
+# terraform-aws-eks
 
 [![Lint Status](https://github.com/terraform-aws-modules/terraform-aws-eks/workflows/Lint/badge.svg)](https://github.com/terraform-aws-modules/terraform-aws-eks/actions)
 [![LICENSE](https://img.shields.io/github/license/terraform-aws-modules/terraform-aws-eks)](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(element(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, list("")), 0))
   token                  = element(concat(data.aws_eks_cluster_auth.cluster[*].token, list("")), 0)
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "= 1.10"
 }
 
 # This cluster will not be created

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "1.10"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -32,7 +32,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "1.10"
 }
 
 data "aws_availability_zones" "available" {}

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "1.10"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "1.10"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "~> 1.10"
+  version                = "1.10"
 }
 
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
# PR o'clock

## Description

Semantic version fails on latest kubernetes provider,  pinning the version on examples exactly to 1.10.0 resolves many issues 

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
