### PR TITLE
fix: Fix cycle error during the destroy phase when we change workers order

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -295,6 +295,10 @@ resource "random_pet" "workers" {
   keepers = {
     lc_name = aws_launch_configuration.workers[count.index].name
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "workers" {
@@ -409,6 +413,10 @@ resource "aws_iam_instance_profile" "workers" {
   )
 
   path = var.iam_path
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "workers_AmazonEKSWorkerNodePolicy" {

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -492,6 +492,7 @@ resource "random_pet" "workers_launch_template" {
       )
     )
   }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -506,4 +507,8 @@ resource "aws_iam_instance_profile" "workers_launch_template" {
     local.default_iam_role_id,
   )
   path = var.iam_path
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
# PR o'clock

## Description

When we change workers order (remove the first worker group by example) all workers groups should be destroyed and recreated. This is done correctly for workers ASG, LT and LC, but not their dependencies like random and instance profiles.

```shell
Error: Cycle: module.eks.aws_launch_template.workers_launch_template[1] (destroy), module.eks.random_pet.workers_launch_template[1] (destroy), module.eks.aws_launch_template.workers_launch_template[0] (destroy deposed c013c2bc), module.eks.aws_iam_instance_profile.workers_launch_template[1] (destroy), module.eks.aws_launch_template.workers_launch_template[0], module.eks.random_pet.workers_launch_template[0], module.eks.aws_autoscaling_group.workers_launch_template[0], module.eks.aws_autoscaling_group.workers_launch_template[0] (destroy deposed d3ef3123), module.eks.random_pet.workers_launch_template[0] (destroy deposed cd8e2227)
```

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/993

NOTES: Keep in mind that changing the order of workers group is a destructive operation. All workers group are destroyed and recreated. If you want to do this safely, you should move then in state with `terraform state mv` until we manage workers groups as maps.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
