### PR TITLE
feat: Add `load_balancers` parameter to associate a CLB (Classic Load Balancer) to worker groups ASG

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -69,6 +69,7 @@ locals {
     iam_role_id                   = "local.default_iam_role_id" # A custom IAM role id. Incompatible with iam_instance_profile_name.  Literal local.default_iam_role_id will never be used but if iam_role_id is not set, the local.default_iam_role_id interpolation will be used.
     suspended_processes           = ["AZRebalance"]             # A list of processes to suspend. i.e. ["AZRebalance", "HealthCheck", "ReplaceUnhealthy"]
     target_group_arns             = null                        # A list of Application LoadBalancer (ALB) target group ARNs to be associated to the autoscaling group
+    load_balancers                = null                        # A list of Classic LoadBalancer (CLB)'s name to be associated to the autoscaling group
     enabled_metrics               = []                          # A list of metrics to be collected i.e. ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity"]
     placement_group               = null                        # The name of the placement group into which to launch the instances, if any.
     service_linked_role_arn       = ""                          # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS

--- a/workers.tf
+++ b/workers.tf
@@ -37,6 +37,11 @@ resource "aws_autoscaling_group" "workers" {
     "target_group_arns",
     local.workers_group_defaults["target_group_arns"]
   )
+  load_balancers = lookup(
+    var.worker_groups[count.index],
+    "load_balancers",
+    local.workers_group_defaults["load_balancers"]
+  )
   service_linked_role_arn = lookup(
     var.worker_groups[count.index],
     "service_linked_role_arn",

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -38,7 +38,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
     local.workers_group_defaults["target_group_arns"]
   )
   load_balancers = lookup(
-    var.worker_groups[count.index],
+    var.worker_groups_launch_template[count.index],
     "load_balancers",
     local.workers_group_defaults["load_balancers"]
   )

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -37,6 +37,11 @@ resource "aws_autoscaling_group" "workers_launch_template" {
     "target_group_arns",
     local.workers_group_defaults["target_group_arns"]
   )
+  load_balancers = lookup(
+    var.worker_groups[count.index],
+    "load_balancers",
+    local.workers_group_defaults["load_balancers"]
+  )
   service_linked_role_arn = lookup(
     var.worker_groups_launch_template[count.index],
     "service_linked_role_arn",


### PR DESCRIPTION
# PR o'clock

## Description


Add `load_balancers`  for clb be associated to asg.

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1036

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
