### PR TITLE
fix: Add load_balancers to lifecycle of Workers ASG

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -155,7 +155,7 @@ resource "aws_autoscaling_group" "workers" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [desired_capacity]
+    ignore_changes        = [desired_capacity, load_balancers]
   }
 }
 

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -231,7 +231,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [desired_capacity]
+    ignore_changes        = [desired_capacity, load_balancers]
   }
 }
 


### PR DESCRIPTION
# PR o'clock
2021.02.05

## Description

This module doesn't allow to connect ELB to Workers ASG's. In order to do it, one must use `aws_autoscaling_attachment` in his own code. Unfortunately latest changes in AWS provider and TF 0.14 have an issue with that (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment):
```
NOTE on Auto Scaling Groups and ASG Attachments:

Terraform currently provides both a standalone aws_autoscaling_attachment resource (describing an ASG attached to an ELB or ALB), and an aws_autoscaling_group with load_balancers and target_group_arns defined in-line. These two methods are not mutually-exclusive. If aws_autoscaling_attachment resources are used, either alone or with inline load_balancers or target_group_arns, the aws_autoscaling_group resource must be configured to ignore changes to the load_balancers and target_group_arns arguments within a lifecycle configuration block.
``` 

So in order to use `aws_autoscaling_attachment` we need to add `load_balancers` to Worker groups ASG's `lifecycle`, thus removing add-remove cycle. 

This change doesn't affect any other behavior as this module doesn't work with ELB's.

### Checklist

- [X] CI tests are passing
- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
