### PR TITLE
docs: Change instance type from `t2` to `t3` in examples

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -139,14 +139,14 @@ module "eks" {
   worker_groups = [
     {
       name                          = "worker-group-1"
-      instance_type                 = "t2.small"
+      instance_type                 = "t3.small"
       additional_userdata           = "echo foo bar"
       asg_desired_capacity          = 2
       additional_security_group_ids = [aws_security_group.worker_group_mgmt_one.id]
     },
     {
       name                          = "worker-group-2"
-      instance_type                 = "t2.medium"
+      instance_type                 = "t3.medium"
       additional_userdata           = "echo foo bar"
       additional_security_group_ids = [aws_security_group.worker_group_mgmt_two.id]
       asg_desired_capacity          = 1

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -65,7 +65,7 @@ module "eks" {
   worker_groups = [
     {
       name                 = "worker-group-1"
-      instance_type        = "t2.medium"
+      instance_type        = "t3.medium"
       asg_desired_capacity = 1
       tags = [
         {

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -72,13 +72,13 @@ module "eks" {
   worker_groups_launch_template = [
     {
       name                 = "worker-group-1"
-      instance_type        = "t2.small"
+      instance_type        = "t3.small"
       asg_desired_capacity = 2
       public_ip            = true
     },
     {
       name                 = "worker-group-2"
-      instance_type        = "t2.medium"
+      instance_type        = "t3.medium"
       asg_desired_capacity = 1
       public_ip            = true
     },

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -121,7 +121,7 @@ module "eks" {
   # worker_groups_launch_template = [
   #   {
   #     name                 = "worker-group-1"
-  #     instance_type        = "t2.small"
+  #     instance_type        = "t3.small"
   #     asg_desired_capacity = 2
   #     public_ip            = true
   #   }

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -103,7 +103,7 @@ module "eks" {
   worker_groups = [
     {
       name                 = "worker-group-1"
-      instance_type        = "t2.small"
+      instance_type        = "t3.small"
       additional_userdata  = "echo foo bar"
       asg_desired_capacity = 2
     },


### PR DESCRIPTION
# PR o'clock

## Description

The t2 instance type isn't available in newer regions such as eu-north-1. Therefore the examples using t2 will fail in this region.

Available instance types can be verified with: 
`aws ec2 describe-instance-type-offerings --location-type "region" --region eu-north-1 | jq '.InstanceTypeOfferings[].InstanceType | select(startswith("t"))'`

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
