### PR TITLE
fix: Remove conditionals from IAM policy attachments and documents

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -122,13 +122,11 @@ resource "aws_iam_role" "cluster" {
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
-  count      = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
   policy_arn = "${local.policy_arn_prefix}/AmazonEKSClusterPolicy"
   role       = local.cluster_iam_role_name
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
-  count      = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
   policy_arn = "${local.policy_arn_prefix}/AmazonEKSServicePolicy"
   role       = local.cluster_iam_role_name
 }
@@ -139,8 +137,6 @@ resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
 */
 
 data "aws_iam_policy_document" "cluster_elb_sl_role_creation" {
-  count = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
-
   statement {
     effect = "Allow"
     actions = [
@@ -152,7 +148,6 @@ data "aws_iam_policy_document" "cluster_elb_sl_role_creation" {
 }
 
 resource "aws_iam_role_policy" "cluster_elb_sl_role_creation" {
-  count       = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
   name_prefix = "${var.cluster_name}-elb-sl-role-creation"
   role        = local.cluster_iam_role_name
   policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json

--- a/cluster.tf
+++ b/cluster.tf
@@ -150,5 +150,5 @@ data "aws_iam_policy_document" "cluster_elb_sl_role_creation" {
 resource "aws_iam_role_policy" "cluster_elb_sl_role_creation" {
   name_prefix = "${var.cluster_name}-elb-sl-role-creation"
   role        = local.cluster_iam_role_name
-  policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json
+  policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation.json
 }


### PR DESCRIPTION
# fix: Remove conditionals for IAM policy attachments

## Description

The IAM policy attachments and documents are applied tolocal.cluster_iam_role_name, which is either the role created by this module or a role supplied by the module's user.  The conditional is the local variable; in either case, they should still be applied?

### Checklist

- [x] CI tests are passing
- [] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
