### PR TITLE
fix: Ensure kubeconfig ends with \n

### DIFF
--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -35,4 +35,4 @@ users:
         - name: ${k}
           value: ${v}
   %{~ endfor ~}
-%{ endif ~}
+%{ endif }


### PR DESCRIPTION
In order to be a text file according to POSIX, file needs to be composed of
text lines. Text line is defined as sequence of characters ending in \n. Sadly,
`~}` did strip everything including the \n, so the kubeconfing did not end
with a new line. Output empty string at the end to make sure of it.

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
