### PR TITLE
fix: jsonencode-instead-of-yamlencode

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -71,13 +71,13 @@ resource "kubernetes_config_map" "aws_auth" {
   }
 
   data = {
-    mapRoles = yamlencode(
+    mapRoles = jsonencode(
       distinct(concat(
         local.configmap_roles,
         var.map_roles,
       ))
     )
-    mapUsers    = yamlencode(var.map_users)
-    mapAccounts = yamlencode(var.map_accounts)
+    mapUsers    = jsonencode(var.map_users)
+    mapAccounts = jsonencode(var.map_accounts)
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

Not a big issue but when generating a plan on mac vs linux `yamlencode` generates different output. This function is still experimental and may change in the future, for a consistent output we could use `jsonencode` until `yamlencode` is ready.

linux:

![image](https://user-images.githubusercontent.com/15851880/95408039-79d42500-08d3-11eb-842a-9bf9995cb9cd.png)

mac:

![image](https://user-images.githubusercontent.com/15851880/95408151-b7d14900-08d3-11eb-9bff-ee0da807847a.png)

ref. https://www.terraform.io/docs/configuration/functions/yamlencode.html

Terraform v0.12.26

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
