### PR TITLE
feat: Add aws_security_group_rule.cluster_https_worker_ingress to output values

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | kubeconfig\_filename | The filename of the generated kubectl config. |
 | node\_groups | Outputs from EKS node groups. Map of maps, keyed by var.node\_groups keys |
 | oidc\_provider\_arn | The ARN of the OIDC Provider if `enable_irsa = true`. |
+| security\_group\_rule\_cluster\_https\_worker\_ingress | Security group rule responsible for allowing pods to communicate with the EKS cluster API. |
 | worker\_iam\_instance\_profile\_arns | default IAM instance profile ARN for EKS worker groups |
 | worker\_iam\_instance\_profile\_names | default IAM instance profile name for EKS worker groups |
 | worker\_iam\_role\_arn | default IAM role ARN for EKS worker groups |

--- a/outputs.tf
+++ b/outputs.tf
@@ -165,3 +165,8 @@ output "node_groups" {
   description = "Outputs from EKS node groups. Map of maps, keyed by var.node_groups keys"
   value       = module.node_groups.node_groups
 }
+
+output "security_group_rule_cluster_https_worker_ingress" {
+  description = "Security group rule responsible for allowing pods to communicate with the EKS cluster API."
+  value       = aws_security_group_rule.cluster_https_worker_ingress
+}


### PR DESCRIPTION
# PR o'clock

## Description

References #888.

This PR exposes the `cluster_https_worker_ingress` security group rule as an output value.

## Motivation 

In order to ensure proper ordering when running `terraform destroy`, I need to be able to establish an explicit dependency on the exposed resource because that resource allows pods to communicate with the control plane. Without being able to declare the dependency, terraform will likely destroy the rule early, which will prevent other resources from proper destruction.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
