### PR TITLE
improvement: update pre-commit-terraform and incude tfsec hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.43.0
+  rev: v1.45.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
     - id: terraform_validate
     - id: terraform_tflint
+    - id: terraform_tfsec

--- a/cluster.tf
+++ b/cluster.tf
@@ -55,6 +55,7 @@ resource "aws_security_group_rule" "cluster_private_access" {
   to_port     = 443
   protocol    = "tcp"
   cidr_blocks = var.cluster_endpoint_private_access_cidrs
+  description = "Permits ingress cluster endpoint access from private cidrs."
 
   security_group_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
 }
@@ -95,7 +96,7 @@ resource "aws_security_group_rule" "cluster_egress_internet" {
   description       = "Allow cluster egress access to the Internet."
   protocol          = "-1"
   security_group_id = local.cluster_security_group_id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007
   from_port         = 0
   to_port           = 0
   type              = "egress"

--- a/workers.tf
+++ b/workers.tf
@@ -327,7 +327,7 @@ resource "aws_security_group_rule" "workers_egress_internet" {
   description       = "Allow nodes all egress to the Internet."
   protocol          = "-1"
   security_group_id = local.worker_security_group_id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007
   from_port         = 0
   to_port           = 0
   type              = "egress"


### PR DESCRIPTION
# PR o'clock

## Description

This PR adds the tfsec pre-commit-terraform hook & also updates the pre-commit-terraform version. In addition I've added some ifgnores to the code. The problem we have is when using tfsec in our workflow then we get tfsec errors for this module since tfsec checks `.terraform` folder however I see this as a good improvement anyway?

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
