### PR TITLE
fix: removed unnecessary conditional in private access security group

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -46,7 +46,7 @@ resource "aws_eks_cluster" "this" {
 }
 
 resource "aws_security_group_rule" "cluster_private_access" {
-  count       = var.create_eks && var.manage_aws_auth && var.cluster_endpoint_private_access && var.cluster_endpoint_public_access == false ? 1 : 0
+  count       = var.create_eks && var.cluster_endpoint_private_access && var.cluster_endpoint_public_access == false ? 1 : 0
   type        = "ingress"
   from_port   = 443
   to_port     = 443


### PR DESCRIPTION
# PR o'clock

## Description

Issue: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/914

This fix corrects an incorrect behavior, in which the module requires the user to have enable `manage_aws_auth` variable for the creation of a security_group with the ingress rules necessary to access the private endpoint of the EKS cluster. 

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
