### PR TITLE
fix: Fix terraform destroy errors when using worker_group_launch_templates

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -8,6 +8,7 @@ locals {
         coalescelist(
           aws_iam_instance_profile.workers_launch_template.*.role,
           data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile.*.role_name,
+          [""]
         ),
         index
       )}"


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

Adds a line to make `worker_group_launch_templates` consistent with `worker_groups` and fix an error that could arise during `terraform destroy`
[#841 ](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/841)

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
