### PR TITLE
ci: remove python@3.8 deps from macos lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,7 @@ jobs:
           # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
           brew untap local/homebrew-openssl
           brew untap local/homebrew-python2
+          brew unlink python@3.8
           brew update
           brew install pre-commit terraform-docs terraform
       - name: Check Docs


### PR DESCRIPTION
# PR o'clock

## Description

[master branch ci](https://github.com/terraform-aws-modules/terraform-aws-eks/runs/1323359003?check_suite_focus=true) is failed, because of conflict python versions.

To solve it, unlink python@3.8 before install `pre-commit` which depends on python@3.9.

https://formulae.brew.sh/formula/pre-commit

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
