### PR TITLE
feat: Allow customization of aws_eks_node_group timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | `list(string)` | `[]` | no |
 | map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
+| node\_group\_timeouts | A map of timeouts for create/update/delete operations. | `map(string)` | `{}` | no |
 | node\_groups | Map of map of node groups to create. See `node_groups` module's documentation for more details | `any` | `{}` | no |
 | node\_groups\_defaults | Map of values to be applied to all node groups. See `node_groups` module's documentation for more details | `any` | `{}` | no |
 | permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | map\_accounts | Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | `list(string)` | `[]` | no |
 | map\_roles | Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | map\_users | Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
-| node\_group\_timeouts | A map of timeouts for create/update/delete operations. | `map(string)` | `{}` | no |
 | node\_groups | Map of map of node groups to create. See `node_groups` module's documentation for more details | `any` | `{}` | no |
 | node\_groups\_defaults | Map of values to be applied to all node groups. See `node_groups` module's documentation for more details | `any` | `{}` | no |
+| node\_groups\_timeouts | A map of timeouts for create/update/delete operations. | `map(string)` | `{}` | no |
 | permissions\_boundary | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | subnets | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | tags | A map of tags to add to all resources. Tags added to launch configuration or templates override these values for ASG Tags only. | `map(string)` | `{}` | no |

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -56,6 +56,7 @@ No requirements.
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | default\_iam\_role\_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | n/a | yes |
 | ng\_depends\_on | List of references to other resources this submodule depends on | `any` | `null` | no |
+| node\_group\_timeouts | A map of timeouts for create/update/delete operations. | `map(string)` | n/a | yes |
 | node\_groups | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | `{}` | no |
 | node\_groups\_defaults | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | n/a | yes |
 | tags | A map of tags to add to all resources | `map(string)` | n/a | yes |

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -56,9 +56,9 @@ No requirements.
 | create\_eks | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | default\_iam\_role\_arn | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | n/a | yes |
 | ng\_depends\_on | List of references to other resources this submodule depends on | `any` | `null` | no |
-| node\_group\_timeouts | A map of timeouts for create/update/delete operations. | `map(string)` | n/a | yes |
 | node\_groups | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | `{}` | no |
 | node\_groups\_defaults | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | n/a | yes |
+| node\_groups\_timeouts | A map of timeouts for create/update/delete operations. | `map(string)` | n/a | yes |
 | tags | A map of tags to add to all resources | `map(string)` | n/a | yes |
 | workers\_group\_defaults | Workers group defaults from parent | `any` | n/a | yes |
 

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -44,9 +44,9 @@ resource "aws_eks_node_group" "workers" {
   }
 
   timeouts {
-    create = lookup(var.node_group_timeouts, "create", null)
-    update = lookup(var.node_group_timeouts, "update", null)
-    delete = lookup(var.node_group_timeouts, "delete", null)
+    create = lookup(var.node_groups_timeouts, "create", null)
+    update = lookup(var.node_groups_timeouts, "update", null)
+    delete = lookup(var.node_groups_timeouts, "delete", null)
   }
 
   version = lookup(each.value, "version", null)

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -43,6 +43,12 @@ resource "aws_eks_node_group" "workers" {
     }
   }
 
+  timeouts {
+    create = lookup(var.node_group_timeouts, "create", null)
+    update = lookup(var.node_group_timeouts, "update", null)
+    delete = lookup(var.node_group_timeouts, "delete", null)
+  }
+
   version = lookup(each.value, "version", null)
 
   labels = merge(

--- a/modules/node_groups/variables.tf
+++ b/modules/node_groups/variables.tf
@@ -35,6 +35,11 @@ variable "node_groups" {
   default     = {}
 }
 
+variable "node_group_timeouts" {
+  description = "A map of timeouts for create/update/delete operations."
+  type        = map(string)
+}
+
 # Hack for a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
 # Will be removed in Terraform 0.13 with the support of module's `depends_on` https://github.com/hashicorp/terraform/issues/10462
 variable "ng_depends_on" {

--- a/modules/node_groups/variables.tf
+++ b/modules/node_groups/variables.tf
@@ -35,7 +35,7 @@ variable "node_groups" {
   default     = {}
 }
 
-variable "node_group_timeouts" {
+variable "node_groups_timeouts" {
   description = "A map of timeouts for create/update/delete operations."
   type        = map(string)
 }

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -7,6 +7,7 @@ module "node_groups" {
   tags                   = var.tags
   node_groups_defaults   = var.node_groups_defaults
   node_groups            = var.node_groups
+  node_group_timeouts    = var.node_group_timeouts
 
   # Hack to ensure ordering of resource creation.
   # This is a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -7,7 +7,7 @@ module "node_groups" {
   tags                   = var.tags
   node_groups_defaults   = var.node_groups_defaults
   node_groups            = var.node_groups
-  node_groups_timeouts    = var.node_groups_timeouts
+  node_groups_timeouts   = var.node_groups_timeouts
 
   # Hack to ensure ordering of resource creation.
   # This is a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -7,7 +7,7 @@ module "node_groups" {
   tags                   = var.tags
   node_groups_defaults   = var.node_groups_defaults
   node_groups            = var.node_groups
-  node_group_timeouts    = var.node_group_timeouts
+  node_groups_timeouts    = var.node_groups_timeouts
 
   # Hack to ensure ordering of resource creation.
   # This is a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2

--- a/variables.tf
+++ b/variables.tf
@@ -331,6 +331,12 @@ variable "node_groups" {
   default     = {}
 }
 
+variable "node_group_timeouts" {
+  description = "A map of timeouts for create/update/delete operations."
+  type        = map(string)
+  default     = {}
+}
+
 variable "enable_irsa" {
   description = "Whether to create OpenID Connect Provider for EKS to enable IRSA"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -331,7 +331,7 @@ variable "node_groups" {
   default     = {}
 }
 
-variable "node_group_timeouts" {
+variable "node_groups_timeouts" {
   description = "A map of timeouts for create/update/delete operations."
   type        = map(string)
   default     = {}


### PR DESCRIPTION
# PR o'clock

## Description

Allows configuration of timeouts for create/update/delete on the aws_eks_node_group resource.

Relevant issue: #1131

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
