### PR TITLE
docs: Update autoscaler installation in IRSA example

### DIFF
--- a/examples/irsa/README.md
+++ b/examples/irsa/README.md
@@ -28,7 +28,9 @@ Replace `<ACCOUNT ID>` with your AWS account ID in `cluster-autoscaler-chart-val
 Install the chart using the provided values file:
 
 ```
-helm install cluster-autoscaler --namespace kube-system autoscaler/cluster-autoscaler-chart --values=cluster-autoscaler-chart-values.yaml
+$ helm repo add autoscaler https://kubernetes.github.io/autoscaler
+$ helm repo update
+$ helm install cluster-autoscaler --namespace kube-system autoscaler/cluster-autoscaler-chart --values=cluster-autoscaler-chart-values.yaml
 ```
 
 ## Verify

--- a/examples/irsa/README.md
+++ b/examples/irsa/README.md
@@ -28,7 +28,7 @@ Replace `<ACCOUNT ID>` with your AWS account ID in `cluster-autoscaler-chart-val
 Install the chart using the provided values file:
 
 ```
-helm install --name cluster-autoscaler --namespace kube-system stable/cluster-autoscaler --values=cluster-autoscaler-chart-values.yaml
+helm install cluster-autoscaler --namespace kube-system autoscaler/cluster-autoscaler-chart --values=cluster-autoscaler-chart-values.yaml
 ```
 
 ## Verify

--- a/examples/irsa/cluster-autoscaler-chart-values.yaml
+++ b/examples/irsa/cluster-autoscaler-chart-values.yaml
@@ -2,8 +2,9 @@ awsRegion: us-west-2
 
 rbac:
   create: true
-  serviceAccountAnnotations:
-    eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT ID>:role/cluster-autoscaler"
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: "arn:aws:iam::<ACCOUNT ID>:role/cluster-autoscaler"
 
 autoDiscovery:
   clusterName: test-eks-irsa


### PR DESCRIPTION
# PR o'clock

## Description

This PR fixes two issues in the irsa example:

1. Wrong chart values (or not compatible with the latest version). Please check this line: https://github.com/helm/charts/blob/a5632b118a97e829d9b93312ddc5816c3025d00b/stable/cluster-autoscaler/templates/serviceaccount.yaml#L8
2. Updates the `helm install` command used as the Helm chart has been moved to the kubernetes/autoscaler repository.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
