### PR TITLE
feat: Create kubeconfig with non-executable permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | terraform | >= 0.12.9 |
 | aws | >= 2.52.0 |
 | kubernetes | >= 1.11.1 |
-| local | >= 1.2 |
+| local | >= 1.4 |
 | null | >= 2.1 |
 | random | >= 2.1 |
 
@@ -141,7 +141,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 |------|---------|
 | aws | >= 2.52.0 |
 | kubernetes | >= 1.11.1 |
-| local | >= 1.2 |
+| local | >= 1.4 |
 | null | >= 2.1 |
 | random | >= 2.1 |
 

--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,5 +1,7 @@
 resource "local_file" "kubeconfig" {
-  count    = var.write_kubeconfig && var.create_eks ? 1 : 0
-  content  = local.kubeconfig
-  filename = substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path
+  count                = var.write_kubeconfig && var.create_eks ? 1 : 0
+  content              = local.kubeconfig
+  filename             = substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path
+  file_permission      = "0644"
+  directory_permission = "0755"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws        = ">= 2.52.0"
-    local      = ">= 1.2"
+    local      = ">= 1.4"
     null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = ">= 1.11.1"


### PR DESCRIPTION
Kubeconfig does not really need to be executable, so let's not create it with executable bit set.

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
