### PR TITLE
fix: list -> tolist for working with terraform v0.15.0

### DIFF
--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -385,7 +385,7 @@ resource "aws_launch_template" "workers_launch_template" {
   }
 
   dynamic "instance_market_options" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : tolist(lookup(var.worker_groups_launch_template[count.index], "market_type", null))
+    for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : tolist([lookup(var.worker_groups_launch_template[count.index], "market_type", null)])
     content {
       market_type = instance_market_options.value
     }

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -385,7 +385,7 @@ resource "aws_launch_template" "workers_launch_template" {
   }
 
   dynamic "instance_market_options" {
-    for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : list(lookup(var.worker_groups_launch_template[count.index], "market_type", null))
+    for_each = lookup(var.worker_groups_launch_template[count.index], "market_type", null) == null ? [] : tolist(lookup(var.worker_groups_launch_template[count.index], "market_type", null))
     content {
       market_type = instance_market_options.value
     }


### PR DESCRIPTION
# PR o'clock

## Description

Fix deprecated function `list` and replaced it with `tolist` to work with terraform 0.15

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
