### PR TITLE
fix: Use splat syntax for cluster name to avoid `(known after apply)` in managed node groups

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -1,6 +1,8 @@
 # Hack to ensure ordering of resource creation. Do not create node_groups
 # before other resources are ready. Removes race conditions
 data "null_data_source" "node_groups" {
+  count = var.create_eks ? 1 : 0
+
   inputs = {
     cluster_name = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
 

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -1,10 +1,8 @@
 # Hack to ensure ordering of resource creation. Do not create node_groups
 # before other resources are ready. Removes race conditions
 data "null_data_source" "node_groups" {
-  count = var.create_eks ? 1 : 0
-
   inputs = {
-    cluster_name = aws_eks_cluster.this[0].name
+    cluster_name = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
 
     # Ensure these resources are created before "unlocking" the data source.
     # `depends_on` causes a refresh on every run so is useless here.


### PR DESCRIPTION
# PR o'clock

## Description

After some tests, I've noticed that all inputs of the `null_data_source` are already know.

```shell
  # module.eks.data.null_data_source.node_groups[0] will be read during apply
  # (config refers to values not yet known)
 <= data "null_data_source" "node_groups"  {
      + has_computed_default = (known after apply)
      + id                   = (known after apply)
      + inputs               = {
          + "aws_auth"        = "kube-system/aws-auth"
          + "cluster_name"    = "test-eks-uIVr3XSp"
          + "role_CNI_Policy" = "test-eks-uIVr3XSp20200505210731845200000005-20200505210733402400000008"
          + "role_Container"  = "test-eks-uIVr3XSp20200505210731845200000005-20200505210733399800000007"
          + "role_NodePolicy" = "test-eks-uIVr3XSp20200505210731845200000005-20200505210733441800000009"
        }
      + outputs              = (known after apply)
      + random               = (known after apply)
    }
```
The unknown values are computed one like `random`, `id`, etc. and those will be read only during apply unless we remove the `count`. In that way Terraform will always read datas before apply and avoid the `(known after apply)` issue. Sounds like a Terraform magic again 🤷‍♂️

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/843 #862 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
