### PR TITLE
feat: Add tags on additional IAM resources like IAM policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.22.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.11.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.4 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.1 |
@@ -156,7 +156,7 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.22.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.11.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1.4 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.1 |

--- a/cluster.tf
+++ b/cluster.tf
@@ -170,6 +170,7 @@ resource "aws_iam_policy" "cluster_elb_sl_role_creation" {
   description = "Permissions for EKS to create AWSServiceRoleForElasticLoadBalancing service-linked role"
   policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json
   path        = var.iam_path
+  tags        = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_elb_sl_role_creation" {

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -21,6 +21,7 @@ resource "aws_iam_policy" "worker_autoscaling" {
   description = "EKS worker node autoscaling policy for cluster ${module.my_cluster.cluster_id}"
   policy      = data.aws_iam_policy_document.worker_autoscaling.json
   path        = var.iam_path
+  tags        = var.tags
 }
 
 data "aws_iam_policy_document" "worker_autoscaling" {

--- a/irsa.tf
+++ b/irsa.tf
@@ -12,4 +12,11 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   client_id_list  = [local.sts_principal]
   thumbprint_list = [var.eks_oidc_root_ca_thumbprint]
   url             = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
+
+  tags = merge(
+    {
+      Name = "${var.cluster_name}-eks-irsa"
+    },
+    var.tags
+  )
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws        = ">= 3.22.0"
+    aws        = ">= 3.35.0"
     local      = ">= 1.4"
     null       = ">= 2.1"
     template   = ">= 2.1"

--- a/workers.tf
+++ b/workers.tf
@@ -453,6 +453,7 @@ resource "aws_iam_instance_profile" "workers" {
   )
 
   path = var.iam_path
+  tags = var.tags
 
   lifecycle {
     create_before_destroy = true

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -563,6 +563,7 @@ resource "aws_iam_instance_profile" "workers_launch_template" {
     local.default_iam_role_id,
   )
   path = var.iam_path
+  tags = var.tags
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# PR o'clock

## Description
Issue - [1320](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1320)
1. Support AWS tags on the following IAM resources
  - `aws_iam_policy`
  - `aws_iam_instance_profile`
  - `aws_iam_openid_connect_provider`
2. Bump required AWS provider version to the `3.35.0`

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
