### PR TITLE
fix: Add fallback for missing Windows AMI

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -27,7 +27,7 @@ data "aws_ami" "eks_worker" {
 data "aws_ami" "eks_worker_windows" {
   filter {
     name   = "name"
-    values = [local.worker_ami_name_filter_windows]
+    values = [local.worker_ami_name_filter_windows, "Windows_Server-2019-English-Core-EKS_Optimized-*"]
   }
 
   filter {


### PR DESCRIPTION
# PR o'clock

## Description

Currently if you try to upgrade to 1.20, you get a error that the Windows AMI can't be found, even if you're just using Linux nodes:

```
╷
│ Error: Your query returned no results. Please change your search criteria and try again.
│ 
│   on .terraform/modules/eks/data.tf line 27, in data "aws_ami" "eks_worker_windows":
│   27: data "aws_ami" "eks_worker_windows" {
│ 
╵
```

This PR adds a fallback so that when the Windows AMI can't be found, the most recent one is used instead.

This fixes issues like:
- #1100 
- #1141 
- #1246
- #1247 

I tested that this PR works by setting `cluster_version = 1.20` and `platform = "windows"`, and looking at the AMI in the plan diff:

![Screenshot from 2021-05-17 17-15-55](https://user-images.githubusercontent.com/7545665/118557781-aa1a5680-b733-11eb-93d2-fd08f4130e8d.png)

Confirmed that the `ami-03be3e9ae875d10ad` AMI was for Windows 1.19:

![Screenshot from 2021-05-17 17-18-42](https://user-images.githubusercontent.com/7545665/118557953-f6659680-b733-11eb-8002-6392eafab7d0.png)


### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
