### PR TITLE
feat: Add AmazonEKSVPCResourceController to cluster policy to be able to set AWS Security Groups for pod

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -43,6 +43,7 @@ resource "aws_eks_cluster" "this" {
     aws_security_group_rule.cluster_https_worker_ingress,
     aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy,
     aws_iam_role_policy_attachment.cluster_AmazonEKSServicePolicy,
+    aws_iam_role_policy_attachment.cluster_AmazonEKSVPCResourceControllerPolicy,
     aws_cloudwatch_log_group.this
   ]
 }
@@ -130,6 +131,12 @@ resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSServicePolicy" {
   count      = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
   policy_arn = "${local.policy_arn_prefix}/AmazonEKSServicePolicy"
+  role       = local.cluster_iam_role_name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSVPCResourceControllerPolicy" {
+  count      = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
+  policy_arn = "${local.policy_arn_prefix}/AmazonEKSVPCResourceController"
   role       = local.cluster_iam_role_name
 }
 


### PR DESCRIPTION
# PR o'clock

## Description

AWS recently added the ability to assign security groups to pods, more info about this can be found [here](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html). This new feature requires an additional policy attached to the cluster role. 

### Checklist

- [X] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
