### PR TITLE
Add option to set the name of a node group manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added example `examples/irsa` for IAM Roles for Service Accounts (by @max-rocket-internet)
 - **Breaking:** Removal of autoscaling IAM policy and tags (by @max-rocket-internet)
 - Add `iam:{Create,Delete,Get}OpenIDConnectProvider` grants to the list of required IAM permissions in `docs/iam-permissions.md` (by @danielelisi)
+- Add an `name` parameter to be able to manually name EKS Managed Node Groups (by @splieth)
 
 #### Important notes
 

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -28,6 +28,7 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | key\_name | Key name for workers. Set to empty string to disable remote access | string | `var.workers_group_defaults[key_name]` |
 | max\_capacity | Max number of workers | number | `var.workers_group_defaults[asg_max_size]` |
 | min\_capacity | Min number of workers | number | `var.workers_group_defaults[asg_min_size]` |
+| name | Name of the node group | string | Auto generated |
 | source\_security\_group\_ids | Source security groups for remote access to workers | list(string) | If key\_name is specified: THE REMOTE ACCESS WILL BE OPENED TO THE WORLD |
 | subnets | Subnets to contain workers | list(string) | `var.workers_group_defaults[subnets]` |
 | version | Kubernetes version | string | Provider default behavior |

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_eks_node_group" "workers" {
   for_each = local.node_groups_expanded
 
-  node_group_name = join("-", [var.cluster_name, each.key, random_pet.node_groups[each.key].id])
+  node_group_name = lookup(each.value, "name", join("-", [var.cluster_name, each.key, random_pet.node_groups[each.key].id]))
 
   cluster_name  = var.cluster_name
   node_role_arn = each.value["iam_role_arn"]


### PR DESCRIPTION
# PR o'clock

## Description

I added an additional parameter `name` to managed node groups in order to be able to manually provide a name for the node group. Resolves #698.

### Checklist

- [X] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [X] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
