### PR TITLE
feat: Drop `asg_recreate_on_change` feature to encourage the usage of  Instance Refresh for EC2 Auto Scaling

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -35,7 +35,6 @@ locals {
     asg_min_size                  = "1"                         # Minimum worker capacity in the autoscaling group. NOTE: Change in this paramater will affect the asg_desired_capacity, like changing its value to 2 will change asg_desired_capacity value to 2 but bringing back it to 1 will not affect the asg_desired_capacity.
     asg_force_delete              = false                       # Enable forced deletion for the autoscaling group.
     asg_initial_lifecycle_hooks   = []                          # Initital lifecycle hook for the autoscaling group.
-    asg_recreate_on_change        = false                       # Recreate the autoscaling group when the Launch Template or Launch Configuration change.
     default_cooldown              = null                        # The amount of time, in seconds, after a scaling activity completes before another scaling activity can start.
     health_check_type             = null                        # Controls how health checking is done. Valid values are "EC2" or "ELB".
     health_check_grace_period     = null                        # Time in seconds after instance comes into service before checking health.

--- a/workers.tf
+++ b/workers.tf
@@ -7,8 +7,7 @@ resource "aws_autoscaling_group" "workers" {
     compact(
       [
         coalescelist(aws_eks_cluster.this[*].name, [""])[0],
-        lookup(var.worker_groups[count.index], "name", count.index),
-        lookup(var.worker_groups[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers[count.index].id : ""
+        lookup(var.worker_groups[count.index], "name", count.index)
       ]
     )
   )
@@ -324,21 +323,6 @@ resource "aws_launch_configuration" "workers" {
     aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly,
     aws_iam_role_policy_attachment.workers_additional_policies
   ]
-}
-
-resource "random_pet" "workers" {
-  count = var.create_eks ? local.worker_group_count : 0
-
-  separator = "-"
-  length    = 2
-
-  keepers = {
-    lc_name = aws_launch_configuration.workers[count.index].name
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group" "workers" {

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -7,8 +7,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
     compact(
       [
         coalescelist(aws_eks_cluster.this[*].name, [""])[0],
-        lookup(var.worker_groups_launch_template[count.index], "name", count.index),
-        lookup(var.worker_groups_launch_template[count.index], "asg_recreate_on_change", local.workers_group_defaults["asg_recreate_on_change"]) ? random_pet.workers_launch_template[count.index].id : ""
+        lookup(var.worker_groups_launch_template[count.index], "name", count.index)
       ]
     )
   )
@@ -529,29 +528,6 @@ resource "aws_launch_template" "workers_launch_template" {
     aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly,
     aws_iam_role_policy_attachment.workers_additional_policies
   ]
-}
-
-resource "random_pet" "workers_launch_template" {
-  count = var.create_eks ? local.worker_group_launch_template_count : 0
-
-  separator = "-"
-  length    = 2
-
-  keepers = {
-    lt_name = join(
-      "-",
-      compact(
-        [
-          aws_launch_template.workers_launch_template[count.index].name,
-          aws_launch_template.workers_launch_template[count.index].latest_version
-        ]
-      )
-    )
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_iam_instance_profile" "workers_launch_template" {


### PR DESCRIPTION
# PR o'clock

## Description

This module used random_pet resources to create a random name for the autoscaling group to force the autoscaling group to be re-created when the launch configuration or launch template was changed (if `recreate_asg_when_lc_changes = true` was set), causing the instances to be removed and re-provisioned each time there was an update. Those random_pet resources has been removed and in its place there is now a set of functionality provided by AWS and the Terraform AWS provider - instance_refresh. We encourage those users to move on `instance_refresh`.

Go with https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1224

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
