### PR TITLE
fix: Make guards in case aws_eks_cluster.this is empty

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -146,10 +146,10 @@ locals {
 
   kubeconfig = var.create_eks ? templatefile("${path.module}/templates/kubeconfig.tpl", {
     kubeconfig_name                   = local.kubeconfig_name
-    endpoint                          = aws_eks_cluster.this[0].endpoint
-    cluster_auth_base64               = aws_eks_cluster.this[0].certificate_authority[0].data
+    endpoint                          = length(aws_eks_cluster.this) > 0 ? aws_eks_cluster.this[0].endpoint : ""
+    cluster_auth_base64               = length(aws_eks_cluster.this) > 0 ? aws_eks_cluster.this[0].certificate_authority[0].data : ""
     aws_authenticator_command         = var.kubeconfig_aws_authenticator_command
-    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", aws_eks_cluster.this[0].name]
+    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", length(aws_eks_cluster.this) > 0 ? aws_eks_cluster.this[0].name : ""]
     aws_authenticator_additional_args = var.kubeconfig_aws_authenticator_additional_args
     aws_authenticator_env_variables   = var.kubeconfig_aws_authenticator_env_variables
   }) : ""


### PR DESCRIPTION
# PR o'clock

## Description

Fix syntax in data elements pulling when a the cluster element is being imported.

In the case of an aws token expiring while the cluster is created, the state might be left without the eks cluster. Upon running an import command for the cluster, the refresh step of the import fails as the cluster does not exist yet. This PR adds some data guards so that this step succeeds without errors:

```
$ terraform import module.terraform-aws-modules.aws_eks_cluster.this[0] my-cluster

module.terraform-aws-modules.aws_eks_cluster.this[0]: Importing from ID "my-cluster"...
module.terraform-aws-modules.aws_eks_cluster.this[0]: Import prepared!
  Prepared aws_eks_cluster for import
module.terraform-aws-modules.aws_eks_cluster.this[0]: Refreshing state... [id=my-cluster]

Error: Invalid index
  on .terraform/modules/terraform-aws-modules/local.tf line 147, in locals:
 147:     endpoint                          = aws_eks_cluster.this[0].endpoint
    |----------------
    | aws_eks_cluster.this is empty tuple

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/terraform-aws-modules/local.tf line 148, in locals:
 148:     cluster_auth_base64               = aws_eks_cluster.this[0].certificate_authority[0].data
    |----------------
    | aws_eks_cluster.this is empty tuple

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/terraform-aws-modules/local.tf line 150, in locals:
 150:     aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authent
icator_command_args : ["token", "-i", aws_eks_cluster.this[0].name]
    |----------------
    | aws_eks_cluster.this is empty tuple

The given key does not identify an element in this collection value.
```

with the PR:
```
Acquiring state lock. This may take a few moments...
module.terraform-aws-modules.aws_eks_cluster.this[0]: Importing from ID "my-cluster"...
module.terraform-aws-modules.aws_eks_cluster.this[0]: Import prepared!
  Prepared aws_eks_cluster for import
module.terraform-aws-modules.aws_eks_cluster.this[0]: Refreshing state... [id=my-cluster]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
