### PR TITLE
fix: Work around path bug in aws-iam-authenticator

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -46,6 +46,7 @@ locals {
       module.node_groups.aws_auth_roles,
     ) :
     {
+      # Work around https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/153
       # Strip the leading slash off so that Terraform doesn't think it's a regex
       rolearn  = replace(role["worker_role_arn"], replace(var.iam_path, "/^//", ""), "")
       username = "system:node:{{EC2PrivateDNSName}}"

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -46,7 +46,8 @@ locals {
       module.node_groups.aws_auth_roles,
     ) :
     {
-      rolearn  = role["worker_role_arn"]
+      # Strip the leading slash off so that Terraform doesn't think it's a regex
+      rolearn  = replace(role["worker_role_arn"], replace(var.iam_path, "/^//", ""), "")
       username = "system:node:{{EC2PrivateDNSName}}"
       groups = tolist(concat(
         [


### PR DESCRIPTION
# PR o'clock

## Description

`aws-iam-authenticator` has an open issue where it will not recognize
IAM roles that include paths. This change causes the path supplied to
`var.iam_path` to be stripped when generating the `aws-auth` ConfigMap
in order to work around this.

https://github.com/kubernetes-sigs/aws-iam-authenticator/issues/153

Fixes #893 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
