### PR TITLE
fix: Incorrect cpu_credit lookup variable (Terraform v0.11)

### DIFF
--- a/workers_launch_template_mixed.tf
+++ b/workers_launch_template_mixed.tf
@@ -90,7 +90,7 @@ resource "aws_launch_template" "workers_launch_template_mixed" {
   ebs_optimized = "${lookup(var.worker_groups_launch_template_mixed[count.index], "ebs_optimized", lookup(local.ebs_optimized, lookup(var.worker_groups_launch_template_mixed[count.index], "instance_type", local.workers_group_defaults["instance_type"]), false))}"
 
   credit_specification {
-    cpu_credits = "${lookup(var.worker_groups_launch_template[count.index], "cpu_credits", local.workers_group_defaults["cpu_credits"])}"
+    cpu_credits = "${lookup(var.worker_groups_launch_template_mixed[count.index], "cpu_credits", local.workers_group_defaults["cpu_credits"])}"
   }
 
   monitoring {


### PR DESCRIPTION
# PR o'clock

## Description
Fixes a variable lookup against the wrong worker group list introduced by commit c660b6e to add support to set cpu_credits.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
