### PR TITLE
improvement: Added asg tag override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| tags\_override\_asg | A map of tags to override in autoscaling group resources. | `map(string)` | `{}` | no |
 | vpc\_id | VPC where the cluster and workers will be deployed. | `string` | n/a | yes |
 | wait\_for\_cluster\_cmd | Custom local-exec command to execute for determining if the eks cluster is healthy. Cluster endpoint will be available as an environment variable called ENDPOINT | `string` | `"for i in `seq 1 60`; do if `command -v wget > /dev/null`; then wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; else curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true;fi; sleep 5; done; echo TIMEOUT && exit 1"` | no |
 | wait\_for\_cluster\_interpreter | Custom local-exec command line interpreter for the command to determining if the eks cluster is healthy. | `list(string)` | <pre>[<br>  "/bin/sh",<br>  "-c"<br>]</pre> | no |

--- a/local.tf
+++ b/local.tf
@@ -1,5 +1,5 @@
 locals {
-  asg_tags = [
+  asg_tags = var.tags_override_asg == {} ? var.tags_override_asg : [
     for item in keys(var.tags) :
     map(
       "key", item,

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_override_asg" {
+  description = "A map of tags to override in autoscaling group resources."
+  type        = map(string)
+  default     = {}
+}
+
 variable "vpc_id" {
   description = "VPC where the cluster and workers will be deployed."
   type        = string


### PR DESCRIPTION
# PR o'clock

## Description

Added asg tag override option to improve availability to exclude worker instances from AWS backup.
So in case you need to backup only PV's you can set extra tags for all resources but EC2 instances to exclude them.

### Checklist

- ✅  CI tests are passing
- ✅  README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
