### PR TITLE
improvement: Add cpu_credits for tf0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - bundle install
 
 before_script:
-- export TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')
+- export TERRAFORM_VERSION='0.11.14'
 - curl --silent --output terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 - unzip terraform.zip ; rm -f terraform.zip; chmod +x terraform
 - mkdir -p ${HOME}/bin ; export PATH=${PATH}:${HOME}/bin; mv terraform ${HOME}/bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added support for termination policies for Auto Scaling group (by @nusnewob)
+- Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` and `worker_groups_launch_template_mixed` (by @rinrailin)
 
 # History
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next release
 
-## [[v4.0.3](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v4.0.0...v4.0.2)] - 2019-09-03]
+## [[v4.?.?](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v4.0.2...tf0.11)] - 2020-??-??]
 
 ### Added
 
@@ -16,7 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 # History
 
-## [[v4.0.2](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v4.0.0...v4.0.1)] - 2019-05-07]
+## [[v4.0.2](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v4.0.1...v4.0.2)] - 2019-05-07]
 
 ### Changed
 

--- a/local.tf
+++ b/local.tf
@@ -54,6 +54,7 @@ locals {
     launch_template_placement_group   = ""                                            # The name of the placement group into which to launch the instances, if any.
     root_encrypted                    = ""                                            # Whether the volume should be encrypted or not
     eni_delete                        = true                                          # Delete the ENI on termination (if set to false you will have to manually delete before destroying)
+    cpu_credits                       = "standard"                                    # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
 
     # Settings for launch templates with mixed instances policy
     override_instance_type_1                 = "m5.large"     # Override instance type 1 for mixed instances policy

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -64,6 +64,10 @@ resource "aws_launch_template" "workers_launch_template" {
   user_data     = "${base64encode(element(data.template_file.launch_template_userdata.*.rendered, count.index))}"
   ebs_optimized = "${lookup(var.worker_groups_launch_template[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups_launch_template[count.index], "instance_type", local.workers_group_defaults["instance_type"]), false))}"
 
+  credit_specification {
+    cpu_credits = "${lookup(var.worker_groups_launch_template[count.index], "cpu_credits", local.workers_group_defaults["cpu_credits"])}"
+  }
+
   monitoring {
     enabled = "${lookup(var.worker_groups_launch_template[count.index], "enable_monitoring", local.workers_group_defaults["enable_monitoring"])}"
   }

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -88,6 +88,10 @@ resource "aws_launch_template" "workers_launch_template_mixed" {
   user_data     = "${base64encode(element(data.template_file.workers_launch_template_mixed.*.rendered, count.index))}"
   ebs_optimized = "${lookup(var.worker_groups_launch_template_mixed[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups_launch_template_mixed[count.index], "instance_type", local.workers_group_defaults["instance_type"]), false))}"
 
+  credit_specification {
+    cpu_credits = "${lookup(var.worker_groups_launch_template[count.index], "cpu_credits", local.workers_group_defaults["cpu_credits"])}"
+  }
+
   monitoring {
     enabled = "${lookup(var.worker_groups_launch_template_mixed[count.index], "enable_monitoring", local.workers_group_defaults["enable_monitoring"])}"
   }


### PR DESCRIPTION
# PR o'clock

## Description

Add `cpu_credits` param for the workers defined in `worker_groups_launch_template*` for tf0.11 branch.
Same as https://github.com/terraform-aws-modules/terraform-aws-eks/issues/253 but for terraform v0.11.*

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
