### PR TITLE
feat: Add support for spot instances node groups.

### DIFF
--- a/examples/launch_templates_with_managed_node_groups/main.tf
+++ b/examples/launch_templates_with_managed_node_groups/main.tf
@@ -89,5 +89,18 @@ module "eks" {
         CustomTag = "EKS example"
       }
     }
+
+    spot-example = {
+      name             = "spot-example"
+      desired_capacity = 1
+      max_capacity     = 20
+      min_capacity     = 1
+      instance_type    = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"]
+      capacity_type    = "SPOT"
+      k8s_labels = {
+        lifecycle = "spot"
+        node-type = "microservice"
+      }
+    }
   }
 }

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -20,6 +20,7 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | additional\_tags | Additional tags to apply to node group | map(string) | Only `var.tags` applied |
 | ami\_release\_version | AMI version of workers | string | Provider default behavior |
 | ami\_type | AMI Type. See Terraform or AWS docs | string | Provider default behavior |
+| capacity_type | Type of nodes in the nodegroup (ON_DEMAND or SPOT) | string | Provider default behavior (ON_DEMAND) |
 | desired\_capacity | Desired number of workers | number | `var.workers_group_defaults[asg_desired_capacity]` |
 | disk\_size | Workers' disk size | number | Provider default behavior |
 | iam\_role\_arn | IAM role ARN for workers | string | `var.default_iam_role_arn` |

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -24,7 +24,7 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | desired\_capacity | Desired number of workers | number | `var.workers_group_defaults[asg_desired_capacity]` |
 | disk\_size | Workers' disk size | number | Provider default behavior |
 | iam\_role\_arn | IAM role ARN for workers | string | `var.default_iam_role_arn` |
-| instance\_type | Workers' instance type | string | `var.workers_group_defaults[instance_type]` |
+| instance\_type | Workers' instance type | string or list(string) | `var.workers_group_defaults[instance_type]` |
 | k8s\_labels | Kubernetes labels | map(string) | No labels applied |
 | key\_name | Key name for workers. Set to empty string to disable remote access | string | `var.workers_group_defaults[key_name]` |
 | launch_template_id | The id of a aws_launch_template to use | string | No LT used |

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -15,7 +15,7 @@ resource "aws_eks_node_group" "workers" {
 
   ami_type        = lookup(each.value, "ami_type", null)
   disk_size       = lookup(each.value, "disk_size", null)
-  instance_types  = try(each.value["launch_template_id"] != "", false) ? [] : flatten([each.value["instance_type"]])
+  instance_types  = each.value["launch_template_id"] != "" ? [] : flatten([each.value["instance_type"]])
   release_version = lookup(each.value, "ami_release_version", null)
   capacity_type   = lookup(each.value, "capacity_type", "ON_DEMAND")
 

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -15,7 +15,7 @@ resource "aws_eks_node_group" "workers" {
 
   ami_type        = lookup(each.value, "ami_type", null)
   disk_size       = lookup(each.value, "disk_size", null)
-  instance_types  = each.value["launch_template_id"] != null ? [] : each.value["instance_types"] != null ? each.value["instance_types"] : [each.value["instance_type"]]
+  instance_types  = try(each.value["launch_template_id"] != "", false) ? [] : flatten([each.value["instance_type"]])
   release_version = lookup(each.value, "ami_release_version", null)
   capacity_type   = lookup(each.value, "capacity_type", "ON_DEMAND")
 

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -15,8 +15,9 @@ resource "aws_eks_node_group" "workers" {
 
   ami_type        = lookup(each.value, "ami_type", null)
   disk_size       = lookup(each.value, "disk_size", null)
-  instance_types  = each.value["launch_template_id"] != null ? [] : [each.value["instance_type"]]
+  instance_types  = each.value["launch_template_id"] != null ? [] : each.value["instance_types"] != null ? each.value["instance_types"] : [each.value["instance_type"]]
   release_version = lookup(each.value, "ami_release_version", null)
+  capacity_type   = lookup(each.value, "capacity_type", "ON_DEMAND")
 
   dynamic "remote_access" {
     for_each = each.value["key_name"] != "" ? [{

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -15,7 +15,7 @@ resource "aws_eks_node_group" "workers" {
 
   ami_type        = lookup(each.value, "ami_type", null)
   disk_size       = lookup(each.value, "disk_size", null)
-  instance_types  = each.value["launch_template_id"] != "" ? [] : flatten([each.value["instance_type"]])
+  instance_types  = each.value["launch_template_id"] != null ? [] : flatten([each.value["instance_type"]])
   release_version = lookup(each.value, "ami_release_version", null)
   capacity_type   = lookup(each.value, "capacity_type", "ON_DEMAND")
 

--- a/modules/node_groups/random.tf
+++ b/modules/node_groups/random.tf
@@ -7,7 +7,7 @@ resource "random_pet" "node_groups" {
   keepers = {
     ami_type      = lookup(each.value, "ami_type", null)
     disk_size     = lookup(each.value, "disk_size", null)
-    instance_type = each.value["instance_type"]
+    instance_type = join("|", flatten([each.value["instance_type"]]))
     iam_role_arn  = each.value["iam_role_arn"]
 
     key_name = each.value["key_name"]


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.
This is to implement feature request #1107.
It allows creating nodegroups with spot instances, as described in https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-eks-support-ec2-spot-instances-managed-node-groups/

example usage:
```
module "eks" {
  // [...]
  node_groups = {
    spot-inst-managed = {
      name             = "spot-managed-${var.cluster_name}"
      desired_capacity = 2
      max_capacity     = 20
      min_capacity     = 2
      instance_type    = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"]
      capacity_type    = "SPOT"
    }
```

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
