### PR TITLE
fix: configuring resource 'local_file kubeconfig' as sensitive content

### DIFF
--- a/kubectl.tf
+++ b/kubectl.tf
@@ -1,6 +1,6 @@
 resource "local_file" "kubeconfig" {
   count                = var.write_kubeconfig && var.create_eks ? 1 : 0
-  content              = local.kubeconfig
+  sensitive_content    = local.kubeconfig
   filename             = substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path
   file_permission      = "0644"
   directory_permission = "0755"


### PR DESCRIPTION
# PR o'clock

## Description

The problem occurs when you run the pipeline in an CI tool, the secret of kubectl appears in the output, this PR hide the content of the file to be taken as a secret.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
