### PR TITLE
docs: Add ec2:CreateVpcEndpoint action to minimum permission list for S3 VPC endpoint

### DIFF
--- a/docs/iam-permissions.md
+++ b/docs/iam-permissions.md
@@ -42,6 +42,7 @@ Following IAM permissions are the minimum permissions needed for your IAM user o
                 "ec2:CreateTags",
                 "ec2:CreateVolume",
                 "ec2:CreateVpc",
+                "ec2:CreateVpcEndpoint",
                 "ec2:DeleteDhcpOptions",
                 "ec2:DeleteEgressOnlyInternetGateway",
                 "ec2:DeleteInternetGateway",


### PR DESCRIPTION
# PR o'clock

## Description

For creating VPC endpoints for S3, "ec2:CreateVpcEndpoint" action must also be included in the minimum permission list.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
