### PR TITLE
cluster-autoscaler shouldn't be scheduled on spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[v9.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v9.0.0...HEAD)] - 2020-xx-xx]
 
-- Write your awesome change here (by @you)
+- Fix doc about spot instances, cluster-autoscaler should be scheduled on normal instances instead of spot (by @simowaer)
 
 # History
 

--- a/docs/spot-instances.md
+++ b/docs/spot-instances.md
@@ -12,7 +12,7 @@ In the following examples at least 1 worker group that uses on-demand instances 
 
 ```yaml
 nodeSelector:
-  kubernetes.io/lifecycle: spot
+  kubernetes.io/lifecycle: normal
 ```
 
 Notes:


### PR DESCRIPTION
Update documentation to schedule cluster-autoscaler on normal instances.

# PR o'clock

## Description

The documentation states the cluster autoscaler should be scheduled on spot instances. This is incorrect. It's the exact opposite.
