### PR TITLE
improvement: Move kubernetes provider into the module

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -79,3 +79,13 @@ data "aws_iam_instance_profile" "custom_worker_group_launch_template_iam_instanc
 }
 
 data "aws_partition" "current" {}
+
+data "aws_eks_cluster" "cluster" {
+  count = var.create_eks ? 1 : 0
+  name  = concat(aws_eks_cluster.this[*].id, [""])[0]
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  count = var.create_eks ? 1 : 0
+  name  = concat(aws_eks_cluster.this[*].id, [""])[0]
+}

--- a/data.tf
+++ b/data.tf
@@ -82,10 +82,14 @@ data "aws_partition" "current" {}
 
 data "aws_eks_cluster" "cluster" {
   count = var.create_eks ? 1 : 0
-  name  = concat(aws_eks_cluster.this[*].id, [""])[0]
+  # The concat here is a trick to stop data sources from appearing in the plan
+  # output when the cluster is being modified.
+  name = concat(aws_eks_cluster.this[*].id, [""])[0]
 }
 
 data "aws_eks_cluster_auth" "cluster" {
   count = var.create_eks ? 1 : 0
-  name  = concat(aws_eks_cluster.this[*].id, [""])[0]
+  # The concat here is a trick to stop data sources from appearing in the plan
+  # output when the cluster is being modified.
+  name = concat(aws_eks_cluster.this[*].id, [""])[0]
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,22 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 data "aws_availability_zones" "available" {
 }
 

--- a/examples/create_false/main.tf
+++ b/examples/create_false/main.tf
@@ -2,24 +2,6 @@ provider "aws" {
   region = var.region
 }
 
-data "aws_eks_cluster" "cluster" {
-  count = 0
-  name  = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  count = 0
-  name  = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = element(concat(data.aws_eks_cluster.cluster[*].endpoint, list("")), 0)
-  cluster_ca_certificate = base64decode(element(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, list("")), 0))
-  token                  = element(concat(data.aws_eks_cluster_auth.cluster[*].token, list("")), 0)
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 module "eks" {
   source     = "../.."
   create_eks = false

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -15,22 +15,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 data "aws_availability_zones" "available" {}
 
 data "aws_caller_identity" "current" {}

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -19,22 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 data "aws_availability_zones" "available" {
 }
 

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -19,22 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 data "aws_availability_zones" "available" {
 }
 

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -19,22 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 data "aws_availability_zones" "available" {
 }
 

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -19,22 +19,6 @@ provider "null" {
   version = "~> 2.1"
 }
 
-data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
-}
-
-data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.11"
-}
-
 data "aws_availability_zones" "available" {
 }
 

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -1,0 +1,6 @@
+provider "kubernetes" {
+  host                   = concat(data.aws_eks_cluster.cluster[*].endpoint, [""])[0]
+  cluster_ca_certificate = base64decode(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, [""])[0])
+  token                  = concat(data.aws_eks_cluster_auth.cluster[*].token, [""])[0]
+  load_config_file       = false
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,9 @@
 output "cluster_id" {
   description = "The name/id of the EKS cluster."
   value       = element(concat(aws_eks_cluster.this.*.id, list("")), 0)
-  depends_on  = [null_resource.wait_for_cluster]
+  # So that calling plans wait for the cluster to be available before attempting
+  # to use it. They do not need to duplicate this null_resource
+  depends_on = [null_resource.wait_for_cluster]
 }
 
 output "cluster_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,7 @@
 output "cluster_id" {
   description = "The name/id of the EKS cluster."
   value       = element(concat(aws_eks_cluster.this.*.id, list("")), 0)
+  depends_on  = [null_resource.wait_for_cluster]
 }
 
 output "cluster_arn" {


### PR DESCRIPTION
# PR o'clock

## Description

I don't know about the other maintainers but I'm bored of the recent increase in the number of Issues caused by people who haven't read the documentation and thus not included the kubernetes provider in their top level. I'm sure that new users who are bumping in to this are also frustrated.

I have a suspicion that the cause is the broken example from Hashicorp as part of their [EKS learning course](https://learn.hashicorp.com/terraform/kubernetes/provision-eks-cluster). In the [source code](https://github.com/hashicorp/learn-terraform-provision-eks-cluster) they forgot to commit the kubernetes provider definition. Data sources and all the other providers are there 🤷 

Solution: include the kubernetes provider inside the module. This is a design pattern recommended against by Hashicorp.  But it works for the equivalent [GKE module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/v9.1.0/auth.tf#L29..L35)

I've tested this by creating new "basic" and "launch_template" clusters as well as throwing it at an existing cluster. Seems to work.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
