### PR TITLE
docs: autoscaler X.Y version must match

### DIFF
--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -78,6 +78,10 @@ awsRegion: YOUR_AWS_REGION
 autoDiscovery:
   clusterName: YOUR_CLUSTER_NAME
   enabled: true
+
+image:
+  repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
+  tag: v1.16.5
 ```
 
 To install the chart, simply run helm with the `--values` option:
@@ -89,3 +93,5 @@ helm install stable/cluster-autoscaler --values=path/to/your/values-file.yaml
 ## Notes
 
 There is a variable `asg_desired_capacity` given in the `local.tf` file, currently it can be used to change the desired worker(s) capacity in the autoscaling group but currently it is being ignored in terraform to reduce the [complexities](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/510#issuecomment-531700442) and the feature of scaling up and down the cluster nodes is being handled by the cluster autoscaler.
+
+The cluster autoscaler major and minor versions must match your cluster. For example if you are running a 1.16 EKS cluster set `image.tag=v1.16.5`. Search through their [releases page](https://github.com/kubernetes/autoscaler/releases) for valid version numbers.


### PR DESCRIPTION
# PR o'clock

## Description

Recently came up in #912. Add a note to our docs about the cluster autoscaler version requirements.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
