### PR TITLE
fix: security group rule conditional creation

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -102,7 +102,7 @@ resource "aws_security_group_rule" "cluster_egress_internet" {
 }
 
 resource "aws_security_group_rule" "cluster_https_worker_ingress" {
-  count                    = var.cluster_create_security_group && var.create_eks ? 1 : 0
+  count                    = var.cluster_create_security_group && local.worker_security_group_id != "" && var.create_eks ? 1 : 0
   description              = "Allow pods to communicate with the EKS cluster API."
   protocol                 = "tcp"
   security_group_id        = local.cluster_security_group_id


### PR DESCRIPTION
# PR o'clock

## Description

Make the `aws_security_group_rule.cluster_https_worker_ingress` resource conditional on the worker security group existing. The worker security group would not exist if the user is using managed node groups only.

Fixes #1103 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
