### PR TITLE
fix: Change the order of the worker tags

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -110,12 +110,12 @@ resource "aws_autoscaling_group" "workers" {
         "propagate_at_launch" = true
       },
       {
-        "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.this[0].name}"
+        "key"                 = "k8s.io/cluster/${aws_eks_cluster.this[0].name}"
         "value"               = "owned"
         "propagate_at_launch" = true
       },
       {
-        "key"                 = "k8s.io/cluster/${aws_eks_cluster.this[0].name}"
+        "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.this[0].name}"
         "value"               = "owned"
         "propagate_at_launch" = true
       },


### PR DESCRIPTION
# PR o'clock

## Description

When you spin up a terraform worker group, it will create everything, however when you run a subsequent `terraform plan` you get an ordering change of the tags. This will just make sure that the tag is created in the correct order.
The problem will give a plan output like this. This will fix it.

```
      ~ tags                      = [
            {
                "key"                 = "Name"
                "propagate_at_launch" = "true"
                "value"               = "k8s-dev-spot-2-eks_asg"
            },
          - {
              - "key"                 = "k8s.io/cluster/k8s-dev"
              - "propagate_at_launch" = "true"
              - "value"               = "owned"
            },
            {
                "key"                 = "kubernetes.io/cluster/k8s-dev"
                "propagate_at_launch" = "true"
                "value"               = "owned"
            },
          + {
              + "key"                 = "k8s.io/cluster/k8s-dev"
              + "propagate_at_launch" = "true"
              + "value"               = "owned"
            },
            {
                "key"                 = "stack-name"
                "propagate_at_launch" = "true"
                "value"               = "k8s-dev"
            },
        ]
```

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
