### PR TITLE
fix: Add instance tag specification to launch template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[v9.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v9.0.0...HEAD)] - 2020-xx-xx]
 
+- Fix #753 by adding and instance tag spec to launch templates (by @js-timbirkett)
 - Fix doc about spot instances, cluster-autoscaler should be scheduled on normal instances instead of spot (by @simowaer)
 
 # History

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -337,6 +337,21 @@ resource "aws_launch_template" "workers_launch_template" {
   }
 
   tag_specifications {
+    resource_type = "instance"
+
+    tags = merge(
+      {
+        "Name" = "${aws_eks_cluster.this[0].name}-${lookup(
+          var.worker_groups_launch_template[count.index],
+          "name",
+          count.index,
+        )}-eks_asg"
+      },
+      var.tags,
+    )
+  }
+
+  tag_specifications {
     resource_type = "volume"
 
     tags = merge(


### PR DESCRIPTION
# PR o'clock

## Description

Tags are being applied after instances are launched whils in pending state.

Adding a tag_specification for instance resources allows ensures that
instances are tagged during launch.

Fixes: #753

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
