### PR TITLE
feat: Add IAM permissions for ELB svc-linked role creation by EKS cluster

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -130,3 +130,28 @@ resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
   policy_arn = "${local.policy_arn_prefix}/AmazonEKSServicePolicy"
   role       = local.cluster_iam_role_name
 }
+
+/*
+ Adding a policy to cluster IAM role that allow permissions
+ required to create AWSServiceRoleForElasticLoadBalancing service-linked role by EKS during ELB provisioning
+*/
+
+data "aws_iam_policy_document" "cluster_elb_sl_role_creation" {
+  count = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeInternetGateways"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cluster_elb_sl_role_creation" {
+  count       = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
+  name_prefix = "${var.cluster_name}-elb-sl-role-creation"
+  role        = local.cluster_iam_role_name
+  policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json
+}


### PR DESCRIPTION
# PR o'clock

## Description

AmazonEKSClusterPolicy IAM policy doesn't contain all necessary permissions to create ELB service-linked role required during LB provisioning at AWS by K8S Service.
    
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/900

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
