### PR TITLE
feat: use aws sdk as authenticator by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | enable\_irsa | Whether to create OpenID Connect Provider for EKS to enable IRSA | `bool` | `false` | no |
 | iam\_path | If provided, all IAM roles will be created on this path. | `string` | `"/"` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | `list(string)` | `[]` | no |
-| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | `string` | `"aws-iam-authenticator"` | no |
+| kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | `string` | `"aws"` | no |
 | kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster\_name]. | `list(string)` | `[]` | no |
 | kubeconfig\_aws\_authenticator\_env\_variables | Environment variables that should be used when executing the authenticator. e.g. { AWS\_PROFILE = "eks"}. | `map(string)` | `{}` | no |
 | kubeconfig\_name | Override the default name used for items kubeconfig. | `string` | `""` | no |

--- a/local.tf
+++ b/local.tf
@@ -143,7 +143,7 @@ locals {
     endpoint                          = aws_eks_cluster.this[0].endpoint
     cluster_auth_base64               = aws_eks_cluster.this[0].certificate_authority[0].data
     aws_authenticator_command         = var.kubeconfig_aws_authenticator_command
-    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", aws_eks_cluster.this[0].name]
+    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["eks", "get-token", "--cluster-name", aws_eks_cluster.this[0].name]
     aws_authenticator_additional_args = var.kubeconfig_aws_authenticator_additional_args
     aws_authenticator_env_variables   = var.kubeconfig_aws_authenticator_env_variables
   }) : ""

--- a/variables.tf
+++ b/variables.tf
@@ -159,7 +159,7 @@ variable "workers_additional_policies" {
 variable "kubeconfig_aws_authenticator_command" {
   description = "Command to use to fetch AWS EKS credentials."
   type        = string
-  default     = "aws-iam-authenticator"
+  default     = "aws"
 }
 
 variable "kubeconfig_aws_authenticator_command_args" {


### PR DESCRIPTION
`aws eks` command is available since `awscli` v1.16.156

Signed-off-by: Kevin Lefevre <lefevre.kevin@gmail.com>

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
