### PR TITLE
improvement: Add timeout to default wait_for_cluster_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | subnets | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | `string` | n/a | yes |
-| wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"until wget --no-check-certificate -O - -q $ENDPOINT/healthz \u003e/dev/null; do sleep 4; done"` | no |
+| wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"for i in `seq 1 60`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz \u003e/dev/null \u0026\u0026 exit 0 \|\| true; sleep 5; done; echo TIMEOUT \u0026\u0026 exit 1"` | no |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |
 | worker\_ami\_name\_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |
 | worker\_ami\_name\_filter\_windows | Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -201,7 +201,7 @@ variable "cluster_delete_timeout" {
 variable "wait_for_cluster_cmd" {
   description = "Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT"
   type        = string
-  default     = "until wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null; do sleep 4; done"
+  default     = "for i in `seq 1 60`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; sleep 5; done; echo TIMEOUT && exit 1"
 }
 
 variable "cluster_create_security_group" {


### PR DESCRIPTION
# PR o'clock

## Description

The current default command for `wait_for_cluster` will happily sit forever in a failing state. Module previously had a timeout before the switch to kubernetes provider in 8.0.0.

Defaults to 5 minutes of sleeps. May be a lot longer depending on how wget hangs. 

Have tested logic on bash 3 (for those older Mac users), zsh, bash 5, and busybox (default in alpine)
```
$ docker run --rm -it alpine /bin/sh -c 'for i in `seq 1 60`; do false && exit 0 || true; sleep 0; done; echo TIMEOUT && exit 1' ; echo $?
TIMEOUT
1
$ docker run --rm -it alpine /bin/sh -c 'for i in `seq 1 60`; do true && exit 0 || true; sleep 0; done; echo TIMEOUT && exit 1' ; echo $?
0
```

Sample failure output (I lowered the seq count because ain't got all day):
```
module.eks.null_resource.wait_for_cluster[0]: Creating...
module.eks.null_resource.wait_for_cluster[0]: Provisioning with 'local-exec'...
module.eks.null_resource.wait_for_cluster[0] (local-exec): Executing: ["/bin/sh" "-c" "for i in `seq 1 2`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; sleep 5; done; echo TIMEOUT && exit 1"]
module.eks.null_resource.wait_for_cluster[0]: Still creating... [10s elapsed]
module.eks.null_resource.wait_for_cluster[0] (local-exec): TIMEOUT


Error: Error running command 'for i in `seq 1 2`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; sleep 5; done; echo TIMEOUT && exit 1': exit status 1. Output: TIMEOUT
```

I don't think there are any issues directly about this but it would have helped the user in #777 for example. Or at least wasted slightly less time watching paint dry 🙂 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
