### PR TITLE
fix: Remove `null` provider from required providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.11.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.1 |
 
 ## Providers
 
@@ -157,7 +156,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.11.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1.4 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
-| <a name="provider_template"></a> [template](#provider\_template) | >= 2.1 |
 
 ## Modules
 
@@ -217,8 +215,6 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | [aws_iam_role.custom_cluster_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [http_http.wait_for_cluster](https://registry.terraform.io/providers/terraform-aws-modules/http/latest/docs/data-sources/http) | data source |
-| [template_file.launch_template_userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [template_file.userdata](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/fargate/versions.tf
+++ b/examples/fargate/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/irsa/versions.tf
+++ b/examples/irsa/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/launch_templates/versions.tf
+++ b/examples/launch_templates/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/launch_templates_with_managed_node_groups/versions.tf
+++ b/examples/launch_templates_with_managed_node_groups/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/managed_node_groups/versions.tf
+++ b/examples/managed_node_groups/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/secrets_encryption/versions.tf
+++ b/examples/secrets_encryption/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }

--- a/examples/spot_instances/versions.tf
+++ b/examples/spot_instances/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
-    null       = ">= 2.1"
     random     = ">= 2.1"
     kubernetes = "~> 1.11"
   }


### PR DESCRIPTION
# PR o'clock

## Description

Since we now use the terraform-aws-modules/http provider to wait the control plane https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1339, we don't need the null provider anymore.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
