### PR TITLE
ci: Use ubuntu-latest instead of MacOS for docs checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,18 +21,22 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Install Deps
+      - uses: actions/setup-python@v2
+      - name: Install terraform-docs
         run: |
-          # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
-          brew untap local/homebrew-openssl
-          brew untap local/homebrew-python2
-          brew update
-          brew install pre-commit terraform-docs terraform
+          # Get the download url of the latest version of terraform-docs
+          tf_docs_download_url=$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | jq -rc '.assets[] | select( .name | contains("linux-amd64")).browser_download_url')
+          mkdir -p $GITHUB_WORKSPACE/bin
+          curl -sLo $GITHUB_WORKSPACE/bin/terraform-docs $tf_docs_download_url
+          chmod +x $GITHUB_WORKSPACE/bin/terraform-docs
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: Check Docs
-        run: pre-commit run --show-diff-on-failure --all-files terraform_docs
+        uses: pre-commit/action@v2.0.0
+        with:
+          extra_args: --show-diff-on-failure --all-files terraform_docs
 
   validate:
     name: Validate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           # Get the download url of the latest version of terraform-docs
           tf_docs_download_url=$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | jq -rc '.assets[] | select( .name | contains("linux-amd64")).browser_download_url')
           mkdir -p $GITHUB_WORKSPACE/bin
-          curl -sLo $GITHUB_WORKSPACE/bin/terraform-docs $tf_docs_download_url
+          curl -Lo $GITHUB_WORKSPACE/bin/terraform-docs $tf_docs_download_url
           chmod +x $GITHUB_WORKSPACE/bin/terraform-docs
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
       - name: Check Docs


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
