### PR TITLE
fix: update supported tf version to have < 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.9, != 0.13.0 |
+| terraform | >= 0.12.9, != 0.13.0, < 0.14.0 |
 | aws | >= 3.22.0 |
 | kubernetes | >= 1.11.1 |
 | local | >= 1.4 |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.9, != 0.13.0"
+  required_version = ">= 0.12.9, != 0.13.0, < 0.14.0"
 
   required_providers {
     aws        = ">= 3.22.0"


### PR DESCRIPTION
modules fails to destroy EKS cluster in 0.14.5 because destroys don't refresh.

# PR o'clock

## Description

> In terraform 0.14+ destroy command no loner refreshes the state of resources before generating execution plan (like it did in 0.13.X). terraform apply still does the refresh, that's why this issue is more frequent the more time elapses after applying.

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1162#issuecomment-767700530

As a result, the module will fail to destroy all of the resources it manages.

I should say that there is a workaround in 0.14.5. The user will be required to run `terraform refresh` then `terraform destroy`.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
