### PR TITLE
improvement: add max_instance_lifetime to asg for tf0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for termination policies for Auto Scaling group (by @nusnewob)
 - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` and `worker_groups_launch_template_mixed` (by @rinrailin)
+- Added `max_instance_lifetime` param for the workers defined in `worker_groups_launch_template` and `worker_groups_launch_template_mixed` (by @sortigoza)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -103,58 +103,71 @@ Many thanks to [the contributors listed here](https://github.com/terraform-aws-m
 MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/LICENSE) for full details.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| local | n/a |
+| null | n/a |
+| template | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | string | `"true"` | no |
-| cluster\_create\_timeout | Timeout value when creating the EKS cluster. | string | `"15m"` | no |
-| cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | string | `"15m"` | no |
-| cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | list | `[]` | no |
-| cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | string | `"false"` | no |
-| cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | string | `"true"` | no |
-| cluster\_iam\_role\_name | IAM role name for the cluster. Only applicable if manage_cluster_iam_resources is set to false. | string | `""` | no |
-| cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | string | n/a | yes |
-| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | string | `""` | no |
-| cluster\_version | Kubernetes version to use for the EKS cluster. | string | `"1.12"` | no |
-| config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | string | `"./"` | no |
-| iam\_path | If provided, all IAM roles will be created on this path. | string | `"/"` | no |
-| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | list | `[]` | no |
-| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | string | `"aws-iam-authenticator"` | no |
-| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]. | list | `[]` | no |
-| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = "eks"}. | map | `{}` | no |
-| kubeconfig\_name | Override the default name used for items kubeconfig. | string | `""` | no |
-| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | list | `[ "/bin/sh", "-c" ]` | no |
-| manage\_aws\_auth | Whether to apply the aws-auth configmap file. | string | `"true"` | no |
-| manage\_cluster\_iam\_resources | Whether to let the module manage cluster IAM resources. If set to false, cluster_iam_role_name must be specified. | string | `"true"` | no |
-| manage\_worker\_iam\_resources | Whether to let the module manage worker IAM resources. If set to false, iam_instance_profile_name must be specified for workers. | string | `"true"` | no |
-| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list | `[]` | no |
-| map\_accounts\_count | The count of accounts in the map_accounts list. | string | `"0"` | no |
-| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list | `[]` | no |
-| map\_roles\_count | The count of roles in the map_roles list. | string | `"0"` | no |
-| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | list | `[]` | no |
-| map\_users\_count | The count of roles in the map_users list. | string | `"0"` | no |
-| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | string | `""` | no |
-| subnets | A list of subnets to place the EKS cluster and workers within. | list | n/a | yes |
-| tags | A map of tags to add to all resources. | map | `{}` | no |
-| vpc\_id | VPC where the cluster and workers will be deployed. | string | n/a | yes |
-| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | list | `[]` | no |
-| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | string | `"v*"` | no |
-| worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | string | `"true"` | no |
-| worker\_group\_count | The number of maps contained within the worker_groups list. | string | `"1"` | no |
-| worker\_group\_launch\_template\_count | The number of maps contained within the worker_groups_launch_template list. | string | `"0"` | no |
-| worker\_group\_launch\_template\_mixed\_count | The number of maps contained within the worker_groups_launch_template_mixed list. | string | `"0"` | no |
-| worker\_group\_tags | A map defining extra tags to be applied to the worker group ASG. | map | `{ "default": [] }` | no |
-| worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_groups\_launch\_template\_mixed | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys. | list | `[ { "name": "default" } ]` | no |
-| worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | string | `""` | no |
-| worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | string | `"1025"` | no |
-| workers\_additional\_policies | Additional policies to be added to workers | list | `[]` | no |
-| workers\_additional\_policies\_count |  | string | `"0"` | no |
-| workers\_group\_defaults | Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys. | map | `{}` | no |
-| write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | string | `"true"` | no |
-| write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | string | `"true"` | no |
+|------|-------------|------|---------|:--------:|
+| cluster\_create\_security\_group | Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`. | `bool` | `true` | no |
+| cluster\_create\_timeout | Timeout value when creating the EKS cluster. | `string` | `"15m"` | no |
+| cluster\_delete\_timeout | Timeout value when deleting the EKS cluster. | `string` | `"15m"` | no |
+| cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | `list` | `[]` | no |
+| cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | `bool` | `false` | no |
+| cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | `bool` | `true` | no |
+| cluster\_iam\_role\_name | IAM role name for the cluster. Only applicable if manage\_cluster\_iam\_resources is set to false. | `string` | `""` | no |
+| cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | `any` | n/a | yes |
+| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | `string` | `""` | no |
+| cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | `"1.12"` | no |
+| config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Should end in a forward slash `/` . | `string` | `"./"` | no |
+| iam\_path | If provided, all IAM roles will be created on this path. | `string` | `"/"` | no |
+| kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | `list` | `[]` | no |
+| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | `string` | `"aws-iam-authenticator"` | no |
+| kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster\_name]. | `list` | `[]` | no |
+| kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS\_PROFILE = "eks"}. | `map` | `{}` | no |
+| kubeconfig\_name | Override the default name used for items kubeconfig. | `string` | `""` | no |
+| local\_exec\_interpreter | Command to run for local-exec resources. Must be a shell-style interpreter. If you are on Windows Git Bash is a good choice. | `list` | <pre>[<br>  "/bin/sh",<br>  "-c"<br>]</pre> | no |
+| manage\_aws\_auth | Whether to apply the aws-auth configmap file. | `bool` | `true` | no |
+| manage\_cluster\_iam\_resources | Whether to let the module manage cluster IAM resources. If set to false, cluster\_iam\_role\_name must be specified. | `bool` | `true` | no |
+| manage\_worker\_iam\_resources | Whether to let the module manage worker IAM resources. If set to false, iam\_instance\_profile\_name must be specified for workers. | `bool` | `true` | no |
+| map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | `list` | `[]` | no |
+| map\_accounts\_count | The count of accounts in the map\_accounts list. | `string` | `0` | no |
+| map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | `list` | `[]` | no |
+| map\_roles\_count | The count of roles in the map\_roles list. | `string` | `0` | no |
+| map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | `list` | `[]` | no |
+| map\_users\_count | The count of roles in the map\_users list. | `string` | `0` | no |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `""` | no |
+| subnets | A list of subnets to place the EKS cluster and workers within. | `list` | n/a | yes |
+| tags | A map of tags to add to all resources. | `map` | `{}` | no |
+| vpc\_id | VPC where the cluster and workers will be deployed. | `any` | n/a | yes |
+| worker\_additional\_security\_group\_ids | A list of additional security group ids to attach to worker instances | `list` | `[]` | no |
+| worker\_ami\_name\_filter | Additional name filter for AWS EKS worker AMI. Default behaviour will get latest for the cluster\_version but could be set to a release from amazon-eks-ami, e.g. "v20190220" | `string` | `"v*"` | no |
+| worker\_create\_security\_group | Whether to create a security group for the workers or attach the workers to `worker_security_group_id`. | `bool` | `true` | no |
+| worker\_group\_count | The number of maps contained within the worker\_groups list. | `string` | `"1"` | no |
+| worker\_group\_launch\_template\_count | The number of maps contained within the worker\_groups\_launch\_template list. | `string` | `"0"` | no |
+| worker\_group\_launch\_template\_mixed\_count | The number of maps contained within the worker\_groups\_launch\_template\_mixed list. | `string` | `"0"` | no |
+| worker\_group\_tags | A map defining extra tags to be applied to the worker group ASG. | `map` | <pre>{<br>  "default": []<br>}</pre> | no |
+| worker\_groups | A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers\_group\_defaults for valid keys. | `list` | <pre>[<br>  {<br>    "name": "default"<br>  }<br>]</pre> | no |
+| worker\_groups\_launch\_template | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers\_group\_defaults for valid keys. | `list` | <pre>[<br>  {<br>    "name": "default"<br>  }<br>]</pre> | no |
+| worker\_groups\_launch\_template\_mixed | A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers\_group\_defaults for valid keys. | `list` | <pre>[<br>  {<br>    "name": "default"<br>  }<br>]</pre> | no |
+| worker\_security\_group\_id | If provided, all workers will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the EKS cluster. | `string` | `""` | no |
+| worker\_sg\_ingress\_from\_port | Minimum port number from which pods will accept communication. Must be changed to a lower value if some pods in your cluster will expose a port lower than 1025 (e.g. 22, 80, or 443). | `string` | `"1025"` | no |
+| workers\_additional\_policies | Additional policies to be added to workers | `list` | `[]` | no |
+| workers\_additional\_policies\_count | n/a | `number` | `0` | no |
+| workers\_group\_defaults | Override default values for target groups. See workers\_group\_defaults\_defaults in local.tf for valid keys. | `map` | `{}` | no |
+| write\_aws\_auth\_config | Whether to write the aws-auth configmap file. | `bool` | `true` | no |
+| write\_kubeconfig | Whether to write a Kubectl config file containing the cluster configuration. Saved to `config_output_path`. | `bool` | `true` | no |
 
 ## Outputs
 
