### PR TITLE
feat: support Fargate in private+public EKS environments

### DIFF
--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -100,6 +100,9 @@ module "eks" {
       #   GithubOrg   = "terraform-aws-modules"
       # }
 
+      # using specific subnets instead of all the ones configured in eks
+      # subnets = ["subnet-0ca3e3d1234a56c78"]
+
       tags = {
         Owner = "test"
       }

--- a/modules/fargate/README.md
+++ b/modules/fargate/README.md
@@ -14,6 +14,7 @@ Helper submodule to create and manage resources related to `aws_eks_fargate_prof
 | namespace | Kubernetes namespace for selection | `string` | n/a | yes |
 | labels | Key-value map of Kubernetes labels for selection | `map(string)` | `{}` | no |
 | tags | Key-value map of resource tags. Will be merged with root module tags. | `map(string)` | `var.tags` | no |
+| subnets | List of subnet IDs. Will replace the root module subnets. | `list(string)` | `var.subnets` | no |
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/fargate/fargate.tf
+++ b/modules/fargate/fargate.tf
@@ -18,7 +18,7 @@ resource "aws_eks_fargate_profile" "this" {
   cluster_name           = var.cluster_name
   fargate_profile_name   = lookup(each.value, "name", format("%s-fargate-%s", var.cluster_name, replace(each.key, "_", "-")))
   pod_execution_role_arn = local.pod_execution_role_arn
-  subnet_ids             = var.subnets
+  subnet_ids             = lookup(each.value, "subnets", var.subnets)
   tags                   = each.value.tags
   selector {
     namespace = each.value.namespace


### PR DESCRIPTION
# PR o'clock

## Description

The EKS cluster can be provisioned with both private and public subnets.
But Fargate only accepts private ones.

This new variable allows to override the subnets to explicitly pass the
private subnets to Fargate and work around that issue.

### Checklist

- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation