### PR TITLE
docs: Remove useless template provider in examples

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,10 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -15,10 +15,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -19,10 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -19,10 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -19,10 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -19,10 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }


### PR DESCRIPTION
# PR o'clock

## Description

Remove useless external template provider after https://github.com/terraform-aws-modules/terraform-aws-eks/pull/854

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
