### PR TITLE
fix: Set IAM Path for `cluster_elb_sl_role_creation` IAM policy

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -163,6 +163,7 @@ resource "aws_iam_policy" "cluster_elb_sl_role_creation" {
   name_prefix = "${var.cluster_name}-elb-sl-role-creation"
   description = "Permissions for EKS to create AWSServiceRoleForElasticLoadBalancing service-linked role"
   policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json
+  path        = var.iam_path
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_elb_sl_role_creation" {


### PR DESCRIPTION
…ter_elb_sl_role_creation"

Fix for #1044 - Path variable is not set for resource "aws_iam_policy" "cluster_elb_sl_role_creation" 

Path variable added to Iam Policy

Resolves #1044 

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
