### PR TITLE
feat: Add support for `service_ipv4_cidr` for the EKS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_log\_retention\_in\_days | Number of days to retain log events. Default retention - 90 days. | `number` | `90` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | `string` | n/a | yes |
 | cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
+| cluster\_service\_ipv4\_cidr | service ipv4 cidr for the kubernetes cluster | `string` | `null` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | `string` | `"./"` | no |
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -22,6 +22,10 @@ resource "aws_eks_cluster" "this" {
     public_access_cidrs     = var.cluster_endpoint_public_access_cidrs
   }
 
+  kubernetes_network_config {
+    service_ipv4_cidr = var.cluster_service_ipv4_cidr
+  }
+
   timeouts {
     create = var.cluster_create_timeout
     delete = var.cluster_delete_timeout

--- a/variables.tf
+++ b/variables.tf
@@ -369,3 +369,9 @@ variable "fargate_pod_execution_role_name" {
   type        = string
   default     = null
 }
+
+variable "cluster_service_ipv4_cidr" {
+  description = "service ipv4 cidr for the kubernetes cluster"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
# PR o'clock

## Description

This change adds support for service_ipv4_cidr that has been added to terraform-provider-aws last week.
( please see https://github.com/hashicorp/terraform-provider-aws/issues/15505 )

This allows the user to specify the ipv4 CIDR for the k8s services (resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1056 )

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
