### PR TITLE
fix: Set kubernetes provider pin to `~> 1.11`

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,6 @@ terraform {
     null       = ">= 2.1"
     template   = ">= 2.1"
     random     = ">= 2.1"
-    kubernetes = ">= 1.11.1"
+    kubernetes = "~> 1.11"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

This allowed me to workaround the problem mentioned in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/911.

The upstream kubernetes provider had a major release (`> 2.0.0`) and I think it may contain a bug related to the `aws_auth` config map data refresh. I'm not 100% sure, but I was still encountering the problem mentioned in that issue until I overwrote the `versions.tf` in this repo with my change.

NOTE: I'm using Terraform 0.14.4 and Terragrunt 0.27.2 if that helps

### Checklist

- [ ] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
