### PR TITLE
fix: Fix destruction failure when talking to EKS endpoint on private network

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -61,7 +61,8 @@ resource "null_resource" "wait_for_cluster" {
   count = var.create_eks && var.manage_aws_auth ? 1 : 0
 
   depends_on = [
-    aws_eks_cluster.this[0]
+    aws_eks_cluster.this[0],
+    aws_security_group_rule.cluster_private_access,
   ]
 
   provisioner "local-exec" {


### PR DESCRIPTION
# PR o'clock

## Description

In #812 we have a situation where when one attempts to `terraform destroy` and `cluster_endpoint_public_access` is `false` then an error will be encountered:
`Error: Get https://SNIP.eks.amazonaws.com/api/v1/namespaces/kube-system/configmaps/aws-auth: dial tcp IP:443: i/o timeout` (`IP:443` is the IP of the endpoint).

This change has been tested with `cluster_endpoint_public_access` as `true` and as `false`. I tested it by running `tf apply && tf destroy` in each case, verifying that it completed.

Resolves #812 

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
