### PR TITLE
fix: Add node_group direct dependency on eks_cluster

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -4,7 +4,7 @@ data "null_data_source" "node_groups" {
   count = var.create_eks ? 1 : 0
 
   inputs = {
-    cluster_name = var.cluster_name
+    cluster_name = aws_eks_cluster.this[0].name
 
     # Ensure these resources are created before "unlocking" the data source.
     # `depends_on` causes a refresh on every run so is useless here.


### PR DESCRIPTION
# PR o'clock

## Description

Setting `manage_aws_auth = false` removes the ordering dependency between node_group and eks_cluster generating an error on first apply. This change ensures that the eks_cluster is created before trying to create the node_group.

Fixes #793

### Checklist

- [x] Add [sementics prefix](#semantic-pull-requests) to your PR or Commits (at leats one of your commit groups)
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
