### PR TITLE
feat: Add `capacity_rebalance` support for self-managed worker groups

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -127,6 +127,7 @@ locals {
     instance_refresh_min_healthy_percentage  = 90                                                   # The amount of capacity in the ASG that must remain healthy during an instance refresh, as a percentage of the ASG's desired capacity.
     instance_refresh_instance_warmup         = null                                                 # The number of seconds until a newly launched instance is configured and ready to use. Defaults to the ASG's health check grace period.
     instance_refresh_triggers                = []                                                   # Set of additional property names that will trigger an Instance Refresh. A refresh will always be triggered by a change in any of launch_configuration, launch_template, or mixed_instances_policy.
+    capacity_rebalance                       = false                                                # Enable capacity rebalance
   }
 
   workers_group_defaults = merge(

--- a/workers.tf
+++ b/workers.tf
@@ -97,6 +97,11 @@ resource "aws_autoscaling_group" "workers" {
     "health_check_grace_period",
     local.workers_group_defaults["health_check_grace_period"]
   )
+  capacity_rebalance = lookup(
+    var.worker_groups[count.index],
+    "capacity_rebalance",
+    local.workers_group_defaults["capacity_rebalance"]
+  )
 
   dynamic "initial_lifecycle_hook" {
     for_each = var.worker_create_initial_lifecycle_hooks ? lookup(var.worker_groups[count.index], "asg_initial_lifecycle_hooks", local.workers_group_defaults["asg_initial_lifecycle_hooks"]) : []

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -96,6 +96,11 @@ resource "aws_autoscaling_group" "workers_launch_template" {
     "health_check_grace_period",
     local.workers_group_defaults["health_check_grace_period"]
   )
+  capacity_rebalance = lookup(
+    var.worker_groups_launch_template[count.index],
+    "capacity_rebalance",
+    local.workers_group_defaults["capacity_rebalance"]
+  )
 
   dynamic "mixed_instances_policy" {
     iterator = item


### PR DESCRIPTION
## Description

- See https://docs.aws.amazon.com/autoscaling/ec2/userguide/capacity-rebalance.html. We already have most functionality, only this parameter is missing

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1124