### PR TITLE
feat: Launch Template ASGs pin to created version

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -76,7 +76,7 @@ locals {
     root_block_device_name               = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
     root_kms_key_id                      = ""                                       # The KMS key to use when encrypting the root storage device
     launch_template_id                   = null                                     # The id of the launch template used for managed node_groups
-    launch_template_version              = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
+    launch_template_version              = "$Created"                               # The created version of the launch template to use in the autoscaling group
     launch_template_placement_tenancy    = "default"                                # The placement tenancy for instances
     launch_template_placement_group      = null                                     # The name of the placement group into which to launch the instances, if any.
     root_encrypted                       = false                                    # Whether the volume should be encrypted or not

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -142,6 +142,8 @@ resource "aws_autoscaling_group" "workers_launch_template" {
           version = lookup(
             var.worker_groups_launch_template[count.index],
             "launch_template_version",
+            local.workers_group_defaults["launch_template_version"] == "$Created" ?
+            aws_launch_template.workers_launch_template.*.latest_version[count.index] :
             local.workers_group_defaults["launch_template_version"],
           )
         }
@@ -171,6 +173,8 @@ resource "aws_autoscaling_group" "workers_launch_template" {
       version = lookup(
         var.worker_groups_launch_template[count.index],
         "launch_template_version",
+        local.workers_group_defaults["launch_template_version"] == "$Created" ?
+        aws_launch_template.workers_launch_template.*.latest_version[count.index] :
         local.workers_group_defaults["launch_template_version"],
       )
     }


### PR DESCRIPTION
# PR o'clock

## Description

When creating worker node groups with Launch Templates, the created ASGs currently use $Latest as the version of the Launch Template to start nodes with. When `asg_recreate_on_change` is false, that's expected, but when `asg_recreate_on_change` is true, this means that as soon as a new Launch Template is created the old ASGs will start using the new launch template.

This changes the logic to support a `$Created` value, which would then reference the version created in Terraform. When `asg_recreate_on_change` is false, the ASG still points to the latest (as soon as Terraform gets to it). When `asg_recreate_on_change` is true, the older ASGs (when using `asg_recreate_on_change` would still reference the older LT version, and so compute capacity won't be lost should the new LT have problems spinning up nodes.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