@@ -166,6 +179,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_iam\_role\_arn | IAM role ARN of the EKS cluster. |
 | cluster\_iam\_role\_name | IAM role name of the EKS cluster. |
 | cluster\_id | The name/id of the EKS cluster. |
+| cluster\_oidc\_issuer\_url | The URL on the EKS cluster OIDC Issuer |
 | cluster\_security\_group\_id | Security group ID attached to the EKS cluster. |
 | cluster\_version | The Kubernetes server version for the EKS cluster. |
 | config\_map\_aws\_auth | A kubernetes configuration to authenticate to this EKS cluster. |

--- a/local.tf
+++ b/local.tf
@@ -45,6 +45,7 @@ locals {
     placement_group               = ""                              # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                              # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
     termination_policies          = ""                              # A list of policies to decide how the instances in the auto scale group should be terminated.
+    max_instance_lifetime         = ""                              # The maximum amount of time, in seconds, that an instance can be in service.
 
     # Settings for launch templates
     root_block_device_name            = "${data.aws_ami.eks_worker.root_device_name}" # Root device name for workers. If non is provided, will assume default AMI was used.

--- a/workers.tf
+++ b/workers.tf
@@ -16,6 +16,7 @@ resource "aws_autoscaling_group" "workers" {
   enabled_metrics         = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "enabled_metrics", ""), local.workers_group_defaults["enabled_metrics"])))}"]
   placement_group         = "${lookup(var.worker_groups[count.index], "placement_group", local.workers_group_defaults["placement_group"])}"
   termination_policies    = ["${compact(split(",", coalesce(lookup(var.worker_groups[count.index], "termination_policies", ""), local.workers_group_defaults["termination_policies"])))}"]
