### PR TITLE
feat: Add instance tag specifications to Launch Template

### DIFF
--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -403,6 +403,21 @@ resource "aws_launch_template" "workers_launch_template" {
     )
   }
 
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = merge(
+      {
+        "Name" = "${aws_eks_cluster.this[0].name}-${lookup(
+          var.worker_groups_launch_template[count.index],
+          "name",
+          count.index,
+        )}-eks_asg"
+      },
+      var.tags,
+    )
+  }
+
   tags = var.tags
 
   lifecycle {


### PR DESCRIPTION
# PR o'clock

## Description

Our company has a policy on the mandatory tags of resources.
If "Tag instances" are not set in the Launch Template, an error occurs:
```
Error: Error creating AutoScaling Group: AccessDenied: You are not authorized to use launch template: lt-0d9b738051139aab9
	status code: 403, request id: 8db8541f-69d2-4vdc-b4cb-25c920ed342f

  on .terraform/modules/eks/terraform-aws-modules-terraform-aws-eks-ca3d1e1/workers_launch_template.tf line 3, in resource "aws_autoscaling_group" "workers_launch_template":
   3: resource "aws_autoscaling_group" "workers_launch_template" {
```

The reason is the invocation of "ec2: RunInstances" when the Launch Template is attached to the AutoScaling Group at creation.

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
