### PR TITLE
change default value for wait_for_cluster_cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - **Breaking:** Removal of autoscaling IAM policy and tags (by @max-rocket-internet)
 - Add `iam:{Create,Delete,Get}OpenIDConnectProvider` grants to the list of required IAM permissions in `docs/iam-permissions.md` (by @danielelisi)
 - Add an `name` parameter to be able to manually name EKS Managed Node Groups (by @splieth)
+- Change variable default `wait_for_cluster_cmd` from curl to wget (by @daroga0002)
 
 #### Important notes
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | subnets | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | `string` | n/a | yes |
-| wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"until curl -k -s $ENDPOINT/healthz \u003e/dev/null; do sleep 4; done"` | no |
+| wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"until wget --no-check-certificate -O - -q $ENDPOINT/healthz \u003e/dev/null; do sleep 4; done"` | no |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |
 | worker\_ami\_name\_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |
 | worker\_ami\_name\_filter\_windows | Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -201,7 +201,7 @@ variable "cluster_delete_timeout" {
 variable "wait_for_cluster_cmd" {
   description = "Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT"
   type        = string
-  default     = "until curl -k -s $ENDPOINT/healthz >/dev/null; do sleep 4; done"
+  default     = "until wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null; do sleep 4; done"
 }
 
 variable "worker_create_initial_lifecycle_hooks" {


### PR DESCRIPTION
# PR o'clock

## Description

This is addressing https://github.com/terraform-aws-modules/terraform-aws-eks/issues/741

Currently after creating eks cluster there is `local-exec` loop checking availability of API endpoint
https://github.com/terraform-aws-modules/terraform-aws-eks/blob/10ca272e5b7ce006a721c99ef8906720ff5cd6ee/variables.tf#L201-L205

This behaviour is working totally fine, but it require installed `curl`, which is missing in official Hashicorp docker image ( `hashicorp/terraform` ). Instead there is `wget`:
```
$ docker run -ti --entrypoint='' hashicorp/terraform sh
/ # which curl 
/ # which wget
/usr/bin/wget
```
This can be workaround by using following input module variable:
```
wait_for_cluster_cmd = "until wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null; do sleep 4; done"
```

So proposing to switch default to `wget` what will allow running module in automated CI processes using Hashicorp docker environment.

### Checklist

- [ x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ x] CI tests are passing
- [ x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
