### PR TITLE
improvement: cluster_id output blocks on wait_for_cluster

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,9 @@
 output "cluster_id" {
   description = "The name/id of the EKS cluster."
   value       = element(concat(aws_eks_cluster.this.*.id, list("")), 0)
+  # So that calling plans wait for the cluster to be available before attempting
+  # to use it. They will not need to duplicate this null_resource
+  depends_on = [null_resource.wait_for_cluster]
 }
 
 output "cluster_arn" {


### PR DESCRIPTION
# PR o'clock

## Description

Make the `cluster_id` module output block on the `null_resource.wait_for_cluster`. Users do not need to re-implement the null resource if they also want to create kubernetes resources in the same configuration.

This won't do anything for users with `manage_aws_auth = false`

From the rejected #884. 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
