### PR TITLE
improvement: update the `wait_for_cluster_cmd` logic to use `curl` if `wget` doesn't exist

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -200,7 +200,7 @@ variable "cluster_delete_timeout" {
 variable "wait_for_cluster_cmd" {
   description = "Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT"
   type        = string
-  default     = "for i in `seq 1 60`; do wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; sleep 5; done; echo TIMEOUT && exit 1"
+  default     = "for i in `seq 1 60`; do if `command -v wget > /dev/null`; then wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; else curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true;fi; sleep 5; done; echo TIMEOUT && exit 1"
 }
 
 variable "wait_for_cluster_interpreter" {


### PR DESCRIPTION
# PR o'clock

## Description
This PR is addressing issue related to `wait_for_cluster_cmd` check which is defaulting to `wget`. This is brining error if you missing `wget` on local system where you execute Terraform apply. This can be customized via `wait_for_cluster_cmd` but usually people are not following this and meet issue. In past there was few issues opened for this:

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/998
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/829


This PR is changing default `wait_for_cluster_cmd` to contain conditional which is checking `wget` availability, if this is missing then switch to `curl`. This logic should remediate most of issues which users meet (as `wget` is available on most linux distrubution and containers, where `curl` is available out of box in Mac OS).

I have tested module on my Mac OS with `wget` available, then repeated test with unavailable `wget` and available `curl`:

Execution with `wget` available:
```
$ terraform apply
.......................
module.eks.aws_eks_cluster.this[0]: Still creating... [9m40s elapsed]
module.eks.aws_eks_cluster.this[0]: Creation complete after 9m44s [id=test-eks-irsa]
module.eks.null_resource.wait_for_cluster[0]: Creating...
module.eks.aws_iam_openid_connect_provider.oidc_provider[0]: Creating...
module.eks.aws_iam_role.workers[0]: Creating...
module.eks.data.template_file.userdata[0]: Refreshing state...
module.eks.null_resource.wait_for_cluster[0]: Provisioning with 'local-exec'...
module.iam_assumable_role_admin.data.aws_iam_policy_document.assume_role_with_oidc[0]: Refreshing state...
module.eks.null_resource.wait_for_cluster[0] (local-exec): Executing: ["/bin/sh" "-c" "for i in `seq 1 60`; do if `command -v wget > /dev/null`; then wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; else curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true;fi; sleep 5; done; echo TIMEOUT && exit 1"]
module.eks.local_file.kubeconfig[0]: Creating...
.......................
module.iam_assumable_role_admin.aws_iam_role_policy_attachment.custom[0]: Creation complete after 2s [id=cluster-autoscaler-2020090709290497280000000f]

Apply complete! Resources: 38 added, 0 changed, 0 destroyed.
.......................
```

Removed `wget`
```
$ command -v wget
$ command -v curl 
/usr/bin/curl
$ 
```

Execution with `wget` unavailable:
```
$ terraform apply
.......................
module.eks.aws_eks_cluster.this[0]: Still creating... [13m0s elapsed]
module.eks.aws_eks_cluster.this[0]: Creation complete after 13m5s [id=test-eks-irsa]
module.eks.null_resource.wait_for_cluster[0]: Creating...
module.iam_assumable_role_admin.data.aws_iam_policy_document.assume_role_with_oidc[0]: Refreshing state...
module.eks.aws_iam_openid_connect_provider.oidc_provider[0]: Creating...
module.eks.aws_iam_role.workers[0]: Creating...
module.eks.data.template_file.userdata[0]: Refreshing state...
module.eks.null_resource.wait_for_cluster[0]: Provisioning with 'local-exec'...
module.eks.null_resource.wait_for_cluster[0] (local-exec): Executing: ["/bin/sh" "-c" "for i in `seq 1 60`; do if `command -v wget > /dev/null`; then wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; else curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true;fi; sleep 5; done; echo TIMEOUT && exit 1"]
module.eks.local_file.kubeconfig[0]: Creating...
module.eks.local_file.kubeconfig[0]: Creation complete after 0s [id=73dcc2465e8a560fe68b82dfd8aa20d4160e6d73]
.......................
module.iam_assumable_role_admin.aws_iam_role_policy_attachment.custom[0]: Creation complete after 2s [id=cluster-autoscaler-2020090709555407010000000f]

Apply complete! Resources: 38 added, 0 changed, 0 destroyed.
.......................
```


### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
