### PR TITLE
fix: change kubectl file permission to 0600

### DIFF
--- a/kubectl.tf
+++ b/kubectl.tf
@@ -2,6 +2,6 @@ resource "local_file" "kubeconfig" {
   count                = var.write_kubeconfig && var.create_eks ? 1 : 0
   content              = local.kubeconfig
   filename             = substr(var.config_output_path, -1, 1) == "/" ? "${var.config_output_path}kubeconfig_${var.cluster_name}" : var.config_output_path
-  file_permission      = "0644"
+  file_permission      = "0600"
   directory_permission = "0755"
 }


### PR DESCRIPTION
# PR o'clock

## Description

Changed kubeconfig file permission to 0600.

See: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1172

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
