### PR TITLE
fix: Change the default `launch_template_id` to `null` for Managed Node Groups

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -80,7 +80,7 @@ locals {
     # Settings for launch templates
     root_block_device_name               = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
     root_kms_key_id                      = ""                                       # The KMS key to use when encrypting the root storage device
-    launch_template_id                   = ""                                       # The id of the launch template used for managed node_groups
+    launch_template_id                   = null                                     # The id of the launch template used for managed node_groups
     launch_template_version              = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
     launch_template_placement_tenancy    = "default"                                # The placement tenancy for instances
     launch_template_placement_group      = null                                     # The name of the placement group into which to launch the instances, if any.

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -15,7 +15,7 @@ resource "aws_eks_node_group" "workers" {
 
   ami_type        = lookup(each.value, "ami_type", null)
   disk_size       = lookup(each.value, "disk_size", null)
-  instance_types  = each.value["launch_template_id"] != "" ? [] : [each.value["instance_type"]]
+  instance_types  = each.value["launch_template_id"] != null ? [] : [each.value["instance_type"]]
   release_version = lookup(each.value, "ami_release_version", null)
 
   dynamic "remote_access" {

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -31,7 +31,7 @@ resource "aws_eks_node_group" "workers" {
   }
 
   dynamic "launch_template" {
-    for_each = each.value["launch_template_id"] != "" ? [{
+    for_each = each.value["launch_template_id"] != null ? [{
       id      = each.value["launch_template_id"]
       version = each.value["launch_template_version"]
     }] : []


### PR DESCRIPTION
# PR o'clock

## Description

We should define launch_template_id for managed node groups only if it needed.

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1087

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
