### PR TITLE
fix: Don’t add empty Roles ARN in aws-auth configmap, specifically when no Fargate profiles are specified

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -59,7 +59,6 @@ locals {
         role["platform"] == "fargate" ? ["system:node-proxier"] : [],
       ))
     }
-    if role["worker_role_arn"] != ""
   ]
 }
 

--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -59,6 +59,7 @@ locals {
         role["platform"] == "fargate" ? ["system:node-proxier"] : [],
       ))
     }
+    if role["worker_role_arn"] != ""
   ]
 }
 

--- a/modules/fargate/outputs.tf
+++ b/modules/fargate/outputs.tf
@@ -24,6 +24,6 @@ output "aws_auth_roles" {
     for i in range(1) : {
       worker_role_arn = local.pod_execution_role_arn
       platform        = "fargate"
-    } if length(var.fargate_profiles) > 0
+    } if local.create_eks
   ]
 }

--- a/modules/fargate/outputs.tf
+++ b/modules/fargate/outputs.tf
@@ -20,8 +20,10 @@ output "iam_role_arn" {
 
 output "aws_auth_roles" {
   description = "Roles for use in aws-auth ConfigMap"
-  value = [{
-    worker_role_arn = local.pod_execution_role_arn
-    platform        = "fargate"
-  }]
+  value = [
+    for i in range(1) : {
+      worker_role_arn = local.pod_execution_role_arn
+      platform        = "fargate"
+    } if length(var.fargate_profiles) > 0
+  ]
 }


### PR DESCRIPTION
# PR o'clock

## Description
The new fargate code seems to have caused a bug in authmap.

Currently even when no fargate profiles are specified the fargate module output is used to create an authmap entry with an empty ARN. 

The plan shows:
```
                - "groups":
              +   - "system:bootstrappers"
              +   - "system:nodes"
              +   - "system:node-proxier"
              +   "rolearn": ""
              +   "username": "system:node:{{SessionName}}"
              + - "groups":
```
Apply errors:

```
Error: Failed to update Config Map: Unauthorized
  on .terraform/modules/eks_cluster/aws_auth.tf line 65, in resource "kubernetes_config_map" "aws_auth":
  65: resource "kubernetes_config_map" "aws_auth" {
```

This seems to be because "rolearn" is empty.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
