### PR TITLE
Fix kitchen test for terraform 0.12.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: "terraform"
+  command_timeout: 3000
   root_module_directory: "examples/basic"
 
 provisioner:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 ruby '2.4.6'
 
 source 'https://rubygems.org/' do
-  gem 'awspec', '~> 1.4.2'
-  gem 'kitchen-terraform', '~> 3.2'
-  gem 'kitchen-verifier-awspec', '~> 0.1.1'
+  gem 'awspec', '~> 1.18'
+  gem 'kitchen-terraform', '~> 5.3'
+  gem 'kitchen-verifier-awspec', '~> 0.2.0'
 end

--- a/test/integration/default/test_eks.rb
+++ b/test/integration/default/test_eks.rb
@@ -3,7 +3,7 @@
 require 'awspec'
 
 # rubocop:disable LineLength
-state_file = 'terraform.tfstate.d/kitchen-terraform-default-aws/terraform.tfstate'
+state_file = 'examples/basic/terraform.tfstate.d/kitchen-terraform-default-aws/terraform.tfstate'
 tf_state = JSON.parse(File.open(state_file).read)
-region = tf_state['modules'][0]['outputs']['region']['value']
+region = tf_state['outputs']['region']['value']
 ENV['AWS_REGION'] = region


### PR DESCRIPTION
# PR o'clock

## Description

Fix kitchen test for terraform 0.12.x.

Test codes are written 6 months ago and it was broken because it supported only terraform 0.11.x.
In 6 months, eks module's least support version bumped to 0.12.x therefore test codes didn't work completely.

This PR ups test library versions and fix broken point.

### Checklist

- [ ] ~Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted~
    - I think no need to do it
- [ ] ~CI tests are passing~
    - Unfortunately, in this module CI test is not running. The test with real AWS resources need real money.
- [ ] ~README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation~
    - no need
