### PR TITLE
fix: More compatibility fixes for Terraform v0.13 and aws v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.9 |
+| terraform | >= 0.12.9, != 0.13.0 |
 | aws | >= 2.55.0 |
 | kubernetes | >= 1.11.1 |
 | local | >= 1.4 |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -100,7 +100,7 @@ resource "aws_security_group" "all_worker_mgmt" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.6.0"
+  version = "2.47.0"
 
   name                 = "test-vpc"
   cidr                 = "10.0.0.0/16"

--- a/examples/irsa/irsa.tf
+++ b/examples/irsa/irsa.tf
@@ -1,6 +1,6 @@
 module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "~> v2.6.0"
+  version                       = "2.14.0"
   create_role                   = true
   role_name                     = "cluster-autoscaler"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -41,7 +41,7 @@ data "aws_caller_identity" "current" {}
 
 module "vpc" {
   source               = "terraform-aws-modules/vpc/aws"
-  version              = "2.6.0"
+  version              = "2.47.0"
   name                 = "test-vpc"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -53,7 +53,7 @@ resource "random_string" "suffix" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.6.0"
+  version = "2.47.0"
 
   name                 = "test-vpc-lt"
   cidr                 = "10.0.0.0/16"

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -53,7 +53,7 @@ resource "random_string" "suffix" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.6"
+  version = "2.47.0"
 
   name                 = "test-vpc"
   cidr                 = "172.16.0.0/16"

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -57,7 +57,7 @@ resource "aws_kms_key" "eks" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.6.0"
+  version = "2.47.0"
 
   name                 = "test-vpc"
   cidr                 = "10.0.0.0/16"

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -53,7 +53,7 @@ resource "random_string" "suffix" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.6.0"
+  version = "2.47.0"
 
   name                 = "test-vpc-spot"
   cidr                 = "10.0.0.0/16"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.9"
+  required_version = ">= 0.12.9, != 0.13.0"
 
   required_providers {
     aws        = ">= 2.55.0"

--- a/workers.tf
+++ b/workers.tf
@@ -102,31 +102,38 @@ resource "aws_autoscaling_group" "workers" {
     }
   }
 
-  tags = concat(
-    [
-      {
-        "key"                 = "Name"
-        "value"               = "${aws_eks_cluster.this[0].name}-${lookup(var.worker_groups[count.index], "name", count.index)}-eks_asg"
-        "propagate_at_launch" = true
-      },
-      {
-        "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.this[0].name}"
-        "value"               = "owned"
-        "propagate_at_launch" = true
-      },
-      {
-        "key"                 = "k8s.io/cluster/${aws_eks_cluster.this[0].name}"
-        "value"               = "owned"
-        "propagate_at_launch" = true
-      },
-    ],
-    local.asg_tags,
-    lookup(
-      var.worker_groups[count.index],
-      "tags",
-      local.workers_group_defaults["tags"]
+  dynamic "tag" {
+    for_each = concat(
+      [
+        {
+          "key"                 = "Name"
+          "value"               = "${aws_eks_cluster.this[0].name}-${lookup(var.worker_groups[count.index], "name", count.index)}-eks_asg"
+          "propagate_at_launch" = true
+        },
+        {
+          "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.this[0].name}"
+          "value"               = "owned"
+          "propagate_at_launch" = true
+        },
+        {
+          "key"                 = "k8s.io/cluster/${aws_eks_cluster.this[0].name}"
+          "value"               = "owned"
+          "propagate_at_launch" = true
+        },
+      ],
+      local.asg_tags,
+      lookup(
+        var.worker_groups[count.index],
+        "tags",
+        local.workers_group_defaults["tags"]
+      )
     )
-  )
+    content {
+      key                 = tag.value.key
+      value               = tag.value.value
+      propagate_at_launch = tag.value.propagate_at_launch
+    }
+  }
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# PR o'clock

## Description

Terraform v0.13 and aws v3 support time!

- The update to the vpc module was, strictly speaking, unnecessary but it adds the `terraform` block with supported versions.
- Update for iam module was very necessary to support new versions
- Workaround for "Provider produced inconsistent final plan" when creating ASGs at the same time as the cluster. See  https://github.com/terraform-providers/terraform-provider-aws/issues/14085 for full details.

When upgrading an existing TF 0.12/aws 2 cluster to TF 0.13/aws 3 you currently have to manually edit the state file to delete removed attributes. Should be fixed in v0.13.1 https://github.com/hashicorp/terraform/pull/25779 . For the basic example I had to remove the following attributes:
- data `aws_availability_zones`: `blacklisted_names` and `blackedlisted_zone_ids`
- `aws_iam_instance_profile`: `roles` (#974)

You also need to mess around with `replace-provider` a lot:
```sh
terraform state replace-provider -- -/aws hashicorp/aws
terraform state replace-provider -- -/kubernetes hashicorp/kubernetes
terraform state replace-provider -- -/local hashicorp/local
terraform state replace-provider -- -/null hashicorp/null
terraform state replace-provider -- -/random hashicorp/random
terraform state replace-provider -- -/template hashicorp/template
```

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
