### PR TITLE
improvement: Generate `aws-auth` ConfigMap's roles from Object. No more string concat.

### DIFF
--- a/templates/worker-role.tpl
+++ b/templates/worker-role.tpl
@@ -1,8 +1,0 @@
-- rolearn: ${worker_role_arn}
-  username: system:node:{{EC2PrivateDNSName}}
-  groups:
-    - system:bootstrappers
-    - system:nodes
-    %{~ if platform == "windows" ~}
-    - eks:kube-proxy-windows
-    %{~ endif ~}


### PR DESCRIPTION
# PR o'clock

## Description

The current module generates the `roles` item of the `aws-auth` ConfigMap using string concatenation. Building a data structure from concat is often fraught with troubles. We can see that with the edge case of having no roles defined generating invalid YAML.

This change uses Terraform primitive data types and then a final yamlencode() to create the `roles`.

Fixes #689

This shouldn't be a breaking change although it will cause an update to the `aws-auth` ConfigMap to remove unnecessary blank lines.

### Checklist

- [x] Add [sementics prefix](#semantic-pull-requests) to your PR or Commits (at leats one of your commit groups)
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation

## Changes tested
### No roles
```hcl
module "eks" {
  source       = "../.."
  cluster_name = local.cluster_name
  subnets      = module.vpc.private_subnets
  vpc_id       = module.vpc.vpc_id
}
```
Previous:
```yaml
apiVersion: v1
data:
  mapAccounts: |
    []
  mapRoles: |2+


  mapUsers: |
    []
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
```
New:
```yaml
apiVersion: v1
data:
  mapAccounts: |
    []
  mapRoles: |
    []
  mapUsers: |
    []
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
```

### examples/basic
```yaml
apiVersion: v1
data:
  mapAccounts: |
    - "777777777777"
    - "888888888888"
  mapRoles: |
    - "groups":
      - "system:bootstrappers"
      - "system:nodes"
      "rolearn": "arn:aws:iam::XXXXXXXXXXXX:role/test-eks-yIaQqH4020200313151442206300000008"
      "username": "system:node:{{EC2PrivateDNSName}}"
    - "groups":
      - "system:masters"
      "rolearn": "arn:aws:iam::66666666666:role/role1"
      "username": "role1"
  mapUsers: |
    - "groups":
      - "system:masters"
      "userarn": "arn:aws:iam::66666666666:user/user1"
      "username": "user1"
    - "groups":
      - "system:masters"
      "userarn": "arn:aws:iam::66666666666:user/user2"
      "username": "user2"
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
```

### Windows works too:
```yaml
apiVersion: v1
data:
  mapAccounts: |
    []
  mapRoles: |
    - "groups":
      - "system:bootstrappers"
      - "system:nodes"
      - "eks:kube-proxy-windows"
      "rolearn": "arn:aws:iam::XXXXXXXXXXXX:role/test-eks-yIaQqH4020200313151442206300000008"
      "username": "system:node:{{EC2PrivateDNSName}}"
  mapUsers: |
    []
kind: ConfigMap
metadata:
  name: aws-auth
  namespace: kube-system
```