### PR TITLE
fix: Create false

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -46,7 +46,7 @@ resource "aws_eks_cluster" "this" {
 }
 
 resource "null_resource" "wait_for_cluster" {
-  count = var.manage_aws_auth ? 1 : 0
+  count = var.create_eks && var.manage_aws_auth ? 1 : 0
 
   depends_on = [
     aws_eks_cluster.this[0]

--- a/examples/create_false/main.tf
+++ b/examples/create_false/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_eks_cluster" "cluster" {
+  count = 0
+  name  = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  count = 0
+  name  = module.eks.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = element(concat(data.aws_eks_cluster.cluster[*].endpoint, list("")), 0)
+  cluster_ca_certificate = base64decode(element(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, list("")), 0))
+  token                  = element(concat(data.aws_eks_cluster_auth.cluster[*].token, list("")), 0)
+  load_config_file       = false
+  version                = "~> 1.11"
+}
+
+module "eks" {
+  source     = "../.."
+  create_eks = false
+
+  vpc_id       = ""
+  cluster_name = ""
+  subnets      = []
+}

--- a/examples/create_false/variables.tf
+++ b/examples/create_false/variables.tf
@@ -1,0 +1,3 @@
+variable "region" {
+  default = "us-west-2"
+}


### PR DESCRIPTION
# PR o'clock

## Description

Simple example for the module with `create_eks = false` set. Mainly useful for testing changes that add new resources.

This also "fixes" the module so that the plan applies cleanly. It was waiting forever for a non-existent cluster to respond.

### Checklist

- [x] Add [sementics prefix](#semantic-pull-requests) to your PR or Commits (at leats one of your commit groups)
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
