### PR TITLE
docs: Update changelog generation to use custom sort with git-chglog v0.10.0

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -13,14 +13,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 {{ .Title }}:
 {{ range .Commits -}}
 {{- if .Subject -}}
-- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject | upperFirst }}
 {{ end -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Unreleased.Commits -}}
 {{- if .Subject -}}
-- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject | upperFirst}}
 {{ end -}}
 {{ end }}
 {{ end -}}
@@ -43,14 +43,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 {{ .Title }}:
 {{ range .Commits -}}
 {{- if .Subject -}}
-- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject | upperFirst }}
 {{ end -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Commits -}}
 {{- if .Subject -}}
-- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject | upperFirst }}
 {{ end -}}
 {{ end }}
 {{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -18,7 +18,15 @@ options:
 
   commit_groups:
     group_by: Type
-    sort_by: Type
+    sort_by: Custom
+    title_order:
+      - feat
+      - improvement
+      - refactor
+      - fix
+      - docs
+      - test
+      - ci
     title_maps:
       feat: FEATURES
       fix: BUG FIXES

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ TAG_QUERY=v11.0.0..
 scope ?= "minor"
 
 changelog-unrelease:
-	git-chglog -o $(CHANGELOG_FILE) $(TAG_QUERY)
+	git-chglog --no-case -o $(CHANGELOG_FILE) $(TAG_QUERY)
 
 changelog:
-	git-chglog -o $(CHANGELOG_FILE) --next-tag `$(SEMTAG) final -s $(scope) -o -f` $(TAG_QUERY)
+	git-chglog --no-case -o $(CHANGELOG_FILE) --next-tag `$(SEMTAG) final -s $(scope) -o -f` $(TAG_QUERY)
 
 release:
 	$(SEMTAG) final -s $(scope)


### PR DESCRIPTION
# PR o'clock

## Description

Use custom sort for commit groups and upperFirst function

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
