### PR TITLE
improvement: Use aws_partition to build IAM policy ARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ And install `terraform-docs` with `go get github.com/segmentio/terraform-docs` o
 
 Report issues/questions/feature requests on in the [issues](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/new) section.
 
-Full contributing [guidelines are covered here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/CONTRIBUTING.md).
+Full contributing [guidelines are covered here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/.github/CONTRIBUTING.md).
 
 ## Change log
 

--- a/data.tf
+++ b/data.tf
@@ -222,4 +222,4 @@ data "aws_iam_instance_profile" "custom_worker_group_launch_template_iam_instanc
   )
 }
 
-data "aws_region" "current" {}
+data "aws_partition" "current" {}

--- a/local.tf
+++ b/local.tf
@@ -22,7 +22,7 @@ locals {
   default_ami_id_linux   = coalesce(local.workers_group_defaults.ami_id, data.aws_ami.eks_worker.id)
   default_ami_id_windows = coalesce(local.workers_group_defaults.ami_id_windows, data.aws_ami.eks_worker_windows.id)
 
-  policy_arn_prefix = contains(["cn-northwest-1", "cn-north-1"], data.aws_region.current.name) ? "arn:aws-cn:iam::aws:policy" : "arn:aws:iam::aws:policy"
+  policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   workers_group_defaults_defaults = {
     name                          = "count.index"               # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
     tags                          = []                          # A list of map defining extra tags to be applied to the worker group autoscaling group.


### PR DESCRIPTION
# PR o'clock

## Description
Use `aws_partition` data resource to dynamically build the IAM policy ARNs instead of branching by region name.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
