### PR TITLE
feat: Add permissions boundary to fargate execution IAM role

### DIFF
--- a/fargate.tf
+++ b/fargate.tf
@@ -5,6 +5,7 @@ module "fargate" {
   create_fargate_pod_execution_role = var.create_fargate_pod_execution_role
   fargate_pod_execution_role_name   = var.fargate_pod_execution_role_name
   fargate_profiles                  = var.fargate_profiles
+  permissions_boundary              = var.permissions_boundary
   iam_path                          = var.iam_path
   iam_policy_arn_prefix             = local.policy_arn_prefix
   subnets                           = var.subnets

--- a/modules/fargate/README.md
+++ b/modules/fargate/README.md
@@ -38,6 +38,7 @@ No requirements.
 | fargate\_profiles | Fargate profiles to create. See `fargate_profile` keys section in README.md for more details | `any` | `{}` | no |
 | iam\_path | IAM roles will be created on this path. | `string` | `"/"` | no |
 | iam\_policy\_arn\_prefix | IAM policy prefix with the correct AWS partition. | `string` | n/a | yes |
+| permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | subnets | A list of subnets for the EKS Fargate profiles. | `list(string)` | `[]` | no |
 | tags | A map of tags to add to all resources. | `map(string)` | `{}` | no |
 

--- a/modules/fargate/fargate.tf
+++ b/modules/fargate/fargate.tf
@@ -1,9 +1,10 @@
 resource "aws_iam_role" "eks_fargate_pod" {
-  count              = local.create_eks && var.create_fargate_pod_execution_role ? 1 : 0
-  name_prefix        = format("%s-fargate", var.cluster_name)
-  assume_role_policy = data.aws_iam_policy_document.eks_fargate_pod_assume_role[0].json
-  tags               = var.tags
-  path               = var.iam_path
+  count                = local.create_eks && var.create_fargate_pod_execution_role ? 1 : 0
+  name_prefix          = format("%s-fargate", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.eks_fargate_pod_assume_role[0].json
+  permissions_boundary = var.permissions_boundary
+  tags                 = var.tags
+  path                 = var.iam_path
 }
 
 resource "aws_iam_role_policy_attachment" "eks_fargate_pod" {

--- a/modules/fargate/variables.tf
+++ b/modules/fargate/variables.tf
@@ -38,6 +38,12 @@ variable "fargate_profiles" {
   default     = {}
 }
 
+variable "permissions_boundary" {
+  description = "If provided, all IAM roles will be created with this permissions boundary attached."
+  type        = string
+  default     = null
+}
+
 variable "subnets" {
   description = "A list of subnets for the EKS Fargate profiles."
   type        = list(string)


### PR DESCRIPTION
# PR o'clock

## Description

The iam role created by fargate is missing the `permissions_boundary` attribute 

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
