### PR TITLE
docs: Explain node_groups and worker_groups difference in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,3 +189,11 @@ Kubelet restricts the allowed list of labels in the `kubernetes.io` namespace th
 Older configurations used labels like `kubernetes.io/lifecycle=spot` and this is no longer allowed. Use `node.kubernetes.io/lifecycle=spot` instead.
 
 Reference the `--node-labels` argument for your version of Kubenetes for the allowed prefixes. [Documentation for 1.16](https://v1-16.docs.kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)
+
+## What is the difference between `node_groups` and `worker_groups`?
+
+`node_groups` are [AWS-managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) (configures "Node Groups" that you can find on the EKS dashboard). This system is supposed to ease some of the lifecycle around upgrading nodes. Although they do not do this automatically and you still need to manually trigger the updates.
+
+`worker_groups` are [self-managed nodes](https://docs.aws.amazon.com/eks/latest/userguide/worker.html) (provisions a typical "Autoscaling group" on EC2). It gives you full control over nodes in the cluster like using custom AMI for the nodes. As AWS says, "with worker groups the customer controls the data plane & AWS controls the control plane".
+
+Both can be used together in the same cluster.


### PR DESCRIPTION
# PR o'clock

## Description

Adds FAQ section on difference between `node_groups` and `worker_groups` (see #895 and #1077). 

It's based on comments from @dpiddockcmp and others in the issues mentioned before. Let me know if I should clarify something or expand in certain areas. It does answer the question I had when I first encountered this issue.

/ping @barryib

### Checklist

- [X] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
