### PR TITLE
Change required_providers for the compatibility with terraform 0.14 

### DIFF
--- a/modules/fargate/versions.tf
+++ b/modules/fargate/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/node_groups/versions.tf
+++ b/modules/node_groups/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,30 @@
 terraform {
-  required_version = ">= 0.12.9, != 0.13.0"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws        = ">= 3.21.0"
-    local      = ">= 1.4"
-    null       = ">= 2.1"
-    template   = ">= 2.1"
-    random     = ">= 2.1"
-    kubernetes = ">= 1.11.1"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.21.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.4"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.1"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 1.11.1"
+    }
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Due to recent change in terraform 0.14, all providers need to be declare with this new format witch include the "source" of the provider.

```
terraform {
  required_version = ">= 0.13"

  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = ">= 3.21.0"
    }
}
```
### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
