### PR TITLE
improvement: use Fargate profile name as for_each index for aws_eks_fargate_profile

### DIFF
--- a/modules/fargate/locals.tf
+++ b/modules/fargate/locals.tf
@@ -3,7 +3,7 @@ locals {
   pod_execution_role_arn  = var.create_fargate_pod_execution_role ? element(concat(aws_iam_role.eks_fargate_pod.*.arn, list("")), 0) : element(concat(data.aws_iam_role.custom_fargate_iam_role.*.arn, list("")), 0)
   pod_execution_role_name = var.create_fargate_pod_execution_role ? element(concat(aws_iam_role.eks_fargate_pod.*.name, list("")), 0) : element(concat(data.aws_iam_role.custom_fargate_iam_role.*.name, list("")), 0)
 
-  fargate_profiles_expanded = { for k, v in var.fargate_profiles : k => merge(
+  fargate_profiles_expanded = { for v in var.fargate_profiles : lookup(v, "name") => merge(
     v,
     { tags = merge(var.tags, lookup(v, "tags", {})) },
   ) if var.create_eks }


### PR DESCRIPTION
# PR o'clock

## Description

We made the experience that adding and/or removing Fargate profiles regenerates all profiles that belong to the cluster. That drives in a maintenance problem, as all pods will be shut down when a related profile will be re-created.

To keep the Fargate profiles a bit more maintainable (when removing or/and adding a profile) the key of the `set`  `fargate_profiles_expanded` is now the name of the profile. The profile name needs to be always unique (constraint by AWS).

Note: That's a breaking change, as all created Fargate profiles by this module need to be re-created with the new index.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
