### PR TITLE
fix: fix git-chglog template to format changelog `Type` nicely

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -14,14 +14,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 {{ range .Commits -}}
 {{- if .Subject -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{- end -}}
+{{ end -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Unreleased.Commits -}}
 {{- if .Subject -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{- end -}}
+{{ end -}}
 {{ end }}
 {{ end -}}
 {{ end -}}
@@ -35,14 +35,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 {{ range .Commits -}}
 {{- if .Subject -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{- end -}}
+{{ end -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Commits -}}
 {{- if .Subject -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{- end -}}
+{{ end -}}
 {{ end }}
 {{ end -}}
 


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
