### PR TITLE
ci: fix CI lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:latest
+      image: hashicorp/terraform:0.12.29
     steps:
       - uses: actions/checkout@master
       - name: Validate Code


### PR DESCRIPTION
# PR o'clock

## Description

Module used by an example does not allow use with 0.13 yet. Lock to latest version of 0.12. No 0.12 floating tag 😞 

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
