### PR TITLE
fix: Use splat syntax to avoid errors during destroy with an empty state

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -1,5 +1,4 @@
-data "aws_caller_identity" "current" {
-}
+data "aws_caller_identity" "current" {}
 
 locals {
   auth_launch_template_worker_roles = [

--- a/cluster.tf
+++ b/cluster.tf
@@ -64,7 +64,7 @@ resource "null_resource" "wait_for_cluster" {
   count = var.create_eks && var.manage_aws_auth ? 1 : 0
 
   depends_on = [
-    aws_eks_cluster.this[0],
+    aws_eks_cluster.this,
     aws_security_group_rule.cluster_private_access,
   ]
 

--- a/local.tf
+++ b/local.tf
@@ -146,8 +146,8 @@ locals {
 
   kubeconfig = var.create_eks ? templatefile("${path.module}/templates/kubeconfig.tpl", {
     kubeconfig_name                   = local.kubeconfig_name
-    endpoint                          = aws_eks_cluster.this[0].endpoint
-    cluster_auth_base64               = aws_eks_cluster.this[0].certificate_authority[0].data
+    endpoint                          = coalescelist(aws_eks_cluster.this[*].endpoint, [""])[0]
+    cluster_auth_base64               = coalescelist(aws_eks_cluster.this[*].certificate_authority[0].data, [""])[0]
     aws_authenticator_command         = var.kubeconfig_aws_authenticator_command
     aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", aws_eks_cluster.this[0].name]
     aws_authenticator_additional_args = var.kubeconfig_aws_authenticator_additional_args

--- a/local.tf
+++ b/local.tf
@@ -149,7 +149,7 @@ locals {
     endpoint                          = coalescelist(aws_eks_cluster.this[*].endpoint, [""])[0]
     cluster_auth_base64               = coalescelist(aws_eks_cluster.this[*].certificate_authority[0].data, [""])[0]
     aws_authenticator_command         = var.kubeconfig_aws_authenticator_command
-    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", aws_eks_cluster.this[0].name]
+    aws_authenticator_command_args    = length(var.kubeconfig_aws_authenticator_command_args) > 0 ? var.kubeconfig_aws_authenticator_command_args : ["token", "-i", coalescelist(aws_eks_cluster.this[*].name, [""])[0]]
     aws_authenticator_additional_args = var.kubeconfig_aws_authenticator_additional_args
     aws_authenticator_env_variables   = var.kubeconfig_aws_authenticator_env_variables
   }) : ""

--- a/workers.tf
+++ b/workers.tf
@@ -6,7 +6,7 @@ resource "aws_autoscaling_group" "workers" {
     "-",
     compact(
       [
-        aws_eks_cluster.this[0].name,
+        coalescelist(aws_eks_cluster.this[*].name, [""])[0],
         lookup(var.worker_groups[count.index], "name", count.index),
         lookup(var.worker_groups[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers[count.index].id : ""
       ]
@@ -112,16 +112,16 @@ resource "aws_autoscaling_group" "workers" {
       [
         {
           "key"                 = "Name"
-          "value"               = "${aws_eks_cluster.this[0].name}-${lookup(var.worker_groups[count.index], "name", count.index)}-eks_asg"
+          "value"               = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(var.worker_groups[count.index], "name", count.index)}-eks_asg"
           "propagate_at_launch" = true
         },
         {
-          "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.this[0].name}"
+          "key"                 = "kubernetes.io/cluster/${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}"
           "value"               = "owned"
           "propagate_at_launch" = true
         },
         {
-          "key"                 = "k8s.io/cluster/${aws_eks_cluster.this[0].name}"
+          "key"                 = "k8s.io/cluster/${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}"
           "value"               = "owned"
           "propagate_at_launch" = true
         },
@@ -148,7 +148,7 @@ resource "aws_autoscaling_group" "workers" {
 
 resource "aws_launch_configuration" "workers" {
   count       = var.create_eks ? local.worker_group_count : 0
-  name_prefix = "${aws_eks_cluster.this[0].name}-${lookup(var.worker_groups[count.index], "name", count.index)}"
+  name_prefix = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(var.worker_groups[count.index], "name", count.index)}"
   associate_public_ip_address = lookup(
     var.worker_groups[count.index],
     "public_ip",
@@ -262,7 +262,6 @@ resource "aws_launch_configuration" "workers" {
       )
       delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", true)
     }
-
   }
 
   lifecycle {
@@ -390,7 +389,7 @@ resource "aws_security_group_rule" "cluster_primary_ingress_workers" {
 
 resource "aws_iam_role" "workers" {
   count                 = var.manage_worker_iam_resources && var.create_eks ? 1 : 0
-  name_prefix           = var.workers_role_name != "" ? null : aws_eks_cluster.this[0].name
+  name_prefix           = var.workers_role_name != "" ? null : coalescelist(aws_eks_cluster.this[*].name, [""])[0]
   name                  = var.workers_role_name != "" ? var.workers_role_name : null
   assume_role_policy    = data.aws_iam_policy_document.workers_assume_role_policy.json
   permissions_boundary  = var.permissions_boundary
@@ -401,7 +400,7 @@ resource "aws_iam_role" "workers" {
 
 resource "aws_iam_instance_profile" "workers" {
   count       = var.manage_worker_iam_resources && var.create_eks ? local.worker_group_count : 0
-  name_prefix = aws_eks_cluster.this[0].name
+  name_prefix = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
   role = lookup(
     var.worker_groups[count.index],
     "iam_role_id",

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -6,7 +6,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
     "-",
     compact(
       [
-        aws_eks_cluster.this[0].name,
+        coalescelist(aws_eks_cluster.this[*].name, [""])[0],
         lookup(var.worker_groups_launch_template[count.index], "name", count.index),
         lookup(var.worker_groups_launch_template[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers_launch_template[count.index].id : ""
       ]
@@ -189,7 +189,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
       [
         {
           "key" = "Name"
-          "value" = "${aws_eks_cluster.this[0].name}-${lookup(
+          "value" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
             var.worker_groups_launch_template[count.index],
             "name",
             count.index,
@@ -197,7 +197,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
           "propagate_at_launch" = true
         },
         {
-          "key"                 = "kubernetes.io/cluster/${aws_eks_cluster.this[0].name}"
+          "key"                 = "kubernetes.io/cluster/${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}"
           "value"               = "owned"
           "propagate_at_launch" = true
         },
@@ -224,7 +224,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
 resource "aws_launch_template" "workers_launch_template" {
   count = var.create_eks ? (local.worker_group_launch_template_count) : 0
-  name_prefix = "${aws_eks_cluster.this[0].name}-${lookup(
+  name_prefix = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
     var.worker_groups_launch_template[count.index],
     "name",
     count.index,
@@ -427,7 +427,7 @@ resource "aws_launch_template" "workers_launch_template" {
 
     tags = merge(
       {
-        "Name" = "${aws_eks_cluster.this[0].name}-${lookup(
+        "Name" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
           var.worker_groups_launch_template[count.index],
           "name",
           count.index,
@@ -442,7 +442,7 @@ resource "aws_launch_template" "workers_launch_template" {
 
     tags = merge(
       {
-        "Name" = "${aws_eks_cluster.this[0].name}-${lookup(
+        "Name" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
           var.worker_groups_launch_template[count.index],
           "name",
           count.index,
@@ -499,7 +499,7 @@ resource "random_pet" "workers_launch_template" {
 
 resource "aws_iam_instance_profile" "workers_launch_template" {
   count       = var.manage_worker_iam_resources && var.create_eks ? local.worker_group_launch_template_count : 0
-  name_prefix = aws_eks_cluster.this[0].name
+  name_prefix = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
   role = lookup(
     var.worker_groups_launch_template[count.index],
     "iam_role_id",


### PR DESCRIPTION
# PR o'clock

## Description

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/568

Supersedes:
- https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1040
- https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1020

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
