### PR TITLE
feat: Add `cloudwatch_log_group_arn` to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Description |
 |------|-------------|
+| cloudwatch\_log\_group\_arn | Arn of cloudwatch log group created |
 | cloudwatch\_log\_group\_name | Name of cloudwatch log group created |
 | cluster\_arn | The Amazon Resource Name (ARN) of the cluster. |
 | cluster\_certificate\_authority\_data | Nested attribute containing certificate-authority-data for your cluster. This is the base64 encoded certificate data required to communicate with your cluster. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,6 +61,11 @@ output "cloudwatch_log_group_name" {
   value       = aws_cloudwatch_log_group.this[*].name
 }
 
+output "cloudwatch_log_group_arn" {
+  description = "Arn of cloudwatch log group created"
+  value       = element(concat(aws_cloudwatch_log_group.this[*].arn, list("")), 0)
+}
+
 output "kubeconfig" {
   description = "kubectl config file contents for this EKS cluster."
   value       = local.kubeconfig


### PR DESCRIPTION
# PR o'clock

## Description

- Problem
  - Currently we cannot apply some resources which depends on eks module generated cloudwatch logs **arn**, like followings.
- How to solve?
  - add output `cloudwatch_log_group_arn`

```tf
module "eks" {
  source = "terraform-aws-modules/eks/aws"
  ...
}

resource "aws_lambda_permission" "log" {
  ...
  source_arn    = module.eks.cloudwatch_log_group_arn // <- we cannot pass cloudwatch arn in the same terraform apply.
}
```

To work-around, we need to define data resource. But in this case, we need to execute terraform apply twice to get cloudwatch resource.

```tf
data "aws_cloudwatch_log_group" "log" {
  name = module.eks.cloudwatch_log_group_name[0]
}
```

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
