### PR TITLE
feat: Ignore changes to SG name_prefix and description to support migration paths to module

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -88,6 +88,9 @@ resource "aws_security_group" "cluster" {
       "Name" = "${var.cluster_name}-eks_cluster_sg"
     },
   )
+  lifecycle {
+    ignore_changes = [name_prefix, description]
+  }
 }
 
 resource "aws_security_group_rule" "cluster_egress_internet" {

--- a/workers.tf
+++ b/workers.tf
@@ -320,6 +320,9 @@ resource "aws_security_group" "workers" {
       "kubernetes.io/cluster/${var.cluster_name}" = "owned"
     },
   )
+  lifecycle {
+    ignore_changes = [name_prefix, description]
+  }
 }
 
 resource "aws_security_group_rule" "workers_egress_internet" {


### PR DESCRIPTION
# PR o'clock

## Description

When migrating existing resources to this module with `terraform state mv`, TF will want to re-create the Security Group (and thus, the cluster) due to the `name_prefix` and `description` field changing unless they happened to match. These are safe enough fields to ignore changes on because they will always force re-creation anyway, which is never wanted.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
