### PR TITLE
feat: Change EKS default version to 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.9 |
-| aws | >= 2.55.0 |
+| aws | >= 2.63.0 |
 | kubernetes | >= 1.11.1 |
 | local | >= 1.4 |
 | null | >= 2.1 |
@@ -160,7 +160,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.55.0 |
+| aws | >= 2.63.0 |
 | kubernetes | >= 1.11.1 |
 | local | >= 1.4 |
 | null | >= 2.1 |

--- a/README.md
+++ b/README.md
@@ -15,9 +15,23 @@ Read the [AWS docs on EKS to get connected to the k8s dashboard](https://docs.aw
 * You want these resources to exist within security groups that allow communication and coordination. These can be user provided or created within the module.
 * You've created a Virtual Private Cloud (VPC) and subnets where you intend to put the EKS resources. The VPC satisfies [EKS requirements](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html).
 
-## Important note
+## Important notes for Kubernetes 1.17
 
-The default `cluster_version`is now 1.16. Kubernetes 1.16 includes a number of deprecated API removals, and you need to ensure your applications and add ons are updated, or workloads could fail after the upgrade is complete. For more information on the API removals, see the [Kubernetes blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). For action you may need to take before upgrading, see the steps in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#1-16-prequisites).
+The default `cluster_version` is now 1.17. Kubernetes 1.17 includes changes to [Cloud Provider Labels](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints), making them now a GA feature. If you are using the `beta` labels in your pod specs for features such as node affinity, or in any custom controllers, then it's recommended that you start migrating them to the new GA labels.
+
+For more information, you can reference the following links:
+
+- [Amazon EKS now supports Kubernetes version 1.17](https://aws.amazon.com/about-aws/whats-new/2020/07/amazon-eks-supports-kubernetes-version-1-17/)
+- [EKS 1.17 Upgrade Documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html)
+- [Kubernetes 1.17 Feature: Kubernetes In-Tree to CSI Volume Migration Moves to Beta](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-feature-csi-migration-beta/)
+- [Kubernetes 1.17 Feature: Kubernetes Volume Snapshot Moves to Beta](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-feature-cis-volume-snapshot-beta/)
+- [Kubernetes 1.17: Stability](https://kubernetes.io/blog/2019/12/09/kubernetes-1-17-release-announcement/)
+
+Please set explicitly your `cluster_version` to an older EKS version until your workloads are ready for Kubernetes 1.17.
+
+## Important notes for Kubernetes 1.16
+
+Kubernetes 1.16 includes a number of deprecated API removals, and you need to ensure your applications and add ons are updated, or workloads could fail after the upgrade is complete. For more information on the API removals, see the [Kubernetes blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). For action you may need to take before upgrading, see the steps in the [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#1-16-prequisites).
 
 Please set explicitly your `cluster_version` to an older EKS version until your workloads are ready for Kubernetes 1.16.
 
@@ -45,7 +59,7 @@ provider "kubernetes" {
 module "my-cluster" {
   source          = "terraform-aws-modules/eks/aws"
   cluster_name    = "my-cluster"
-  cluster_version = "1.16"
+  cluster_version = "1.17"
   subnets         = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
   vpc_id          = "vpc-1234556abcdef"
 
@@ -172,7 +186,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_log\_retention\_in\_days | Number of days to retain log events. Default retention - 90 days. | `number` | `90` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | `string` | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
-| cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | `"1.16"` | no |
+| cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | `"1.17"` | no |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | `string` | `"./"` | no |
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | eks\_oidc\_root\_ca\_thumbprint | Thumbprint of Root CA for EKS OIDC, Valid until 2037 | `string` | `"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"` | no |

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -81,7 +81,7 @@ autoDiscovery:
 
 image:
   repository: us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler
-  tag: v1.16.5
+  tag: v1.17.2
 ```
 
 To install the chart, simply run helm with the `--values` option:
@@ -94,4 +94,4 @@ helm install stable/cluster-autoscaler --values=path/to/your/values-file.yaml
 
 There is a variable `asg_desired_capacity` given in the `local.tf` file, currently it can be used to change the desired worker(s) capacity in the autoscaling group but currently it is being ignored in terraform to reduce the [complexities](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/510#issuecomment-531700442) and the feature of scaling up and down the cluster nodes is being handled by the cluster autoscaler.
 
-The cluster autoscaler major and minor versions must match your cluster. For example if you are running a 1.16 EKS cluster set `image.tag=v1.16.5`. Search through their [releases page](https://github.com/kubernetes/autoscaler/releases) for valid version numbers.
+The cluster autoscaler major and minor versions must match your cluster. For example if you are running a 1.17 EKS cluster set `image.tag=v1.17.2`. Search through their [releases page](https://github.com/kubernetes/autoscaler/releases) for valid version numbers.

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "cluster_security_group_id" {
 variable "cluster_version" {
   description = "Kubernetes version to use for the EKS cluster."
   type        = string
-  default     = "1.16"
+  default     = "1.17"
 }
 
 variable "config_output_path" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.9"
 
   required_providers {
-    aws        = ">= 2.55.0"
+    aws        = ">= 2.63.0"
     local      = ">= 1.4"
     null       = ">= 2.1"
     template   = ">= 2.1"


### PR DESCRIPTION
# PR o'clock

## Description

Upgrading module to support EKS 1.17. Resolves issue https://github.com/terraform-aws-modules/terraform-aws-eks/issues/947.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
