### PR TITLE
fix: #961 - Allow running cloud-init boothook commands

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -72,6 +72,11 @@ data "template_file" "userdata" {
     cluster_name        = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
     endpoint            = coalescelist(aws_eks_cluster.this[*].endpoint, [""])[0]
     cluster_auth_base64 = coalescelist(aws_eks_cluster.this[*].certificate_authority[0].data, [""])[0]
+    boothook = lookup(
+      var.worker_groups[count.index],
+      "boothook",
+      local.workers_group_defaults["boothook"],
+    )
     pre_userdata = lookup(
       var.worker_groups[count.index],
       "pre_userdata",
@@ -118,6 +123,11 @@ data "template_file" "launch_template_userdata" {
     cluster_name        = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
     endpoint            = coalescelist(aws_eks_cluster.this[*].endpoint, [""])[0]
     cluster_auth_base64 = coalescelist(aws_eks_cluster.this[*].certificate_authority[0].data, [""])[0]
+    boothook = lookup(
+      var.worker_groups_launch_template[count.index],
+      "boothook",
+      local.workers_group_defaults["boothook"],
+    )
     pre_userdata = lookup(
       var.worker_groups_launch_template[count.index],
       "pre_userdata",

--- a/local.tf
+++ b/local.tf
@@ -53,6 +53,7 @@ locals {
     root_volume_type              = "gp2"                       # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                          # The key name that should be used for the instances in the autoscaling group
+    boothook                      = ""                          # boothook script to execute early in the boot process
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
     userdata_template_file        = ""                          # alternate template to use for userdata
     userdata_template_extra_args  = {}                          # Additional arguments to use when expanding the userdata template file

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -1,3 +1,13 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-boothook; charset="us-ascii"
+
+${boothook}
+
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash -xe
 
 # Allow user supplied pre userdata code
@@ -8,3 +18,4 @@ ${pre_userdata}
 
 # Allow user supplied userdata code
 ${additional_userdata}
+--==BOUNDARY==--


### PR DESCRIPTION
#  Description

Fixes #961 by changing user-data template into a [Multipart MIME format](https://cloudinit.readthedocs.io/en/latest/topics/format.html#mime-multi-part-archive) that includes a cloud-init [boothook section](https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-boothook) to allow users running commands early in the boot process.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
