### PR TITLE
fix: Add `vpc_config.cluster_security_group` output as primary cluster security group id

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig\_filename | The filename of the generated kubectl config. |
 | node\_groups | Outputs from EKS node groups. Map of maps, keyed by var.node\_groups keys |
 | oidc\_provider\_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
+| primary_cluster_security_group_id | The Primary Cluster security group ID created by the EKS cluster on 1.14 or later. |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
 | worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |

--- a/README.md
+++ b/README.md
@@ -219,14 +219,14 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
 | cluster\_id | The name/id of the EKS cluster. |
 | cluster\_oidc\_issuer\_url | The URL on the EKS cluster OIDC Issuer |
-| cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
+| cluster\_primary\_security\_group\_id | The cluster primary security group ID created by the EKS cluster on 1.14 or later. Referred to as 'Cluster security group' in the EKS console. |
+| cluster\_security\_group\_id | Security group ID attached to the EKS cluster. On 1.14 or later, this is the 'Additional security groups' in the EKS console. |
 | cluster\_version | The Kubernetes server version for the EKS cluster. |
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |
 | kubeconfig | kubectl config file contents for this EKS cluster. |
 | kubeconfig\_filename | The filename of the generated kubectl config. |
 | node\_groups | Outputs from EKS node groups. Map of maps, keyed by var.node\_groups keys |
 | oidc\_provider\_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
-| primary\_cluster\_security\_group\_id | The Primary Cluster security group ID created by the EKS cluster on 1.14 or later. |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
 | worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig\_filename | The filename of the generated kubectl config. |
 | node\_groups | Outputs from EKS node groups. Map of maps, keyed by var.node\_groups keys |
 | oidc\_provider\_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
-| primary_cluster_security_group_id | The Primary Cluster security group ID created by the EKS cluster on 1.14 or later. |
+| primary\_cluster\_security\_group\_id | The Primary Cluster security group ID created by the EKS cluster on 1.14 or later. |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
 | worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,6 +68,11 @@ output "oidc_provider_arn" {
   value       = var.enable_irsa ? concat(aws_iam_openid_connect_provider.oidc_provider[*].arn, [""])[0] : null
 }
 
+output "primary_cluster_security_group_id" {
+  description = "The Primary Cluster security group ID created by the EKS cluster on 1.14 or later."
+  value       = var.cluster_version >= 1.14 ? element(concat(aws_eks_cluster.this[*].vpc_config[0].cluster_security_group_id, list("")), 0) : null
+}
+
 output "workers_asg_arns" {
   description = "IDs of the autoscaling groups containing workers."
   value = concat(

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,7 +24,7 @@ output "cluster_version" {
 }
 
 output "cluster_security_group_id" {
-  description = "Security group ID attached to the EKS cluster."
+  description = "Security group ID attached to the EKS cluster. On 1.14 or later, this is the 'Additional security groups' in the EKS console."
   value       = local.cluster_security_group_id
 }
 
@@ -48,6 +48,11 @@ output "cluster_oidc_issuer_url" {
   value       = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
 }
 
+output "cluster_primary_security_group_id" {
+  description = "The cluster primary security group ID created by the EKS cluster on 1.14 or later. Referred to as 'Cluster security group' in the EKS console."
+  value       = var.cluster_version >= 1.14 ? element(concat(aws_eks_cluster.this[*].vpc_config[0].cluster_security_group_id, list("")), 0) : null
+}
+
 output "cloudwatch_log_group_name" {
   description = "Name of cloudwatch log group created"
   value       = aws_cloudwatch_log_group.this[*].name
@@ -66,11 +71,6 @@ output "kubeconfig_filename" {
 output "oidc_provider_arn" {
   description = "The ARN of the OIDC Provider if `enable_irsa = true`."
   value       = var.enable_irsa ? concat(aws_iam_openid_connect_provider.oidc_provider[*].arn, [""])[0] : null
-}
-
-output "primary_cluster_security_group_id" {
-  description = "The Primary Cluster security group ID created by the EKS cluster on 1.14 or later."
-  value       = var.cluster_version >= 1.14 ? element(concat(aws_eks_cluster.this[*].vpc_config[0].cluster_security_group_id, list("")), 0) : null
 }
 
 output "workers_asg_arns" {


### PR DESCRIPTION
# PR o'clock
Add cluster security group output as "primary cluster security group id".  

This is a short term fix to provide the cluster security group id until 1.16 is released and node groups can be refactored to move cluster security group id to additional security group id.   With 1.16 release, 1.13 will no longer be maintained which will cause the issues with backwards compatibility to go away because the old node groups will no longer be supported.  

## Description

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/799
and 
https://github.com/terraform-aws-modules/terraform-aws-eks/pull/792

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
