### PR TITLE
fix: Strip user Name tag from asg_tags (#945)

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -1,6 +1,6 @@
 locals {
   asg_tags = [
-    for item in keys(var.tags) :
+    for item in setsubtract(keys(var.tags), ["Name"]) :
     map(
       "key", item,
       "value", element(values(var.tags), index(keys(var.tags), item)),

--- a/local.tf
+++ b/local.tf
@@ -1,11 +1,12 @@
 locals {
   asg_tags = [
-    for item in setsubtract(keys(var.tags), ["Name"]) :
+    for item in keys(var.tags) :
     map(
       "key", item,
       "value", element(values(var.tags), index(keys(var.tags), item)),
       "propagate_at_launch", "true"
     )
+    if item != "Name"
   ]
 
   cluster_security_group_id         = var.cluster_create_security_group ? join("", aws_security_group.cluster.*.id) : var.cluster_security_group_id


### PR DESCRIPTION
# PR o'clock
See issue #945 

## Description

I added a call to strip out any user given Name tags from `locals.asg_tags` so only the internal Name tags will be applied to asg workers. It looks like this var is only used for two resources, and both of them also try to apply their own Name tags, so there shouldn't be any fallout from dropping it.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
