### PR TITLE
improvement: Make the `cpu_credits` optional for workers launch template

### DIFF
--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -309,13 +309,9 @@ resource "aws_launch_template" "workers_launch_template" {
       var.worker_groups_launch_template[count.index],
       "cpu_credits",
       local.workers_group_defaults["cpu_credits"]
-    ) != null ? [{}] : []
+    ) != null ? [lookup(var.worker_groups_launch_template[count.index], "cpu_credits", local.workers_group_defaults["cpu_credits"])] : []
     content {
-      cpu_credits = lookup(
-        var.worker_groups_launch_template[count.index],
-        "cpu_credits",
-        local.workers_group_defaults["cpu_credits"]
-      )
+      cpu_credits = credit_specification.value
     }
   }
 

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -304,12 +304,19 @@ resource "aws_launch_template" "workers_launch_template" {
     )
   }
 
-  credit_specification {
-    cpu_credits = lookup(
+  dynamic "credit_specification" {
+    for_each = lookup(
       var.worker_groups_launch_template[count.index],
       "cpu_credits",
       local.workers_group_defaults["cpu_credits"]
-    )
+    ) != null ? [{}] : []
+    content {
+      cpu_credits = lookup(
+        var.worker_groups_launch_template[count.index],
+        "cpu_credits",
+        local.workers_group_defaults["cpu_credits"]
+      )
+    }
   }
 
   monitoring {


### PR DESCRIPTION
# PR o'clock

## Description

If you choose non bustable families in your template (c5 for example...) and you no remove `credit_specification` section, ASG can't start any instance.
Now you can set module `cpu_credits` option to null to made it fonctionnal.

### Checklist

- [x] CI tests are passing

