### PR TITLE
docs: Describe key_name is about AWS EC2 key pairs

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -52,7 +52,7 @@ locals {
     root_volume_size              = "100"                       # root volume size of workers instances.
     root_volume_type              = "gp2"                       # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
-    key_name                      = ""                          # The key name that should be used for the instances in the autoscaling group
+    key_name                      = ""                          # The key pair name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
     userdata_template_file        = ""                          # alternate template to use for userdata
     userdata_template_extra_args  = {}                          # Additional arguments to use when expanding the userdata template file


### PR DESCRIPTION
# PR o'clock

## Description

I feel like people ctrl+f for "key pair", "keypair", "ssh", ... when they look for ways to associate a _key pair_ (that's how AWS calls ssh keys) to worker nodes.

I propose to change the documentation string in local.tf to help users.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
