### PR TITLE
fix: Use customer managed policy instead of inline policy for `cluster_elb_sl_role_creation`

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -158,9 +158,15 @@ data "aws_iam_policy_document" "cluster_elb_sl_role_creation" {
   }
 }
 
-resource "aws_iam_role_policy" "cluster_elb_sl_role_creation" {
+resource "aws_iam_policy" "cluster_elb_sl_role_creation" {
   count       = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
   name_prefix = "${var.cluster_name}-elb-sl-role-creation"
-  role        = local.cluster_iam_role_name
+  description = "Permissions for EKS to create AWSServiceRoleForElasticLoadBalancing service-linked role"
   policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_elb_sl_role_creation" {
+  count      = var.manage_cluster_iam_resources && var.create_eks ? 1 : 0
+  policy_arn = aws_iam_policy.cluster_elb_sl_role_creation[0].arn
+  role       = local.cluster_iam_role_name
 }


### PR DESCRIPTION
## Description

Uses a customer-managed policy, not an inline policy, for the `cluster_elb_sl_role_creation` policy. It is common for "enterprise" AWS users to disallow inline policies with an SCP rule for auditing-related reasons, and this accomplishes the same thing. 

Verified `iam:CreatePolicy` is already listed in `docs/iam-permissions.md`. 

Fixes #1035. 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
