### PR TITLE
improvement: Require k8s provider >=1.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | Name | Version |
 |------|---------|
 | aws | >= 2.52.0 |
-| kubernetes | >= 1.6.2 |
+| kubernetes | >= 1.11.1 |
 | local | >= 1.2 |
 | null | >= 2.1 |
 | random | >= 2.1 |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "1.10"
+  version                = "~> 1.11"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -32,7 +32,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "1.10"
+  version                = "~> 1.11"
 }
 
 data "aws_availability_zones" "available" {}

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "1.10"
+  version                = "~> 1.11"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "1.10"
+  version                = "~> 1.11"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "1.10"
+  version                = "~> 1.11"
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   load_config_file       = false
-  version                = "1.10"
+  version                = "~> 1.11"
 }
 
 data "aws_availability_zones" "available" {

--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,6 @@ terraform {
     null       = ">= 2.1"
     template   = ">= 2.1"
     random     = ">= 2.1"
-    kubernetes = ">= 1.6.2"
+    kubernetes = ">= 1.11.1"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Set the required kubernetes provider version to 1.11.1.

Looks like the original breaking changes in 1.11.0 have been fixed. And hopefully this also resolves the problems people were seeing with the provider randomly trying to modify their default or localhost clusters. Or at least we'll encourage further testing of the provider 😁 

Not sure how you want to classify this. It's not really a breaking change but it may cause terraform to fail to init if users have set `version = "1.10"` like we had in the examples.

Fixes #733
Fixes #713 [probably]

### Checklist

- [x] Add [sementics prefix](#semantic-pull-requests) to your PR or Commits (at leats one of your commit groups)
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
