### PR TITLE
fix: Do not recreate cluster when no SG given

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -15,7 +15,7 @@ resource "aws_eks_cluster" "this" {
   tags                      = var.tags
 
   vpc_config {
-    security_group_ids      = [local.cluster_security_group_id]
+    security_group_ids      = compact([local.cluster_security_group_id])
     subnet_ids              = var.subnets
     endpoint_private_access = var.cluster_endpoint_private_access
     endpoint_public_access  = var.cluster_endpoint_public_access


### PR DESCRIPTION
# PR o'clock

## Description

Setting `cluster_create_security_group = false` and not setting `cluster_security_group_id` causes the cluster to be recreated on every apply.

I did try setting `cluster_security_group_id = null` but then terraform complains that there's a null item inside a list and that I'm a very bad person for doing something so rude.

Fixes #797

### Checklist

- [x] Add [sementics prefix](#semantic-pull-requests) to your PR or Commits (at leats one of your commit groups)
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
