### PR TITLE
feat: Add support for EC2 principal in assume worker role policy for China

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Many thanks to [the contributors listed here](https://github.com/terraform-aws-m
 MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/LICENSE) for full details.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.9 |
+| aws | >= 2.52.0 |
+| kubernetes | >= 1.11.1 |
+| local | >= 1.2 |
+| null | >= 2.1 |
+| random | >= 2.1 |
+| template | >= 2.1 |
+
 ## Providers
 
 | Name | Version |
@@ -138,7 +150,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | attach\_worker\_cni\_policy | Whether to attach the Amazon managed `AmazonEKS_CNI_Policy` IAM policy to the default worker IAM role. WARNING: If set `false` the permissions must be assigned to the `aws-node` DaemonSet pods via another method or nodes will not be able to join the cluster. | `bool` | `true` | no |
 | cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | `bool` | `true` | no |
 | cluster\_create\_timeout | Timeout value when creating the EKS cluster. | `string` | `"30m"` | no |
@@ -173,11 +185,11 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | node\_groups | Map of map of node groups to create. See `node_groups` module's documentation for more details | `any` | `{}` | no |
 | node\_groups\_defaults | Map of values to be applied to all node groups. See `node_groups` module's documentaton for more details | `any` | `{}` | no |
-| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | n/a | yes |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | `string` | n/a | yes |
-| wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"for i in `seq 1 60`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz \u003e/dev/null \u0026\u0026 exit 0 \|\| true; sleep 5; done; echo TIMEOUT \u0026\u0026 exit 1"` | no |
+| wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"for i in `seq 1 60`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz \u003e/dev/null \u0026\u0026 exit 0 || true; sleep 5; done; echo TIMEOUT \u0026\u0026 exit 1"` | no |
 | wait\_for\_cluster\_interpreter | Custom local-exec command line interpreter for the command to determining if the eks cluster is healthy. | `list(string)` | <pre>[<br>  "/bin/sh",<br>  "-c"<br>]</pre> | no |
 | worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |
 | worker\_ami\_name\_filter | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -2,10 +2,9 @@ data "aws_caller_identity" "current" {
 }
 
 locals {
-  arn_partition = data.aws_partition.current.partition
   auth_launch_template_worker_roles = [
     for index in range(0, var.create_eks ? local.worker_group_launch_template_count : 0) : {
-      worker_role_arn = "arn:${local.arn_partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
+      worker_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
         coalescelist(
           aws_iam_instance_profile.workers_launch_template.*.role,
           data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile.*.role_name,
@@ -22,7 +21,7 @@ locals {
 
   auth_worker_roles = [
     for index in range(0, var.create_eks ? local.worker_group_count : 0) : {
-      worker_role_arn = "arn:${local.arn_partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
+      worker_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
         coalescelist(
           aws_iam_instance_profile.workers.*.role,
           data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile.*.role_name,

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -2,9 +2,10 @@ data "aws_caller_identity" "current" {
 }
 
 locals {
+  arn_partition = data.aws_partition.current.partition
   auth_launch_template_worker_roles = [
     for index in range(0, var.create_eks ? local.worker_group_launch_template_count : 0) : {
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${element(
+      worker_role_arn = "arn:${local.arn_partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
         coalescelist(
           aws_iam_instance_profile.workers_launch_template.*.role,
           data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile.*.role_name,
@@ -21,7 +22,7 @@ locals {
 
   auth_worker_roles = [
     for index in range(0, var.create_eks ? local.worker_group_count : 0) : {
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${element(
+      worker_role_arn = "arn:${local.arn_partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
         coalescelist(
           aws_iam_instance_profile.workers.*.role,
           data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile.*.role_name,

--- a/data.tf
+++ b/data.tf
@@ -5,6 +5,7 @@ locals {
   worker_ami_name_filter_windows = (var.worker_ami_name_filter_windows != "" ?
     var.worker_ami_name_filter_windows : "Windows_Server-2019-English-Core-EKS_Optimized-${tonumber(var.cluster_version) >= 1.14 ? var.cluster_version : 1.14}-*"
   )
+  ec2_principal = "ec2.${data.aws_partition.current.dns_suffix}"
 }
 
 data "aws_iam_policy_document" "workers_assume_role_policy" {
@@ -17,7 +18,7 @@ data "aws_iam_policy_document" "workers_assume_role_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
+      identifiers = [local.ec2_principal]
     }
   }
 }

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -34,6 +34,10 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | version | Kubernetes version | string | Provider default behavior |
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 | Name | Version |
@@ -44,7 +48,7 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | cluster\_name | Name of parent cluster | `string` | n/a | yes |
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | default\_iam\_role\_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | n/a | yes |


### PR DESCRIPTION
fix: EC2 principal for EKS worker role assume policy

# PR o'clock

## Description

Add logic to correctly handle EC2 principal service endpoint in China region for EKS Worker role assume policy.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
