### PR TITLE
fix: #568 Terraform destroy fails when state is empty

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -63,7 +63,7 @@ locals {
 
 resource "kubernetes_config_map" "aws_auth" {
   count      = var.create_eks && var.manage_aws_auth ? 1 : 0
-  depends_on = [null_resource.wait_for_cluster[0]]
+  depends_on = [aws_eks_cluster.this[0], null_resource.wait_for_cluster[0]]
 
   metadata {
     name      = "aws-auth"

--- a/local.tf
+++ b/local.tf
@@ -144,10 +144,10 @@ locals {
 
   kubeconfig = var.create_eks ? templatefile("${path.module}/templates/kubeconfig.tpl", {
     kubeconfig_name                   = local.kubeconfig_name
-    endpoint                          = aws_eks_cluster.this[0].endpoint
-    cluster_auth_base64               = aws_eks_cluster.this[0].certificate_authority[0].data
+    endpoint                          = length(aws_eks_cluster.this) > 0 ? aws_eks_cluster.this[0].endpoint : ""
+    cluster_auth_base64               = length(aws_eks_cluster.this) > 0 ? aws_eks_cluster.this[0].certificate_authority[0].data : ""
     aws_authenticator_command         = var.kubeconfig_aws_authenticator_command
-    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", aws_eks_cluster.this[0].name]
+    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", var.cluster_name]
     aws_authenticator_additional_args = var.kubeconfig_aws_authenticator_additional_args
     aws_authenticator_env_variables   = var.kubeconfig_aws_authenticator_env_variables
   }) : ""


### PR DESCRIPTION
# Terraform destroy fails when state is empty

## Description

The terraform destroy fails on any incomplete run because there is reference of name everywhere. Replacing the name with user provided one. Fixes #568 

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
