### PR TITLE
feat: Add a homemade `depends_on` for MNG submodule to ensure ordering of resource creation

### DIFF
--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -52,6 +52,7 @@ No requirements.
 | cluster\_name | Name of parent cluster | `string` | n/a | yes |
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | default\_iam\_role\_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | n/a | yes |
+| ng\_depends\_on | List of references to other resources this submodule depends on | `any` | `null` | no |
 | node\_groups | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | `{}` | no |
 | node\_groups\_defaults | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | n/a | yes |
 | tags | A map of tags to add to all resources | `map(string)` | n/a | yes |

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -47,4 +47,6 @@ resource "aws_eks_node_group" "workers" {
     create_before_destroy = true
     ignore_changes        = [scaling_config.0.desired_size]
   }
+
+  depends_on = [var.ng_depends_on]
 }

--- a/modules/node_groups/random.tf
+++ b/modules/node_groups/random.tf
@@ -18,4 +18,6 @@ resource "random_pet" "node_groups" {
     subnet_ids      = join("|", each.value["subnets"])
     node_group_name = join("-", [var.cluster_name, each.key])
   }
+
+  depends_on = [var.ng_depends_on]
 }

--- a/modules/node_groups/variables.tf
+++ b/modules/node_groups/variables.tf
@@ -34,3 +34,11 @@ variable "node_groups" {
   type        = any
   default     = {}
 }
+
+# Hack for a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
+# Will be removed in Terraform 0.13 with the support of module's `depends_on` https://github.com/hashicorp/terraform/issues/10462
+variable "ng_depends_on" {
+  description = "List of references to other resources this submodule depends on"
+  type        = any
+  default     = null
+}

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -15,6 +15,7 @@ module "node_groups" {
   # Will be removed in Terraform 0.13
   ng_depends_on = [
     aws_eks_cluster.this,
+    kubernetes_config_map.aws_auth,
     aws_iam_role_policy_attachment.workers_AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.workers_AmazonEKS_CNI_Policy,
     aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -1,28 +1,22 @@
-# Hack to ensure ordering of resource creation. Do not create node_groups
-# before other resources are ready. Removes race conditions
-data "null_data_source" "node_groups" {
-  count = var.create_eks ? 1 : 0
-
-  inputs = {
-    cluster_name = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
-
-    # Ensure these resources are created before "unlocking" the data source.
-    # `depends_on` causes a refresh on every run so is useless here.
-    # [Re]creating or removing these resources will trigger recreation of Node Group resources
-    aws_auth        = coalescelist(kubernetes_config_map.aws_auth[*].id, [""])[0]
-    role_NodePolicy = coalescelist(aws_iam_role_policy_attachment.workers_AmazonEKSWorkerNodePolicy[*].id, [""])[0]
-    role_CNI_Policy = coalescelist(aws_iam_role_policy_attachment.workers_AmazonEKS_CNI_Policy[*].id, [""])[0]
-    role_Container  = coalescelist(aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly[*].id, [""])[0]
-  }
-}
-
 module "node_groups" {
   source                 = "./modules/node_groups"
   create_eks             = var.create_eks
-  cluster_name           = coalescelist(data.null_data_source.node_groups[*].outputs["cluster_name"], [""])[0]
+  cluster_name           = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
   default_iam_role_arn   = coalescelist(aws_iam_role.workers[*].arn, [""])[0]
   workers_group_defaults = local.workers_group_defaults
   tags                   = var.tags
   node_groups_defaults   = var.node_groups_defaults
   node_groups            = var.node_groups
+
+  # Hack to ensure ordering of resource creation.
+  # This is a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
+  # Do not create node_groups before other resources are ready and removes race conditions
+  # Ensure these resources are created before "unlocking" the data source.
+  # Will be removed in Terraform 0.13
+  ng_depends_on = [
+    aws_eks_cluster.this,
+    aws_iam_role_policy_attachment.workers_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.workers_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly
+  ]
 }


### PR DESCRIPTION
# PR o'clock

## Description

Hack to add a "homemade" depends_on as suggested https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2 to ensure ordering of ressource creation for managed node groups.

I don't really like the approach, but the hack doesn't add complexity (because, there are only 2 resources in the submodule in which we add an explicit `depends_on`) and seems to work as expected.

I tested it to resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/843

__Note:__ I'm opening this PR to start discussion. So feedbacks are welcomed.

### Questions

- Is this something we want to do ?
- @dpiddockcmp is your [comment](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/node_groups.tf#L10) still apply ?

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
