### PR TITLE
fix: ManagedNodeGroups using LaunchTemplate and while specifying Disk Size

### DIFF
--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -14,7 +14,7 @@ resource "aws_eks_node_group" "workers" {
   }
 
   ami_type        = lookup(each.value, "ami_type", null)
-  disk_size       = lookup(each.value, "disk_size", null)
+  disk_size       = each.value["launch_template_id"] != null ? null : lookup(each.value, "disk_size", null)
   instance_types  = lookup(each.value, "instance_types", null)
   release_version = lookup(each.value, "ami_release_version", null)
   capacity_type   = lookup(each.value, "capacity_type", null)


### PR DESCRIPTION
If using Managed Node Groups with a Launch Template, the disk size MUST be specified in the Launch Template and not in the Managed Node Group definition otherwise AWS API produces an error that Disk Size is specified

# PR o'clock

## Description

If the `launch_template_id` is specified, specify null for disk size in managed node group resource

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
