### PR TITLE
Adding encrypted option to root_block_device of launch_configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ## [[v9.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v9.0.0...HEAD)] - 2020-xx-xx]
 
 - Fix doc about spot instances, cluster-autoscaler should be scheduled on normal instances instead of spot (by @simowaer)
+- Adding `encrypted` option to worker's root_block_device as read from the worker configurations (by @craig-rueda)
 
 # History
 

--- a/local.tf
+++ b/local.tf
@@ -66,7 +66,7 @@ locals {
     launch_template_version           = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
     launch_template_placement_tenancy = "default"                                # The placement tenancy for instances
     launch_template_placement_group   = ""                                       # The name of the placement group into which to launch the instances, if any.
-    root_encrypted                    = ""                                       # Whether the volume should be encrypted or not
+    root_encrypted                    = false                                    # Whether the volume should be encrypted or not
     eni_delete                        = true                                     # Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying)
     cpu_credits                       = "standard"                               # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     market_type                       = null

--- a/local.tf
+++ b/local.tf
@@ -66,7 +66,7 @@ locals {
     launch_template_version           = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
     launch_template_placement_tenancy = "default"                                # The placement tenancy for instances
     launch_template_placement_group   = ""                                       # The name of the placement group into which to launch the instances, if any.
-    root_encrypted                    = false                                    # Whether the volume should be encrypted or not
+    root_encrypted                    = ""                                       # Whether the volume should be encrypted or not
     eni_delete                        = true                                     # Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying)
     cpu_credits                       = "standard"                               # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     market_type                       = null

--- a/workers.tf
+++ b/workers.tf
@@ -185,6 +185,11 @@ resource "aws_launch_configuration" "workers" {
   )
 
   root_block_device {
+    encrypted = lookup(
+      var.worker_groups[count.index],
+      "root_encrypted",
+      local.workers_group_defaults["root_encrypted"],
+    )
     volume_size = lookup(
       var.worker_groups[count.index],
       "root_volume_size",


### PR DESCRIPTION
# PR o'clock

## Description

This adds the `encrypted` option found in the `root_block_device` stanza in the `aws_launch_configuration` resource. Reuses the field currently utilized by worker_launch_templates to perform the same function.

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
