### PR TITLE
fix: Put KubeletExtraArgs in double quotes for Windows

### DIFF
--- a/templates/userdata_windows.tpl
+++ b/templates/userdata_windows.tpl
@@ -4,7 +4,7 @@ ${pre_userdata}
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
 [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
-& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -KubeletExtraArgs '${kubelet_extra_args}' 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -KubeletExtraArgs "${kubelet_extra_args}" 3>&1 4>&1 5>&1 6>&1
 $LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
 
 ${additional_userdata}


### PR DESCRIPTION
# PR o'clock

## Description

Put KubeletExtraArgs in double quotes for Windows, it is already double quoted in the Bash script. This allows for variable substitution within the string e.g.
```
kubelet_extra_args = "node.kubernetes.io/lifecycle=$(Invoke-WebRequest -Uri http://169.254.169.254/latest/meta-data/instance-life-cycle | Select-Object -ExpandProperty Content)"
```

### Checklist

- [x] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
