### PR TITLE
fix: kubelet-extra-args double quote bug

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,3 +189,17 @@ Kubelet restricts the allowed list of labels in the `kubernetes.io` namespace th
 Older configurations used labels like `kubernetes.io/lifecycle=spot` and this is no longer allowed. Use `node.kubernetes.io/lifecycle=spot` instead.
 
 Reference the `--node-labels` argument for your version of Kubenetes for the allowed prefixes. [Documentation for 1.16](https://v1-16.docs.kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
+
+## Variables like ${availability_zone} get treated as string literals in userdata.sh due to single quotes
+
+This can be resolved by wrapping the variable in single quotes.
+
+For example:
+
+```sh
+$ echo 'my name is ${USER}'
+my name is ${USER}
+
+$ echo 'my name is '${USER}''
+my name is foo
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -196,10 +196,14 @@ This can be resolved by wrapping the variable in single quotes.
 
 For example:
 
-```sh
-$ echo 'my name is ${USER}'
-my name is ${USER}
+When passing the following in your Terraform configuration :
 
-$ echo 'my name is '${USER}''
-my name is foo
+```terraform
+kubelet_extra_args = "--node-labels=k8s.amazonaws.com/eniConfig='$${availability_zone}'-pod-netconfig"
+```
+
+The output of the userdata will be as follows:
+
+```shell
+/etc/eks/bootstrap.sh --b64-cluster-ca ........... --kubelet-extra-args '--node-labels=k8s.amazonaws.com/eniConfig='${availability_zone}'-pod-netconfig' 'my-eks-cluster'
 ```

--- a/templates/userdata.sh.tpl
+++ b/templates/userdata.sh.tpl
@@ -4,7 +4,7 @@
 ${pre_userdata}
 
 # Bootstrap and join the cluster
-/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' ${bootstrap_extra_args} --kubelet-extra-args "${kubelet_extra_args}" '${cluster_name}'
+/etc/eks/bootstrap.sh --b64-cluster-ca '${cluster_auth_base64}' --apiserver-endpoint '${endpoint}' ${bootstrap_extra_args} --kubelet-extra-args '${kubelet_extra_args}' '${cluster_name}'
 
 # Allow user supplied userdata code
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

Revert the change made in #474 which breaks --kubelet-extra-args taints and node labels (as described in #814 and #1004).

Closes #1004

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
