### PR TITLE
improvement: count to for_each

### DIFF
--- a/aws_auth.tf
+++ b/aws_auth.tf
@@ -2,38 +2,24 @@ data "aws_caller_identity" "current" {}
 
 locals {
   auth_launch_template_worker_roles = [
-    for index in range(0, var.create_eks ? local.worker_group_launch_template_count : 0) : {
-      worker_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
-        coalescelist(
-          aws_iam_instance_profile.workers_launch_template.*.role,
-          data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile.*.role_name,
-          [""]
-        ),
-        index
-      )}"
-      platform = lookup(
-        var.worker_groups_launch_template[index],
-        "platform",
-        local.workers_group_defaults["platform"]
-      )
+    for key, worker_group in(var.create_eks ? local.worker_groups_launch_template_with_defaults : {}) : {
+      worker_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${
+        var.manage_worker_iam_resources ?
+        aws_iam_instance_profile.workers_launch_template[key].role :
+        data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile[key].role_name
+      }"
+      platform = worker_group.platform
     }
   ]
 
   auth_worker_roles = [
-    for index in range(0, var.create_eks ? local.worker_group_count : 0) : {
-      worker_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${element(
-        coalescelist(
-          aws_iam_instance_profile.workers.*.role,
-          data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile.*.role_name,
-          [""]
-        ),
-        index,
-      )}"
-      platform = lookup(
-        var.worker_groups[index],
-        "platform",
-        local.workers_group_defaults["platform"]
-      )
+    for key, worker_group in(var.create_eks ? local.worker_groups_with_defaults : {}) : {
+      worker_role_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${
+        var.manage_worker_iam_resources ?
+        aws_iam_instance_profile.workers[key].role :
+        data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile[key].role_name
+      }"
+      platform = worker_group.platform
     }
   ]
 

--- a/local.tf
+++ b/local.tf
@@ -26,52 +26,52 @@ locals {
 
   policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   workers_group_defaults_defaults = {
-    name                          = "count.index"               # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
-    tags                          = []                          # A list of map defining extra tags to be applied to the worker group autoscaling group.
-    ami_id                        = ""                          # AMI ID for the eks linux based workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
-    ami_id_windows                = ""                          # AMI ID for the eks windows based workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
-    asg_desired_capacity          = "1"                         # Desired worker capacity in the autoscaling group and changing its value will not affect the autoscaling group's desired capacity because the cluster-autoscaler manages up and down scaling of the nodes. Cluster-autoscaler add nodes when pods are in pending state and remove the nodes when they are not required by modifying the desirec_capacity of the autoscaling group. Although an issue exists in which if the value of the asg_min_size is changed it modifies the value of asg_desired_capacity.
-    asg_max_size                  = "3"                         # Maximum worker capacity in the autoscaling group.
-    asg_min_size                  = "1"                         # Minimum worker capacity in the autoscaling group. NOTE: Change in this paramater will affect the asg_desired_capacity, like changing its value to 2 will change asg_desired_capacity value to 2 but bringing back it to 1 will not affect the asg_desired_capacity.
-    asg_force_delete              = false                       # Enable forced deletion for the autoscaling group.
-    asg_initial_lifecycle_hooks   = []                          # Initital lifecycle hook for the autoscaling group.
-    asg_recreate_on_change        = false                       # Recreate the autoscaling group when the Launch Template or Launch Configuration change.
-    default_cooldown              = null                        # The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
-    health_check_type             = null                        # Controls how health checking is done. Valid values are "EC2" or "ELB".
-    health_check_grace_period     = null                        # Time in seconds after instance comes into service before checking health.
-    instance_type                 = "m4.large"                  # Size of the workers instances.
-    spot_price                    = ""                          # Cost of spot instance.
-    placement_tenancy             = ""                          # The tenancy of the instance. Valid values are "default" or "dedicated".
-    root_volume_size              = "100"                       # root volume size of workers instances.
-    root_volume_type              = "gp2"                       # root volume type of workers instances, can be 'standard', 'gp3' (for Launch Template), 'gp2', or 'io1'
-    root_iops                     = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
-    root_volume_throughput        = null                        # The amount of throughput to provision for a gp3 volume.
-    key_name                      = ""                          # The key pair name that should be used for the instances in the autoscaling group
-    pre_userdata                  = ""                          # userdata to pre-append to the default userdata.
-    userdata_template_file        = ""                          # alternate template to use for userdata
-    userdata_template_extra_args  = {}                          # Additional arguments to use when expanding the userdata template file
-    bootstrap_extra_args          = ""                          # Extra arguments passed to the bootstrap.sh script from the EKS AMI (Amazon Machine Image).
-    additional_userdata           = ""                          # userdata to append to the default userdata.
-    ebs_optimized                 = true                        # sets whether to use ebs optimization on supported types.
-    enable_monitoring             = true                        # Enables/disables detailed monitoring.
-    enclave_support               = false                       # Enables/disables enclave support
-    public_ip                     = false                       # Associate a public ip address with a worker
-    kubelet_extra_args            = ""                          # This string is passed directly to kubelet if set. Useful for adding labels or taints.
-    subnets                       = var.subnets                 # A list of subnets to place the worker nodes in. i.e. ["subnet-123", "subnet-456", "subnet-789"]
-    additional_security_group_ids = []                          # A list of additional security group ids to include in worker launch config
-    protect_from_scale_in         = false                       # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
-    iam_instance_profile_name     = ""                          # A custom IAM instance profile name. Used when manage_worker_iam_resources is set to false. Incompatible with iam_role_id.
-    iam_role_id                   = "local.default_iam_role_id" # A custom IAM role id. Incompatible with iam_instance_profile_name.  Literal local.default_iam_role_id will never be used but if iam_role_id is not set, the local.default_iam_role_id interpolation will be used.
-    suspended_processes           = ["AZRebalance"]             # A list of processes to suspend. i.e. ["AZRebalance", "HealthCheck", "ReplaceUnhealthy"]
-    target_group_arns             = null                        # A list of Application LoadBalancer (ALB) target group ARNs to be associated to the autoscaling group
-    load_balancers                = null                        # A list of Classic LoadBalancer (CLB)'s name to be associated to the autoscaling group
-    enabled_metrics               = []                          # A list of metrics to be collected i.e. ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity"]
-    placement_group               = null                        # The name of the placement group into which to launch the instances, if any.
-    service_linked_role_arn       = ""                          # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
-    termination_policies          = []                          # A list of policies to decide how the instances in the auto scale group should be terminated.
-    platform                      = "linux"                     # Platform of workers. either "linux" or "windows"
-    additional_ebs_volumes        = []                          # A list of additional volumes to be attached to the instances on this Auto Scaling group. Each volume should be an object with the following: block_device_name (required), volume_size, volume_type, iops, encrypted, kms_key_id (only on launch-template), delete_on_termination. Optional values are grabbed from root volume or from defaults
-    warm_pool                     = null                        # If this block is configured, add a Warm Pool to the specified Auto Scaling group.
+    name                          = "count.index"             # Name of the worker group. Literal count.index will never be used but if name is not set, the count.index interpolation will be used.
+    tags                          = []                        # A list of map defining extra tags to be applied to the worker group autoscaling group.
+    ami_id                        = ""                        # AMI ID for the eks linux based workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
+    ami_id_windows                = ""                        # AMI ID for the eks windows based workers. If none is provided, Terraform will search for the latest version of their EKS optimized worker AMI based on platform.
+    asg_desired_capacity          = "1"                       # Desired worker capacity in the autoscaling group and changing its value will not affect the autoscaling group's desired capacity because the cluster-autoscaler manages up and down scaling of the nodes. Cluster-autoscaler add nodes when pods are in pending state and remove the nodes when they are not required by modifying the desirec_capacity of the autoscaling group. Although an issue exists in which if the value of the asg_min_size is changed it modifies the value of asg_desired_capacity.
+    asg_max_size                  = "3"                       # Maximum worker capacity in the autoscaling group.
+    asg_min_size                  = "1"                       # Minimum worker capacity in the autoscaling group. NOTE: Change in this paramater will affect the asg_desired_capacity, like changing its value to 2 will change asg_desired_capacity value to 2 but bringing back it to 1 will not affect the asg_desired_capacity.
+    asg_force_delete              = false                     # Enable forced deletion for the autoscaling group.
+    asg_initial_lifecycle_hooks   = []                        # Initital lifecycle hook for the autoscaling group.
+    asg_recreate_on_change        = false                     # Recreate the autoscaling group when the Launch Template or Launch Configuration change.
+    default_cooldown              = null                      # The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
+    health_check_type             = null                      # Controls how health checking is done. Valid values are "EC2" or "ELB".
+    health_check_grace_period     = null                      # Time in seconds after instance comes into service before checking health.
+    instance_type                 = "m4.large"                # Size of the workers instances.
+    spot_price                    = ""                        # Cost of spot instance.
+    placement_tenancy             = ""                        # The tenancy of the instance. Valid values are "default" or "dedicated".
+    root_volume_size              = "100"                     # root volume size of workers instances.
+    root_volume_type              = "gp2"                     # root volume type of workers instances, can be 'standard', 'gp3' (for Launch Template), 'gp2', or 'io1'
+    root_iops                     = "0"                       # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
+    root_volume_throughput        = null                      # The amount of throughput to provision for a gp3 volume.
+    key_name                      = ""                        # The key pair name that should be used for the instances in the autoscaling group
+    pre_userdata                  = ""                        # userdata to pre-append to the default userdata.
+    userdata_template_file        = ""                        # alternate template to use for userdata
+    userdata_template_extra_args  = {}                        # Additional arguments to use when expanding the userdata template file
+    bootstrap_extra_args          = ""                        # Extra arguments passed to the bootstrap.sh script from the EKS AMI (Amazon Machine Image).
+    additional_userdata           = ""                        # userdata to append to the default userdata.
+    ebs_optimized                 = true                      # sets whether to use ebs optimization on supported types.
+    enable_monitoring             = true                      # Enables/disables detailed monitoring.
+    enclave_support               = false                     # Enables/disables enclave support
+    public_ip                     = false                     # Associate a public ip address with a worker
+    kubelet_extra_args            = ""                        # This string is passed directly to kubelet if set. Useful for adding labels or taints.
+    subnets                       = var.subnets               # A list of subnets to place the worker nodes in. i.e. ["subnet-123", "subnet-456", "subnet-789"]
+    additional_security_group_ids = []                        # A list of additional security group ids to include in worker launch config
+    protect_from_scale_in         = false                     # Prevent AWS from scaling in, so that cluster-autoscaler is solely responsible.
+    iam_instance_profile_name     = ""                        # A custom IAM instance profile name. Used when manage_worker_iam_resources is set to false. Incompatible with iam_role_id.
+    iam_role_id                   = local.default_iam_role_id # A custom IAM role id. Incompatible with iam_instance_profile_name.  Literal local.default_iam_role_id will never be used but if iam_role_id is not set, the local.default_iam_role_id interpolation will be used.
+    suspended_processes           = ["AZRebalance"]           # A list of processes to suspend. i.e. ["AZRebalance", "HealthCheck", "ReplaceUnhealthy"]
+    target_group_arns             = null                      # A list of Application LoadBalancer (ALB) target group ARNs to be associated to the autoscaling group
+    load_balancers                = null                      # A list of Classic LoadBalancer (CLB)'s name to be associated to the autoscaling group
+    enabled_metrics               = []                        # A list of metrics to be collected i.e. ["GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity"]
+    placement_group               = null                      # The name of the placement group into which to launch the instances, if any.
+    service_linked_role_arn       = ""                        # Arn of custom service linked role that Auto Scaling group will use. Useful when you have encrypted EBS
+    termination_policies          = []                        # A list of policies to decide how the instances in the auto scale group should be terminated.
+    platform                      = "linux"                   # Platform of workers. either "linux" or "windows"
+    additional_ebs_volumes        = []                        # A list of additional volumes to be attached to the instances on this Auto Scaling group. Each volume should be an object with the following: block_device_name (required), volume_size, volume_type, iops, encrypted, kms_key_id (only on launch-template), delete_on_termination. Optional values are grabbed from root volume or from defaults
+    warm_pool                     = null                      # If this block is configured, add a Warm Pool to the specified Auto Scaling group.
     # Settings for launch templates
     root_block_device_name               = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
     root_kms_key_id                      = ""                                       # The KMS key to use when encrypting the root storage device
@@ -102,6 +102,64 @@ locals {
     local.workers_group_defaults_defaults,
     var.workers_group_defaults,
   )
+
+  volume_defaults = {
+    volume_size           = local.workers_group_defaults.root_volume_size       # root volume size of workers instances.
+    volume_type           = local.workers_group_defaults.root_volume_type       # root volume type of workers instances, can be 'standard', 'gp2', or 'io1'
+    iops                  = local.workers_group_defaults.root_iops              # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
+    volume_throughput     = local.workers_group_defaults.root_volume_throughput # The amount of throughput to provision for a gp3 volume.
+    block_device_name     = local.workers_group_defaults.root_block_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
+    encrypted             = local.workers_group_defaults.root_encrypted         # Whether the volume should be encrypted or not
+    kms_key_id            = local.workers_group_defaults.root_kms_key_id        # The KMS key to use when encrypting the root storage device
+    delete_on_termination = true
+  }
+
+  worker_groups_launch_template_with_defaults = {
+    for key, template in var.worker_groups_launch_template : lookup(template, "name", key) => merge(
+      local.workers_group_defaults,
+      { name = key },
+      merge(
+        template,
+        {
+          additional_ebs_volumes = [
+            for volume_definition in lookup(template, "additional_ebs_volumes", []) : merge(
+              local.volume_defaults,
+              volume_definition
+            )
+          ]
+        }
+      )
+    )
+  }
+
+  worker_groups_with_defaults = {
+    for key, group in var.worker_groups : lookup(group, "name", key) => merge(
+      local.workers_group_defaults,
+      { name = key },
+      merge(
+        group,
+        {
+          additional_ebs_volumes = [
+            for volume_definition in lookup(group, "additional_ebs_volumes", []) : merge(
+              local.volume_defaults,
+              volume_definition
+            )
+          ]
+        }
+      )
+    )
+  }
+
+  # These sorted arrays are used in outputs to keep the original input order intact
+  sorted_aws_autoscaling_group_workers                                                          = var.create_eks ? [for g in var.worker_groups : aws_autoscaling_group.workers[g.name]] : []
+  sorted_aws_autoscaling_group_workers_launch_templates                                         = var.create_eks ? [for g in var.worker_groups_launch_template : aws_autoscaling_group.workers_launch_template[g.name]] : []
+  sorted_data_template_file_userdata                                                            = var.create_eks ? [for g in var.worker_groups : data.template_file.userdata[g.name]] : []
+  sorted_data_template_file_launch_template_userdata                                            = var.create_eks ? [for g in var.worker_groups_launch_template : data.template_file.launch_template_userdata[g.name]] : []
+  sorted_aws_launch_template_workers_launch_template                                            = var.create_eks ? [for g in var.worker_groups_launch_template : aws_launch_template.workers_launch_template[g.name]] : []
+  sorted_aws_iam_instance_profile_workers                                                       = var.manage_worker_iam_resources && var.create_eks ? [for g in var.worker_groups : aws_iam_instance_profile.workers[g.name]] : []
+  sorted_aws_iam_instance_profile_workers_launch_template                                       = var.manage_worker_iam_resources && var.create_eks ? [for g in var.worker_groups_launch_template : aws_iam_instance_profile.workers_launch_template[g.name]] : []
+  sorted_data_aws_iam_instance_profile_custom_worker_group_iam_instance_profile                 = var.manage_worker_iam_resources ? [] : [for g in var.worker_groups : data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile[g.name]]
+  sorted_data_aws_iam_instance_profile_custom_worker_group_launch_template_iam_instance_profile = var.manage_worker_iam_resources ? [] : [for g in var.worker_groups_launch_template : data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile[g.name]]
 
   ebs_optimized_not_supported = [
     "c1.medium",

--- a/workers.tf
+++ b/workers.tf
@@ -1,106 +1,40 @@
 # Worker Groups using Launch Configurations
 
 resource "aws_autoscaling_group" "workers" {
-  count = var.create_eks ? local.worker_group_count : 0
+  for_each = var.create_eks ? local.worker_groups_with_defaults : {}
   name_prefix = join(
     "-",
     compact(
       [
         coalescelist(aws_eks_cluster.this[*].name, [""])[0],
-        lookup(var.worker_groups[count.index], "name", count.index),
-        lookup(var.worker_groups[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers[count.index].id : ""
+        each.value.name,
+        each.value.asg_recreate_on_change ? random_pet.workers[each.key].id : ""
       ]
     )
   )
-  desired_capacity = lookup(
-    var.worker_groups[count.index],
-    "asg_desired_capacity",
-    local.workers_group_defaults["asg_desired_capacity"],
-  )
-  max_size = lookup(
-    var.worker_groups[count.index],
-    "asg_max_size",
-    local.workers_group_defaults["asg_max_size"],
-  )
-  min_size = lookup(
-    var.worker_groups[count.index],
-    "asg_min_size",
-    local.workers_group_defaults["asg_min_size"],
-  )
-  force_delete = lookup(
-    var.worker_groups[count.index],
-    "asg_force_delete",
-    local.workers_group_defaults["asg_force_delete"],
-  )
-  target_group_arns = lookup(
-    var.worker_groups[count.index],
-    "target_group_arns",
-    local.workers_group_defaults["target_group_arns"]
-  )
-  load_balancers = lookup(
-    var.worker_groups[count.index],
-    "load_balancers",
-    local.workers_group_defaults["load_balancers"]
-  )
-  service_linked_role_arn = lookup(
-    var.worker_groups[count.index],
-    "service_linked_role_arn",
-    local.workers_group_defaults["service_linked_role_arn"],
-  )
-  launch_configuration = aws_launch_configuration.workers.*.id[count.index]
-  vpc_zone_identifier = lookup(
-    var.worker_groups[count.index],
-    "subnets",
-    local.workers_group_defaults["subnets"]
-  )
-  protect_from_scale_in = lookup(
-    var.worker_groups[count.index],
-    "protect_from_scale_in",
-    local.workers_group_defaults["protect_from_scale_in"],
-  )
-  suspended_processes = lookup(
-    var.worker_groups[count.index],
-    "suspended_processes",
-    local.workers_group_defaults["suspended_processes"]
-  )
-  enabled_metrics = lookup(
-    var.worker_groups[count.index],
-    "enabled_metrics",
-    local.workers_group_defaults["enabled_metrics"]
-  )
-  placement_group = lookup(
-    var.worker_groups[count.index],
-    "placement_group",
-    local.workers_group_defaults["placement_group"],
-  )
-  termination_policies = lookup(
-    var.worker_groups[count.index],
-    "termination_policies",
-    local.workers_group_defaults["termination_policies"]
-  )
-  max_instance_lifetime = lookup(
-    var.worker_groups[count.index],
-    "max_instance_lifetime",
-    local.workers_group_defaults["max_instance_lifetime"],
-  )
-  default_cooldown = lookup(
-    var.worker_groups[count.index],
-    "default_cooldown",
-    local.workers_group_defaults["default_cooldown"]
-  )
-  health_check_type = lookup(
-    var.worker_groups[count.index],
-    "health_check_type",
-    local.workers_group_defaults["health_check_type"]
-  )
-  health_check_grace_period = lookup(
-    var.worker_groups[count.index],
-    "health_check_grace_period",
-    local.workers_group_defaults["health_check_grace_period"]
-  )
+
+  desired_capacity          = each.value.asg_desired_capacity
+  max_size                  = each.value.asg_max_size
+  min_size                  = each.value.asg_min_size
+  force_delete              = each.value.asg_force_delete
+  target_group_arns         = each.value.target_group_arns
+  load_balancers            = each.value.load_balancers
+  service_linked_role_arn   = each.value.service_linked_role_arn
+  launch_configuration      = aws_launch_configuration.workers[each.key].id
+  vpc_zone_identifier       = each.value.subnets
+  protect_from_scale_in     = each.value.protect_from_scale_in
+  suspended_processes       = each.value.suspended_processes
+  enabled_metrics           = each.value.enabled_metrics
+  placement_group           = each.value.placement_group
+  termination_policies      = each.value.termination_policies
+  max_instance_lifetime     = each.value.max_instance_lifetime
+  default_cooldown          = each.value.default_cooldown
+  health_check_type         = each.value.health_check_type
+  health_check_grace_period = each.value.health_check_grace_period
 
   dynamic "initial_lifecycle_hook" {
-    for_each = var.worker_create_initial_lifecycle_hooks ? lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
+    for_each = var.worker_create_initial_lifecycle_hooks ? each.value.asg_initial_lifecycle_hooks : []
+
     content {
       name                    = initial_lifecycle_hook.value["name"]
       lifecycle_transition    = initial_lifecycle_hook.value["lifecycle_transition"]
@@ -113,7 +47,7 @@ resource "aws_autoscaling_group" "workers" {
   }
 
   dynamic "warm_pool" {
-    for_each = lookup(var.worker_groups[count.index], "warm_pool", null) != null ? [lookup(var.worker_groups[count.index], "warm_pool")] : []
+    for_each = lookup(each.value, "warm_pool", null) != null ? [lookup(each.value, "warm_pool")] : []
 
     content {
       pool_state                  = lookup(warm_pool.value, "pool_state", null)
@@ -127,7 +61,7 @@ resource "aws_autoscaling_group" "workers" {
       [
         {
           "key"                 = "Name"
-          "value"               = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(var.worker_groups[count.index], "name", count.index)}-eks_asg"
+          "value"               = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${each.value.name}-eks_asg"
           "propagate_at_launch" = true
         },
         {
@@ -143,18 +77,14 @@ resource "aws_autoscaling_group" "workers" {
       ],
       [
         for tag_key, tag_value in var.tags :
-        {
-          "key"                 = tag_key,
-          "value"               = tag_value,
-          "propagate_at_launch" = "true"
-        }
-        if tag_key != "Name" && !contains([for tag in lookup(var.worker_groups[count.index], "tags", local.workers_group_defaults["tags"]) : tag["key"]], tag_key)
+        tomap({
+          key                 = tag_key
+          value               = tag_value
+          propagate_at_launch = "true"
+        })
+        if tag_key != "Name" && !contains([for tag in each.value.tags : tag["key"]], tag_key)
       ],
-      lookup(
-        var.worker_groups[count.index],
-        "tags",
-        local.workers_group_defaults["tags"]
-      )
+      each.value.tags
     )
     content {
       key                 = tag.value.key
@@ -170,138 +100,66 @@ resource "aws_autoscaling_group" "workers" {
 }
 
 resource "aws_launch_configuration" "workers" {
-  count       = var.create_eks ? local.worker_group_count : 0
-  name_prefix = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(var.worker_groups[count.index], "name", count.index)}"
-  associate_public_ip_address = lookup(
-    var.worker_groups[count.index],
-    "public_ip",
-    local.workers_group_defaults["public_ip"],
-  )
+  for_each                    = var.create_eks ? local.worker_groups_with_defaults : {}
+  name_prefix                 = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${each.value.name}"
+  associate_public_ip_address = each.value.public_ip
   security_groups = flatten([
     local.worker_security_group_id,
     var.worker_additional_security_group_ids,
-    lookup(
-      var.worker_groups[count.index],
-      "additional_security_group_ids",
-      local.workers_group_defaults["additional_security_group_ids"]
-    )
+    each.value.additional_security_group_ids
   ])
-  iam_instance_profile = coalescelist(
-    aws_iam_instance_profile.workers.*.id,
-    data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile.*.name,
-  )[count.index]
+  iam_instance_profile = coalesce(
+    aws_iam_instance_profile.workers[each.key].id,
+    lookup(
+      data.aws_iam_instance_profile.custom_worker_group_iam_instance_profile,
+      each.key,
+      { name = "" }
+    ).name
+  )
   image_id = lookup(
-    var.worker_groups[count.index],
+    each.value,
     "ami_id",
-    lookup(var.worker_groups[count.index], "platform", local.workers_group_defaults["platform"]) == "windows" ? local.default_ami_id_windows : local.default_ami_id_linux,
+    each.value.platform == "windows" ? local.default_ami_id_windows : local.default_ami_id_linux,
   )
-  instance_type = lookup(
-    var.worker_groups[count.index],
-    "instance_type",
-    local.workers_group_defaults["instance_type"],
-  )
-  key_name = lookup(
-    var.worker_groups[count.index],
-    "key_name",
-    local.workers_group_defaults["key_name"],
-  )
-  user_data_base64 = base64encode(data.template_file.userdata.*.rendered[count.index])
+  instance_type    = each.value.instance_type
+  key_name         = each.value.key_name
+  user_data_base64 = base64encode(data.template_file.userdata[each.key].rendered)
   ebs_optimized = lookup(
-    var.worker_groups[count.index],
+    each.value,
     "ebs_optimized",
     !contains(
       local.ebs_optimized_not_supported,
-      lookup(
-        var.worker_groups[count.index],
-        "instance_type",
-        local.workers_group_defaults["instance_type"]
-      )
+      each.value.instance_type
     )
   )
-  enable_monitoring = lookup(
-    var.worker_groups[count.index],
-    "enable_monitoring",
-    local.workers_group_defaults["enable_monitoring"],
-  )
-  spot_price = lookup(
-    var.worker_groups[count.index],
-    "spot_price",
-    local.workers_group_defaults["spot_price"],
-  )
-  placement_tenancy = lookup(
-    var.worker_groups[count.index],
-    "placement_tenancy",
-    local.workers_group_defaults["placement_tenancy"],
-  )
+  enable_monitoring = each.value.enable_monitoring
+  spot_price        = each.value.spot_price
+  placement_tenancy = each.value.placement_tenancy
 
   metadata_options {
-    http_endpoint = lookup(
-      var.worker_groups[count.index],
-      "metadata_http_endpoint",
-      local.workers_group_defaults["metadata_http_endpoint"],
-    )
-    http_tokens = lookup(
-      var.worker_groups[count.index],
-      "metadata_http_tokens",
-      local.workers_group_defaults["metadata_http_tokens"],
-    )
-    http_put_response_hop_limit = lookup(
-      var.worker_groups[count.index],
-      "metadata_http_put_response_hop_limit",
-      local.workers_group_defaults["metadata_http_put_response_hop_limit"],
-    )
+    http_endpoint               = each.value.metadata_http_endpoint
+    http_tokens                 = each.value.metadata_http_tokens
+    http_put_response_hop_limit = each.value.metadata_http_put_response_hop_limit
   }
 
   root_block_device {
-    encrypted = lookup(
-      var.worker_groups[count.index],
-      "root_encrypted",
-      local.workers_group_defaults["root_encrypted"],
-    )
-    volume_size = lookup(
-      var.worker_groups[count.index],
-      "root_volume_size",
-      local.workers_group_defaults["root_volume_size"],
-    )
-    volume_type = lookup(
-      var.worker_groups[count.index],
-      "root_volume_type",
-      local.workers_group_defaults["root_volume_type"],
-    )
-    iops = lookup(
-      var.worker_groups[count.index],
-      "root_iops",
-      local.workers_group_defaults["root_iops"],
-    )
+    encrypted             = each.value.root_encrypted
+    volume_size           = each.value.root_volume_size
+    volume_type           = each.value.root_volume_type
+    iops                  = each.value.root_iops
     delete_on_termination = true
   }
 
   dynamic "ebs_block_device" {
-    for_each = lookup(var.worker_groups[count.index], "additional_ebs_volumes", local.workers_group_defaults["additional_ebs_volumes"])
+    for_each = each.value.additional_ebs_volumes
 
     content {
-      device_name = ebs_block_device.value.block_device_name
-      volume_size = lookup(
-        ebs_block_device.value,
-        "volume_size",
-        local.workers_group_defaults["root_volume_size"],
-      )
-      volume_type = lookup(
-        ebs_block_device.value,
-        "volume_type",
-        local.workers_group_defaults["root_volume_type"],
-      )
-      iops = lookup(
-        ebs_block_device.value,
-        "iops",
-        local.workers_group_defaults["root_iops"],
-      )
-      encrypted = lookup(
-        ebs_block_device.value,
-        "encrypted",
-        local.workers_group_defaults["root_encrypted"],
-      )
-      delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", true)
+      device_name           = ebs_block_device.value.block_device_name
+      volume_size           = ebs_block_device.value.volume_size
+      volume_type           = ebs_block_device.value.volume_type
+      iops                  = ebs_block_device.value.iops
+      encrypted             = ebs_block_device.value.encrypted
+      delete_on_termination = ebs_block_device.value.delete_on_termination
     }
   }
 
@@ -327,13 +185,13 @@ resource "aws_launch_configuration" "workers" {
 }
 
 resource "random_pet" "workers" {
-  count = var.create_eks ? local.worker_group_count : 0
+  for_each = var.create_eks ? local.worker_groups_with_defaults : {}
 
   separator = "-"
   length    = 2
 
   keepers = {
-    lc_name = aws_launch_configuration.workers[count.index].name
+    lc_name = aws_launch_configuration.workers[each.key].name
   }
 
   lifecycle {
@@ -444,15 +302,10 @@ resource "aws_iam_role" "workers" {
 }
 
 resource "aws_iam_instance_profile" "workers" {
-  count       = var.manage_worker_iam_resources && var.create_eks ? local.worker_group_count : 0
-  name_prefix = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
-  role = lookup(
-    var.worker_groups[count.index],
-    "iam_role_id",
-    local.default_iam_role_id,
-  )
-
-  path = var.iam_path
+  for_each    = var.manage_worker_iam_resources && var.create_eks ? local.worker_groups_with_defaults : {}
+  name_prefix = aws_eks_cluster.this[0].name
+  role        = each.value.iam_role_id
+  path        = var.iam_path
 
   lifecycle {
     create_before_destroy = true

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -1,157 +1,58 @@
 # Worker Groups using Launch Templates
 
 resource "aws_autoscaling_group" "workers_launch_template" {
-  count = var.create_eks ? local.worker_group_launch_template_count : 0
+  for_each = var.create_eks ? local.worker_groups_launch_template_with_defaults : {}
+
   name_prefix = join(
     "-",
     compact(
       [
         coalescelist(aws_eks_cluster.this[*].name, [""])[0],
-        lookup(var.worker_groups_launch_template[count.index], "name", count.index),
-        lookup(var.worker_groups_launch_template[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers_launch_template[count.index].id : ""
+        each.value.name,
+        each.value.asg_recreate_on_change ? random_pet.workers_launch_template[each.key].id : ""
       ]
     )
   )
-  desired_capacity = lookup(
-    var.worker_groups_launch_template[count.index],
-    "asg_desired_capacity",
-    local.workers_group_defaults["asg_desired_capacity"],
-  )
-  max_size = lookup(
-    var.worker_groups_launch_template[count.index],
-    "asg_max_size",
-    local.workers_group_defaults["asg_max_size"],
-  )
-  min_size = lookup(
-    var.worker_groups_launch_template[count.index],
-    "asg_min_size",
-    local.workers_group_defaults["asg_min_size"],
-  )
-  force_delete = lookup(
-    var.worker_groups_launch_template[count.index],
-    "asg_force_delete",
-    local.workers_group_defaults["asg_force_delete"],
-  )
-  target_group_arns = lookup(
-    var.worker_groups_launch_template[count.index],
-    "target_group_arns",
-    local.workers_group_defaults["target_group_arns"]
-  )
-  load_balancers = lookup(
-    var.worker_groups_launch_template[count.index],
-    "load_balancers",
-    local.workers_group_defaults["load_balancers"]
-  )
-  service_linked_role_arn = lookup(
-    var.worker_groups_launch_template[count.index],
-    "service_linked_role_arn",
-    local.workers_group_defaults["service_linked_role_arn"],
-  )
-  vpc_zone_identifier = lookup(
-    var.worker_groups_launch_template[count.index],
-    "subnets",
-    local.workers_group_defaults["subnets"]
-  )
-  protect_from_scale_in = lookup(
-    var.worker_groups_launch_template[count.index],
-    "protect_from_scale_in",
-    local.workers_group_defaults["protect_from_scale_in"],
-  )
-  suspended_processes = lookup(
-    var.worker_groups_launch_template[count.index],
-    "suspended_processes",
-    local.workers_group_defaults["suspended_processes"]
-  )
-  enabled_metrics = lookup(
-    var.worker_groups_launch_template[count.index],
-    "enabled_metrics",
-    local.workers_group_defaults["enabled_metrics"]
-  )
-  placement_group = lookup(
-    var.worker_groups_launch_template[count.index],
-    "placement_group",
-    local.workers_group_defaults["placement_group"],
-  )
-  termination_policies = lookup(
-    var.worker_groups_launch_template[count.index],
-    "termination_policies",
-    local.workers_group_defaults["termination_policies"]
-  )
-  max_instance_lifetime = lookup(
-    var.worker_groups_launch_template[count.index],
-    "max_instance_lifetime",
-    local.workers_group_defaults["max_instance_lifetime"],
-  )
-  default_cooldown = lookup(
-    var.worker_groups_launch_template[count.index],
-    "default_cooldown",
-    local.workers_group_defaults["default_cooldown"]
-  )
-  health_check_type = lookup(
-    var.worker_groups_launch_template[count.index],
-    "health_check_type",
-    local.workers_group_defaults["health_check_type"]
-  )
-  health_check_grace_period = lookup(
-    var.worker_groups_launch_template[count.index],
-    "health_check_grace_period",
-    local.workers_group_defaults["health_check_grace_period"]
-  )
+  desired_capacity          = each.value.asg_desired_capacity
+  max_size                  = each.value.asg_max_size
+  min_size                  = each.value.asg_min_size
+  force_delete              = each.value.asg_force_delete
+  target_group_arns         = each.value.target_group_arns
+  load_balancers            = each.value.load_balancers
+  service_linked_role_arn   = each.value.service_linked_role_arn
+  vpc_zone_identifier       = each.value.subnets
+  protect_from_scale_in     = each.value.protect_from_scale_in
+  suspended_processes       = each.value.suspended_processes
+  enabled_metrics           = each.value.enabled_metrics
+  placement_group           = each.value.placement_group
+  termination_policies      = each.value.termination_policies
+  max_instance_lifetime     = each.value.max_instance_lifetime
+  default_cooldown          = each.value.default_cooldown
+  health_check_type         = each.value.health_check_type
+  health_check_grace_period = each.value.health_check_grace_period
 
   dynamic "mixed_instances_policy" {
     iterator = item
-    for_each = (lookup(var.worker_groups_launch_template[count.index], "override_instance_types", null) != null) || (lookup(var.worker_groups_launch_template[count.index], "on_demand_allocation_strategy", local.workers_group_defaults["on_demand_allocation_strategy"]) != null) ? [var.worker_groups_launch_template[count.index]] : []
+    for_each = (lookup(each.value, "override_instance_types", null) != null) || (each.value.on_demand_allocation_strategy != null) ? [each.value] : []
 
     content {
       instances_distribution {
-        on_demand_allocation_strategy = lookup(
-          item.value,
-          "on_demand_allocation_strategy",
-          "prioritized",
-        )
-        on_demand_base_capacity = lookup(
-          item.value,
-          "on_demand_base_capacity",
-          local.workers_group_defaults["on_demand_base_capacity"],
-        )
-        on_demand_percentage_above_base_capacity = lookup(
-          item.value,
-          "on_demand_percentage_above_base_capacity",
-          local.workers_group_defaults["on_demand_percentage_above_base_capacity"],
-        )
-        spot_allocation_strategy = lookup(
-          item.value,
-          "spot_allocation_strategy",
-          local.workers_group_defaults["spot_allocation_strategy"],
-        )
-        spot_instance_pools = lookup(
-          item.value,
-          "spot_instance_pools",
-          local.workers_group_defaults["spot_instance_pools"],
-        )
-        spot_max_price = lookup(
-          item.value,
-          "spot_max_price",
-          local.workers_group_defaults["spot_max_price"],
-        )
+        on_demand_allocation_strategy            = each.value.on_demand_allocation_strategy
+        on_demand_base_capacity                  = each.value.on_demand_base_capacity
+        on_demand_percentage_above_base_capacity = each.value.on_demand_percentage_above_base_capacity
+        spot_allocation_strategy                 = each.value.spot_allocation_strategy
+        spot_instance_pools                      = each.value.spot_instance_pools
+        spot_max_price                           = each.value.spot_max_price
       }
 
       launch_template {
         launch_template_specification {
-          launch_template_id = aws_launch_template.workers_launch_template.*.id[count.index]
-          version = lookup(
-            var.worker_groups_launch_template[count.index],
-            "launch_template_version",
-            local.workers_group_defaults["launch_template_version"],
-          )
+          launch_template_id = aws_launch_template.workers_launch_template[each.key].id
+          version            = each.value.launch_template_version
         }
 
         dynamic "override" {
-          for_each = lookup(
-            var.worker_groups_launch_template[count.index],
-            "override_instance_types",
-            local.workers_group_defaults["override_instance_types"]
-          )
+          for_each = each.value.override_instance_types
 
           content {
             instance_type = override.value
@@ -164,20 +65,16 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
   dynamic "launch_template" {
     iterator = item
-    for_each = (lookup(var.worker_groups_launch_template[count.index], "override_instance_types", null) != null) || (lookup(var.worker_groups_launch_template[count.index], "on_demand_allocation_strategy", local.workers_group_defaults["on_demand_allocation_strategy"]) != null) ? [] : [var.worker_groups_launch_template[count.index]]
+    for_each = (lookup(each.value, "override_instance_types", null) != null) || (each.value.on_demand_allocation_strategy != null) ? [] : [each.value]
 
     content {
-      id = aws_launch_template.workers_launch_template.*.id[count.index]
-      version = lookup(
-        var.worker_groups_launch_template[count.index],
-        "launch_template_version",
-        local.workers_group_defaults["launch_template_version"],
-      )
+      id      = aws_launch_template.workers_launch_template[each.key].id
+      version = each.value.launch_template_version
     }
   }
 
   dynamic "initial_lifecycle_hook" {
-    for_each = var.worker_create_initial_lifecycle_hooks ? lookup(var.worker_groups_launch_template[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []
+    for_each = var.worker_create_initial_lifecycle_hooks ? each.value.asg_initial_lifecycle_hooks : []
     content {
       name                    = initial_lifecycle_hook.value["name"]
       lifecycle_transition    = initial_lifecycle_hook.value["lifecycle_transition"]
@@ -190,7 +87,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
   }
 
   dynamic "warm_pool" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "warm_pool", null) != null ? [lookup(var.worker_groups_launch_template[count.index], "warm_pool")] : []
+    for_each = lookup(each.value, "warm_pool", null) != null ? [lookup(each.value, "warm_pool")] : []
 
     content {
       pool_state                  = lookup(warm_pool.value, "pool_state", null)
@@ -205,9 +102,9 @@ resource "aws_autoscaling_group" "workers_launch_template" {
         {
           "key" = "Name"
           "value" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
-            var.worker_groups_launch_template[count.index],
+            each.value,
             "name",
-            count.index,
+            each.key,
           )}-eks_asg"
           "propagate_at_launch" = true
         },
@@ -224,13 +121,9 @@ resource "aws_autoscaling_group" "workers_launch_template" {
           value               = tag_value
           propagate_at_launch = "true"
         })
-        if tag_key != "Name" && !contains([for tag in lookup(var.worker_groups_launch_template[count.index], "tags", local.workers_group_defaults["tags"]) : tag["key"]], tag_key)
+        if tag_key != "Name" && !contains([for tag in each.value.tags : tag["key"]], tag_key)
       ],
-      lookup(
-        var.worker_groups_launch_template[count.index],
-        "tags",
-        local.workers_group_defaults["tags"]
-      )
+      each.value.tags
     )
     content {
       key                 = tag.value.key
@@ -246,230 +139,123 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 }
 
 resource "aws_launch_template" "workers_launch_template" {
-  count = var.create_eks ? (local.worker_group_launch_template_count) : 0
+  for_each = var.create_eks ? local.worker_groups_launch_template_with_defaults : {}
   name_prefix = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
-    var.worker_groups_launch_template[count.index],
+    each.value,
     "name",
-    count.index,
+    each.key,
   )}"
 
   network_interfaces {
-    associate_public_ip_address = lookup(
-      var.worker_groups_launch_template[count.index],
-      "public_ip",
-      local.workers_group_defaults["public_ip"],
-    )
-    delete_on_termination = lookup(
-      var.worker_groups_launch_template[count.index],
-      "eni_delete",
-      local.workers_group_defaults["eni_delete"],
-    )
+    associate_public_ip_address = each.value.public_ip
+    delete_on_termination       = each.value.eni_delete
     security_groups = flatten([
       local.worker_security_group_id,
       var.worker_additional_security_group_ids,
-      lookup(
-        var.worker_groups_launch_template[count.index],
-        "additional_security_group_ids",
-        local.workers_group_defaults["additional_security_group_ids"],
-      ),
+      each.value.additional_security_group_ids,
     ])
   }
 
   iam_instance_profile {
-    name = coalescelist(
-      aws_iam_instance_profile.workers_launch_template.*.name,
-      data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile.*.name,
-    )[count.index]
+    name = coalesce(
+      aws_iam_instance_profile.workers_launch_template,
+      data.aws_iam_instance_profile.custom_worker_group_launch_template_iam_instance_profile,
+    )[each.key].name
   }
 
   enclave_options {
-    enabled = lookup(
-      var.worker_groups_launch_template[count.index],
-      "enclave_support",
-      local.workers_group_defaults["enclave_support"],
-    )
+    enabled = each.value.enclave_support
   }
 
   image_id = lookup(
-    var.worker_groups_launch_template[count.index],
+    each.value,
     "ami_id",
-    lookup(var.worker_groups_launch_template[count.index], "platform", local.workers_group_defaults["platform"]) == "windows" ? local.default_ami_id_windows : local.default_ami_id_linux,
-  )
-  instance_type = lookup(
-    var.worker_groups_launch_template[count.index],
-    "instance_type",
-    local.workers_group_defaults["instance_type"],
+    each.value.platform == "windows" ? local.default_ami_id_windows : local.default_ami_id_linux,
   )
 
+  instance_type = each.value.instance_type
+  key_name      = each.value.key_name
+
   dynamic "elastic_inference_accelerator" {
-    for_each = lookup(
-      var.worker_groups_launch_template[count.index],
-      "elastic_inference_accelerator",
-      local.workers_group_defaults["elastic_inference_accelerator"]
-    ) != null ? [lookup(var.worker_groups_launch_template[count.index], "elastic_inference_accelerator", local.workers_group_defaults["elastic_inference_accelerator"])] : []
+    for_each = each.value.elastic_inference_accelerator != null ? [each.value.elastic_inference_accelerator] : []
     content {
       type = elastic_inference_accelerator.value
     }
   }
 
-  key_name = lookup(
-    var.worker_groups_launch_template[count.index],
-    "key_name",
-    local.workers_group_defaults["key_name"],
-  )
   user_data = base64encode(
-    data.template_file.launch_template_userdata.*.rendered[count.index],
+    data.template_file.launch_template_userdata[each.key].rendered,
   )
 
   ebs_optimized = lookup(
-    var.worker_groups_launch_template[count.index],
+    each.value,
     "ebs_optimized",
     !contains(
       local.ebs_optimized_not_supported,
-      lookup(
-        var.worker_groups_launch_template[count.index],
-        "instance_type",
-        local.workers_group_defaults["instance_type"],
-      )
+      each.value.instance_type,
     )
   )
 
   metadata_options {
-    http_endpoint = lookup(
-      var.worker_groups_launch_template[count.index],
-      "metadata_http_endpoint",
-      local.workers_group_defaults["metadata_http_endpoint"],
-    )
-    http_tokens = lookup(
-      var.worker_groups_launch_template[count.index],
-      "metadata_http_tokens",
-      local.workers_group_defaults["metadata_http_tokens"],
-    )
-    http_put_response_hop_limit = lookup(
-      var.worker_groups_launch_template[count.index],
-      "metadata_http_put_response_hop_limit",
-      local.workers_group_defaults["metadata_http_put_response_hop_limit"],
-    )
+    http_endpoint               = each.value.metadata_http_endpoint
+    http_tokens                 = each.value.metadata_http_tokens
+    http_put_response_hop_limit = each.value.metadata_http_put_response_hop_limit
   }
 
   dynamic "credit_specification" {
-    for_each = lookup(
-      var.worker_groups_launch_template[count.index],
-      "cpu_credits",
-      local.workers_group_defaults["cpu_credits"]
-    ) != null ? [lookup(var.worker_groups_launch_template[count.index], "cpu_credits", local.workers_group_defaults["cpu_credits"])] : []
+    for_each = each.value.cpu_credits != null ? [each.value.cpu_credits] : []
     content {
       cpu_credits = credit_specification.value
     }
   }
 
   monitoring {
-    enabled = lookup(
-      var.worker_groups_launch_template[count.index],
-      "enable_monitoring",
-      local.workers_group_defaults["enable_monitoring"],
-    )
+    enabled = each.value.enable_monitoring
   }
 
   dynamic "placement" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "launch_template_placement_group", local.workers_group_defaults["launch_template_placement_group"]) != null ? [lookup(var.worker_groups_launch_template[count.index], "launch_template_placement_group", local.workers_group_defaults["launch_template_placement_group"])] : []
+    for_each = each.value.launch_template_placement_group != null ? [each.value.launch_template_placement_group] : []
 
     content {
-      tenancy = lookup(
-        var.worker_groups_launch_template[count.index],
-        "launch_template_placement_tenancy",
-        local.workers_group_defaults["launch_template_placement_tenancy"],
-      )
+      tenancy    = each.value.launch_template_placement_tenancy
       group_name = placement.value
     }
   }
 
   dynamic "instance_market_options" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : list(lookup(var.worker_groups_launch_template[count.index], "market_type", null))
+    for_each = lookup(each.value, "market_type", null) == null ? [] : [lookup(each.value, "market_type", null)]
     content {
       market_type = instance_market_options.value
     }
   }
 
   block_device_mappings {
-    device_name = lookup(
-      var.worker_groups_launch_template[count.index],
-      "root_block_device_name",
-      local.workers_group_defaults["root_block_device_name"],
-    )
+    device_name = each.value.root_block_device_name
 
     ebs {
-      volume_size = lookup(
-        var.worker_groups_launch_template[count.index],
-        "root_volume_size",
-        local.workers_group_defaults["root_volume_size"],
-      )
-      volume_type = lookup(
-        var.worker_groups_launch_template[count.index],
-        "root_volume_type",
-        local.workers_group_defaults["root_volume_type"],
-      )
-      iops = lookup(
-        var.worker_groups_launch_template[count.index],
-        "root_iops",
-        local.workers_group_defaults["root_iops"],
-      )
-      throughput = lookup(
-        var.worker_groups_launch_template[count.index],
-        "root_volume_throughput",
-        local.workers_group_defaults["root_volume_throughput"],
-      )
-      encrypted = lookup(
-        var.worker_groups_launch_template[count.index],
-        "root_encrypted",
-        local.workers_group_defaults["root_encrypted"],
-      )
-      kms_key_id = lookup(
-        var.worker_groups_launch_template[count.index],
-        "root_kms_key_id",
-        local.workers_group_defaults["root_kms_key_id"],
-      )
+      volume_size           = each.value.root_volume_size
+      volume_type           = each.value.root_volume_type
+      iops                  = each.value.root_iops
+      throughput            = each.value.root_volume_throughput
+      encrypted             = each.value.root_encrypted
+      kms_key_id            = each.value.root_kms_key_id
       delete_on_termination = true
     }
   }
 
   dynamic "block_device_mappings" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "additional_ebs_volumes", local.workers_group_defaults["additional_ebs_volumes"])
+    for_each = each.value.additional_ebs_volumes
     content {
       device_name = block_device_mappings.value.block_device_name
 
       ebs {
-        volume_size = lookup(
-          block_device_mappings.value,
-          "volume_size",
-          local.workers_group_defaults["root_volume_size"],
-        )
-        volume_type = lookup(
-          block_device_mappings.value,
-          "volume_type",
-          local.workers_group_defaults["root_volume_type"],
-        )
-        iops = lookup(
-          block_device_mappings.value,
-          "iops",
-          local.workers_group_defaults["root_iops"],
-        )
-        throughput = lookup(
-          block_device_mappings.value,
-          "throughput",
-          local.workers_group_defaults["root_volume_throughput"],
-        )
-        encrypted = lookup(
-          block_device_mappings.value,
-          "encrypted",
-          local.workers_group_defaults["root_encrypted"],
-        )
-        kms_key_id = lookup(
-          block_device_mappings.value,
-          "kms_key_id",
-          local.workers_group_defaults["root_kms_key_id"],
-        )
-        delete_on_termination = lookup(block_device_mappings.value, "delete_on_termination", true)
+        volume_size           = block_device_mappings.value.volume_size
+        volume_type           = block_device_mappings.value.volume_type
+        iops                  = block_device_mappings.value.iops
+        throughput            = block_device_mappings.value.volume_throughput
+        encrypted             = block_device_mappings.value.encrypted
+        kms_key_id            = block_device_mappings.value.kms_key_id
+        delete_on_termination = block_device_mappings.value.delete_on_termination
       }
     }
 
@@ -481,9 +267,9 @@ resource "aws_launch_template" "workers_launch_template" {
     tags = merge(
       {
         "Name" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
-          var.worker_groups_launch_template[count.index],
+          each.value,
           "name",
-          count.index,
+          each.key,
         )}-eks_asg"
       },
       var.tags,
@@ -496,14 +282,14 @@ resource "aws_launch_template" "workers_launch_template" {
     tags = merge(
       {
         "Name" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
-          var.worker_groups_launch_template[count.index],
+          each.value,
           "name",
-          count.index,
+          each.key,
         )}-eks_asg"
       },
       { for tag_key, tag_value in var.tags :
         tag_key => tag_value
-        if tag_key != "Name" && !contains([for tag in lookup(var.worker_groups_launch_template[count.index], "tags", local.workers_group_defaults["tags"]) : tag["key"]], tag_key)
+        if tag_key != "Name" && !contains([for tag in each.value.tags : tag["key"]], tag_key)
       }
     )
   }
@@ -532,7 +318,7 @@ resource "aws_launch_template" "workers_launch_template" {
 }
 
 resource "random_pet" "workers_launch_template" {
-  count = var.create_eks ? local.worker_group_launch_template_count : 0
+  for_each = var.create_eks ? local.worker_groups_launch_template_with_defaults : {}
 
   separator = "-"
   length    = 2
@@ -542,8 +328,8 @@ resource "random_pet" "workers_launch_template" {
       "-",
       compact(
         [
-          aws_launch_template.workers_launch_template[count.index].name,
-          aws_launch_template.workers_launch_template[count.index].latest_version
+          aws_launch_template.workers_launch_template[each.key].name,
+          aws_launch_template.workers_launch_template[each.key].latest_version
         ]
       )
     )
@@ -555,14 +341,11 @@ resource "random_pet" "workers_launch_template" {
 }
 
 resource "aws_iam_instance_profile" "workers_launch_template" {
-  count       = var.manage_worker_iam_resources && var.create_eks ? local.worker_group_launch_template_count : 0
+  for_each = var.manage_worker_iam_resources && var.create_eks ? local.worker_groups_launch_template_with_defaults : {}
+
   name_prefix = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
-  role = lookup(
-    var.worker_groups_launch_template[count.index],
-    "iam_role_id",
-    local.default_iam_role_id,
-  )
-  path = var.iam_path
+  role        = each.value.iam_role_id
+  path        = var.iam_path
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# PR o'clock

## Description

Closes #1105 
Partially addresses #635 

There are two themes to this PR. 
- One is merging the default values in the locals to avoid unnecessary lookups, which pollutes the codebase
- The main theme is migrating `count` to `for_each`, so that we can use relevant key names for identification
```
module.terraform_aws_eks.aws_autoscaling_group.workers["node-1"]
module.terraform_aws_eks.aws_autoscaling_group.workers["node-spots-2"]
module.terraform_aws_eks.aws_autoscaling_group.workers["gpu-1"]
...
module.terraform_aws_eks.aws_launch_configuration.workers["node-1"]
module.terraform_aws_eks.aws_launch_configuration.workers["node-spots-2"]
module.terraform_aws_eks.aws_launch_configuration.workers["gpu-1"]
```

## State migration process

There are no breaking changes in the interface (variables, outputs), But we have a tfstate migration required to move to the for_each index pattern.

The four main resources to migrate are:
- `aws_autoscaling_group.workers`
- `aws_iam_instance_profile.workers`
- `aws_launch_configuration.workers`
- `random_pet.workers`

> This can be done a variety of ways, but Ive built a migration-file-generator which feeds on a terraform plan output and prints `terraform state mv` commands. Please tell me if you are interested, and I'll look into open sourcing it. 

Example migration
```shell
terraform state mv module.terraform_aws_eks.aws_autoscaling_group.workers[0]  module.terraform_aws_eks.aws_autoscaling_group.workers["node-0"]
terraform state mv module.terraform_aws_eks.aws_autoscaling_group.workers[1]  module.terraform_aws_eks.aws_autoscaling_group.workers["node-1"]
terraform state mv module.terraform_aws_eks.aws_autoscaling_group.workers[2]  module.terraform_aws_eks.aws_autoscaling_group.workers["node-spots-0"]

terraform state mv module.terraform_aws_eks.aws_iam_instance_profile.workers[0]  module.terraform_aws_eks.aws_iam_instance_profile.workers["node-0"]
terraform state mv module.terraform_aws_eks.aws_iam_instance_profile.workers[1]  module.terraform_aws_eks.aws_iam_instance_profile.workers["node-1"]
terraform state mv module.terraform_aws_eks.aws_iam_instance_profile.workers[2]  module.terraform_aws_eks.aws_iam_instance_profile.workers["node-spots-0"]

terraform state mv module.terraform_aws_eks.aws_launch_configuration.workers[0]  module.terraform_aws_eks.aws_launch_configuration.workers["node-0"]
terraform state mv module.terraform_aws_eks.aws_launch_configuration.workers[1]  module.terraform_aws_eks.aws_launch_configuration.workers["node-1"]
terraform state mv module.terraform_aws_eks.aws_launch_configuration.workers[2]  module.terraform_aws_eks.aws_launch_configuration.workers["node-spots-0"]

terraform state mv module.terraform_aws_eks.random_pet.workers[0]  module.terraform_aws_eks.random_pet.workers["node-0"]
terraform state mv module.terraform_aws_eks.random_pet.workers[1]  module.terraform_aws_eks.random_pet.workers["node-1"]
terraform state mv module.terraform_aws_eks.random_pet.workers[2]  module.terraform_aws_eks.random_pet.workers["node-spots-0"]
```

## Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation (no interface change)
