### PR TITLE
feat: Cluster version is now a required variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_log\_retention\_in\_days | Number of days to retain log events. Default retention - 90 days. | `number` | `90` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | `string` | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
-| cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | `"1.16"` | no |
+| cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | `string` | `"./"` | no |
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | eks\_oidc\_root\_ca\_thumbprint | Thumbprint of Root CA for EKS OIDC, Valid until 2037 | `string` | `"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -123,9 +123,10 @@ module "vpc" {
 }
 
 module "eks" {
-  source       = "../.."
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.private_subnets
+  source          = "../.."
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.private_subnets
 
   tags = {
     Environment = "test"

--- a/examples/create_false/main.tf
+++ b/examples/create_false/main.tf
@@ -21,8 +21,9 @@ provider "kubernetes" {
 }
 
 module "eks" {
-  source     = "../.."
-  create_eks = false
+  source          = "../.."
+  create_eks      = false
+  cluster_version = ""
 
   vpc_id       = ""
   cluster_name = ""

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -55,11 +55,12 @@ module "vpc" {
 }
 
 module "eks" {
-  source       = "../.."
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.public_subnets
-  vpc_id       = module.vpc.vpc_id
-  enable_irsa  = true
+  source          = "../.."
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.public_subnets
+  vpc_id          = module.vpc.vpc_id
+  enable_irsa     = true
 
   worker_groups = [
     {

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -63,10 +63,11 @@ module "vpc" {
 }
 
 module "eks" {
-  source       = "../.."
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.public_subnets
-  vpc_id       = module.vpc.vpc_id
+  source          = "../.."
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.public_subnets
+  vpc_id          = module.vpc.vpc_id
 
   worker_groups_launch_template = [
     {

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -76,9 +76,10 @@ module "vpc" {
 }
 
 module "eks" {
-  source       = "../.."
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.private_subnets
+  source          = "../.."
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.private_subnets
 
   tags = {
     Environment = "test"

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -80,9 +80,10 @@ module "vpc" {
 }
 
 module "eks" {
-  source       = "../.."
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.private_subnets
+  source          = "../.."
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.private_subnets
 
   cluster_encryption_config = [
     {

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -63,10 +63,11 @@ module "vpc" {
 }
 
 module "eks" {
-  source       = "../.."
-  cluster_name = local.cluster_name
-  subnets      = module.vpc.public_subnets
-  vpc_id       = module.vpc.vpc_id
+  source          = "../.."
+  cluster_name    = local.cluster_name
+  cluster_version = "1.17"
+  subnets         = module.vpc.public_subnets
+  vpc_id          = module.vpc.vpc_id
 
   worker_groups_launch_template = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,6 @@ variable "cluster_security_group_id" {
 variable "cluster_version" {
   description = "Kubernetes version to use for the EKS cluster."
   type        = string
-  default     = "1.16"
 }
 
 variable "config_output_path" {


### PR DESCRIPTION
Breaking change!

# PR o'clock

## Description

Remove the default value from `cluster_version` making it required.

Stop the rush every time AWS releases a new supported kubernetes version to "upgrade the module". #949 was really a single line change that triggers a major version bump for something a user can set in a variable.

Fixes #947 (sort of)

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
