### PR TITLE
feat: Added input for worker nodes ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | fargate\_pod\_execution\_role\_name | The IAM Role that provides permissions for the EKS Fargate Profile. | `string` | `null` | no |
 | fargate\_profiles | Fargate profiles to create. See `fargate_profile` keys section in fargate submodule's README.md for more details | `any` | `{}` | no |
 | iam\_path | If provided, all IAM roles will be created on this path. | `string` | `"/"` | no |
+| key\_name | Attach SSH key to worker nodes | `string` | `null` | no |
 | kubeconfig\_aws\_authenticator\_additional\_args | Any additional arguments to pass to the authenticator such as the role to assume. e.g. ["-r", "MyEksRole"]. | `list(string)` | `[]` | no |
 | kubeconfig\_aws\_authenticator\_command | Command to use to fetch AWS EKS credentials. | `string` | `"aws-iam-authenticator"` | no |
 | kubeconfig\_aws\_authenticator\_command\_args | Default arguments passed to the authenticator command. Defaults to [token -i $cluster\_name]. | `list(string)` | `[]` | no |

--- a/local.tf
+++ b/local.tf
@@ -44,7 +44,7 @@ locals {
     root_volume_size              = "100"                       # root volume size of workers instances.
     root_volume_type              = "gp2"                       # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
-    key_name                      = ""                          # The key pair name that should be used for the instances in the autoscaling group
+    key_name                      = var.key_name                # The key pair name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
     userdata_template_file        = ""                          # alternate template to use for userdata
     userdata_template_extra_args  = {}                          # Additional arguments to use when expanding the userdata template file

--- a/variables.tf
+++ b/variables.tf
@@ -367,3 +367,9 @@ variable "fargate_pod_execution_role_name" {
   type        = string
   default     = null
 }
+
+variable "key_name" {
+  description = "Attach SSH key to worker nodes"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
# PR o'clock

## Description

Just add an input variable for worker node ssh `key_name`.  
for example usage: `key_name        = module.key_pair.this_key_pair_key_name`
### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
