### PR TITLE
docs: Bump IRSA example dependencies to versions which work with TF 0.14

### DIFF
--- a/examples/irsa/irsa.tf
+++ b/examples/irsa/irsa.tf
@@ -1,6 +1,6 @@
 module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "2.14.0"
+  version                       = "3.6.0"
   create_role                   = true
   role_name                     = "cluster-autoscaler"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -41,7 +41,7 @@ data "aws_caller_identity" "current" {}
 
 module "vpc" {
   source               = "terraform-aws-modules/vpc/aws"
-  version              = "2.47.0"
+  version              = "2.64.0"
   name                 = "test-vpc"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names

--- a/examples/irsa/variables.tf
+++ b/examples/irsa/variables.tf
@@ -1,3 +1,3 @@
 variable "region" {
-  default = "us-west-2"
+  default = "eu-west-2"
 }

--- a/examples/irsa/variables.tf
+++ b/examples/irsa/variables.tf
@@ -1,3 +1,3 @@
 variable "region" {
-  default = "eu-west-2"
+  default = "us-west-2"
 }


### PR DESCRIPTION
# PR o'clock

## Description

Bump irsa example deps to versions which work with Terraform 1.4

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
