### PR TITLE
feat: Use `gp3` as default as it saves 20% and is more performant

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -42,7 +42,7 @@ locals {
     spot_price                    = ""                          # Cost of spot instance.
     placement_tenancy             = ""                          # The tenancy of the instance. Valid values are "default" or "dedicated".
     root_volume_size              = "100"                       # root volume size of workers instances.
-    root_volume_type              = "gp3"                       # root volume type of workers instances, can be 'standard', 'gp3', 'gp2', or 'io1'
+    root_volume_type              = "gp3"                       # root volume type of workers instances, can be "standard", "gp3", "gp2", or "io1"
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                          # The key pair name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.

--- a/local.tf
+++ b/local.tf
@@ -42,7 +42,7 @@ locals {
     spot_price                    = ""                          # Cost of spot instance.
     placement_tenancy             = ""                          # The tenancy of the instance. Valid values are "default" or "dedicated".
     root_volume_size              = "100"                       # root volume size of workers instances.
-    root_volume_type              = "gp2"                       # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
+    root_volume_type              = "gp3"                       # root volume type of workers instances, can be 'standard', 'gp3', 'gp2', or 'io1'
     root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     key_name                      = ""                          # The key pair name that should be used for the instances in the autoscaling group
     pre_userdata                  = ""                          # userdata to pre-append to the default userdata.


### PR DESCRIPTION
# PR o'clock
Provider has caught up https://github.com/hashicorp/terraform-provider-aws/pull/16652, thanks @ewbankkit 

## Description
AWS now has a cheaper and more performant drive type:
https://aws.amazon.com/about-aws/whats-new/2020/12/introducing-new-amazon-ebs-general-purpose-volumes-gp3/
Re: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1130
### Checklist

- [] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
