### PR TITLE
improvement: Add cluster_endpoint_public_access_cidrs for tf0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
 - echo "install"
-- gem install bundler --no-rdoc --no-ri
+- gem install bundler --no-document
 - bundle install
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for termination policies for Auto Scaling group (by @nusnewob)
 - Added `cpu_credits` param for the workers defined in `worker_groups_launch_template` and `worker_groups_launch_template_mixed` (by @rinrailin)
 - Added `max_instance_lifetime` param for the workers defined in `worker_groups_launch_template` and `worker_groups_launch_template_mixed` (by @sortigoza)
+- Added support for restricting access to the public API endpoint (by @rinrailin)
 
 # History
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ No requirements.
 | cluster\_enabled\_log\_types | A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) | `list` | `[]` | no |
 | cluster\_endpoint\_private\_access | Indicates whether or not the Amazon EKS private API server endpoint is enabled. | `bool` | `false` | no |
 | cluster\_endpoint\_public\_access | Indicates whether or not the Amazon EKS public API server endpoint is enabled. | `bool` | `true` | no |
+| cluster\_endpoint\_public\_access\_cidrs | List of CIDR blocks which can access the Amazon EKS public API server endpoint. | `list` | `[ "0.0.0.0/0" ]` | no |
 | cluster\_iam\_role\_name | IAM role name for the cluster. Only applicable if manage\_cluster\_iam\_resources is set to false. | `string` | `""` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | `any` | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingres/egress to work with the workers and provide API access to your current IP/32. | `string` | `""` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -9,6 +9,7 @@ resource "aws_eks_cluster" "this" {
     subnet_ids              = ["${var.subnets}"]
     endpoint_private_access = "${var.cluster_endpoint_private_access}"
     endpoint_public_access  = "${var.cluster_endpoint_public_access}"
+    public_access_cidrs     = ["${var.cluster_endpoint_public_access_cidrs}"]
   }
 
   timeouts {

--- a/local.tf
+++ b/local.tf
@@ -45,7 +45,7 @@ locals {
     placement_group               = ""                              # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                              # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
     termination_policies          = ""                              # A list of policies to decide how the instances in the auto scale group should be terminated.
-    max_instance_lifetime         = ""                              # The maximum amount of time, in seconds, that an instance can be in service.
+    max_instance_lifetime         = "0"                             # The maximum amount of time, in seconds, that an instance can be in service. 0 is unlimited.
 
     # Settings for launch templates
     root_block_device_name            = "${data.aws_ami.eks_worker.root_device_name}" # Root device name for workers. If non is provided, will assume default AMI was used.

--- a/variables.tf
+++ b/variables.tf
@@ -260,6 +260,12 @@ variable "cluster_endpoint_public_access" {
   default     = true
 }
 
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint."
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "manage_cluster_iam_resources" {
   description = "Whether to let the module manage cluster IAM resources. If set to false, cluster_iam_role_name must be specified."
   default     = true


### PR DESCRIPTION
# PR o'clock

## Description

- Add `cluster_endpoint_public_access_cidrs` parameter for for restricting access to the public API endpoint for `tf0.11` branch
- Fix failed `max_instance_lifetime` default value, which was added in #879 for `tf0.11` branch

### Checklist

- [x] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation