### PR TITLE
fix: Fix Launch Templates error with aws 2.61.0

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -68,7 +68,7 @@ locals {
     suspended_processes           = ["AZRebalance"]             # A list of processes to suspend. i.e. ["AZRebalance", "HealthCheck", "ReplaceUnhealthy"]
     target_group_arns             = null                        # A list of Application LoadBalancer (ALB) target group ARNs to be associated to the autoscaling group
     enabled_metrics               = []                          # A list of metrics to be collected i.e. ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity"]
-    placement_group               = ""                          # The name of the placement group into which to launch the instances, if any.
+    placement_group               = null                        # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                          # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
     termination_policies          = []                          # A list of policies to decide how the instances in the auto scale group should be terminated.
     platform                      = "linux"                     # Platform of workers. either "linux" or "windows"
@@ -78,7 +78,7 @@ locals {
     root_kms_key_id                   = ""                                       # The KMS key to use when encrypting the root storage device
     launch_template_version           = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
     launch_template_placement_tenancy = "default"                                # The placement tenancy for instances
-    launch_template_placement_group   = ""                                       # The name of the placement group into which to launch the instances, if any.
+    launch_template_placement_group   = null                                     # The name of the placement group into which to launch the instances, if any.
     root_encrypted                    = false                                    # Whether the volume should be encrypted or not
     eni_delete                        = true                                     # Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying)
     cpu_credits                       = "standard"                               # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -294,17 +294,17 @@ resource "aws_launch_template" "workers_launch_template" {
     )
   }
 
-  placement {
-    tenancy = lookup(
-      var.worker_groups_launch_template[count.index],
-      "launch_template_placement_tenancy",
-      local.workers_group_defaults["launch_template_placement_tenancy"],
-    )
-    group_name = lookup(
-      var.worker_groups_launch_template[count.index],
-      "launch_template_placement_group",
-      local.workers_group_defaults["launch_template_placement_group"],
-    )
+  dynamic placement {
+    for_each = lookup(var.worker_groups_launch_template[count.index], "launch_template_placement_group", local.workers_group_defaults["launch_template_placement_group"]) != null ? [lookup(var.worker_groups_launch_template[count.index], "launch_template_placement_group", local.workers_group_defaults["launch_template_placement_group"])] : []
+
+    content {
+      tenancy = lookup(
+        var.worker_groups_launch_template[count.index],
+        "launch_template_placement_tenancy",
+        local.workers_group_defaults["launch_template_placement_tenancy"],
+      )
+      group_name = placement.value
+    }
   }
 
   dynamic instance_market_options {


### PR DESCRIPTION
# PR o'clock

## Description

Updating Launch Templates with aws provider 2.61.0 generates an error when creating the ASG or attempting to launch new instances. This is caused by the aws provider adding support to the launch template for `placement.partition_number`. I think the root issue is go-aws-sdk defaulting this to 0 as it's an integer and the module setting the placement block when no placement group is in use. Having partition_number set but no placement group name is a validation error. For example when creating a new ASG:
`Error: Error creating AutoScaling Group: ValidationError: You must use a valid fully-formed launch template. You cannot use PartitionNumber with a Placement Group that does not exist. Specify a valid Placement Group and try again.`

Resolve the issue by not setting the placement block if no placement group name is passed in.

This will cause an update for all users using launch templates unless they are using placement groups.

Fixes #874 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