+  max_instance_lifetime   = "${lookup(var.worker_groups[count.index], "max_instance_lifetime", local.workers_group_defaults["max_instance_lifetime"])}"
 
   tags = ["${concat(
     list(

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -15,6 +15,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   enabled_metrics         = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template[count.index], "enabled_metrics", ""), local.workers_group_defaults["enabled_metrics"])))}"]
   placement_group         = "${lookup(var.worker_groups_launch_template[count.index], "placement_group", local.workers_group_defaults["placement_group"])}"
   termination_policies    = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template[count.index], "termination_policies", ""), local.workers_group_defaults["termination_policies"])))}"]
+  max_instance_lifetime   = "${lookup(var.worker_groups_launch_template[count.index], "max_instance_lifetime", local.workers_group_defaults["max_instance_lifetime"])}"
 
   launch_template {
     id      = "${element(aws_launch_template.workers_launch_template.*.id, count.index)}"

--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -15,6 +15,7 @@ resource "aws_autoscaling_group" "workers_launch_template_mixed" {
   enabled_metrics         = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template_mixed[count.index], "enabled_metrics", ""), local.workers_group_defaults["enabled_metrics"])))}"]
   placement_group         = "${lookup(var.worker_groups_launch_template_mixed[count.index], "placement_group", local.workers_group_defaults["placement_group"])}"
   termination_policies    = ["${compact(split(",", coalesce(lookup(var.worker_groups_launch_template_mixed[count.index], "termination_policies", ""), local.workers_group_defaults["termination_policies"])))}"]
+  max_instance_lifetime   = "${lookup(var.worker_groups_launch_template_mixed[count.index], "max_instance_lifetime", local.workers_group_defaults["max_instance_lifetime"])}"
 
   mixed_instances_policy {
     instances_distribution {


### PR DESCRIPTION
# PR o'clock

## Description

- adds max_instance_lifetime parameter to the ASG resources.

This configuration is useful when implementing a "phoenix server" patter to rotate older instances.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
