### PR TITLE
docs: Add notes for Kubernetes 1.16

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -24,6 +24,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
 {{ end -}}
 {{ end }}
 {{ end -}}
+
+{{- if .Unreleased.NoteGroups -}}
+{{ range .Unreleased.NoteGroups -}}
+{{ .Title }}:
+{{ range .Notes -}}
+- {{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
 {{ end -}}
 
 {{ range .Versions }}
@@ -49,8 +58,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 {{- if .NoteGroups -}}
 {{ range .NoteGroups -}}
 {{ .Title }}:
-{{ range .Notes }}
-{{ .Body }}
+{{ range .Notes -}}
+- {{ .Body }}
 {{ end }}
 {{ end -}}
 {{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -36,7 +36,7 @@ options:
 
   notes:
     keywords:
-      - BREAKING CHANGE
+      - BREAKING CHANGES
       - NOTES
 
   refs:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Read the [AWS docs on EKS to get connected to the k8s dashboard](https://docs.aw
 * You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
 * You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources. The VPC satisfies [EKS requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html).
 
+## Important note
+
+The default `cluster_version`is now 1.16. Kubernetes 1.16 includes a number of deprecated API removals, and you need to ensure your applications and add ons are updated, or workloads could fail after the upgrade is complete. For more information on the API removals, see the [Kubernetes blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). For action you may need to take before upgrading, see the steps in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#1-16-prequisites).
+
+Please set explicitly your `cluster_version` to an older EKS version untill your workload are ready for Kubernetes 1.16.
+
 ## Usage example
 
 A full example leveraging other community modules is contained in the [examples/basic directory](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/basic).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read the [AWS docs on EKS to get connected to the k8s dashboard](https://docs.aw
 
 The default `cluster_version`is now 1.16. Kubernetes 1.16 includes a number of deprecated API removals, and you need to ensure your applications and add ons are updated, or workloads could fail after the upgrade is complete. For more information on the API removals, see the [Kubernetes blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). For action you may need to take before upgrading, see the steps in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#1-16-prequisites).
 
-Please set explicitly your `cluster_version` to an older EKS version untill your workload are ready for Kubernetes 1.16.
+Please set explicitly your `cluster_version` to an older EKS version until your workloads are ready for Kubernetes 1.16.
 
 ## Usage example
 


### PR DESCRIPTION
# PR o'clock

## Description

Add notes and breaking change about Kubernetes 1.16 before https://github.com/terraform-aws-modules/terraform-aws-eks/pull/871 get merged.

By commiting this, we'll generate changelog like this:

------------------

DOCS:
- Add notes for Kubernetes 1.16
- Remove useless template provider in examples ([#863](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/863))

BUG FIXES:
- Use splat syntax for cluster name to avoid `(known after apply)` in managed node groups ([#868](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/868))

FEATURES:
- Create kubeconfig with non-executable permissions ([#864](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/864))
- Change EKS default version to 1.16 ([#857](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/857))

ENHANCEMENTS:
- Remove dependency on external template provider ([#854](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/854))

BREAKING CHANGES:
- The default `cluster_version`is now 1.16. Kubernetes 1.16 includes a number of deprecated API removals, and you need to ensure your applications and add ons are updated, or workloads could fail after the upgrade is complete. For more information on the API removals, see the [Kubernetes blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). For action you may need to take before upgrading, see the steps in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html[#1](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1)-16-prequisites).
Please set explicitly your `cluster_version` to an older EKS version untill your workload are ready for Kubernetes 1.16.

--------

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
