### PR TITLE
fix: set an ASG's launch template version to an explicit version to automatically trigger instance refresh

### DIFF
--- a/examples/instance_refresh/main.tf
+++ b/examples/instance_refresh/main.tf
@@ -217,10 +217,9 @@ resource "helm_release" "aws_node_termination_handler" {
 # ensures that node termination does not require the lifecycle action to be completed,
 # and thus allows the ASG to be destroyed cleanly.
 resource "aws_autoscaling_lifecycle_hook" "aws_node_termination_handler" {
-  for_each = toset(module.eks.workers_asg_names)
-
+  count                  = length(module.eks.workers_asg_names)
   name                   = "aws-node-termination-handler"
-  autoscaling_group_name = each.value
+  autoscaling_group_name = module.eks.workers_asg_names[count.index]
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
   heartbeat_timeout      = 300
   default_result         = "CONTINUE"

--- a/examples/instance_refresh/main.tf
+++ b/examples/instance_refresh/main.tf
@@ -241,7 +241,6 @@ module "eks" {
       instance_refresh_instance_warmup     = 60
       public_ip                            = true
       metadata_http_put_response_hop_limit = 3
-      use_latest_version                   = true
       update_default_version               = true
       instance_refresh_triggers            = ["tag"]
       tags = [

--- a/examples/instance_refresh/main.tf
+++ b/examples/instance_refresh/main.tf
@@ -239,9 +239,12 @@ module "eks" {
       asg_max_size                         = 2
       asg_desired_capacity                 = 2
       instance_refresh_enabled             = true
-      instance_refresh_triggers            = ["tag"]
+      instance_refresh_instance_warmup     = 60
       public_ip                            = true
       metadata_http_put_response_hop_limit = 3
+      use_latest_version                   = true
+      update_default_version               = true
+      instance_refresh_triggers            = ["tag"]
       tags = [
         {
           key                 = "aws-node-termination-handler/managed"

--- a/local.tf
+++ b/local.tf
@@ -75,7 +75,9 @@ locals {
     root_block_device_name               = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
     root_kms_key_id                      = ""                                       # The KMS key to use when encrypting the root storage device
     launch_template_id                   = null                                     # The id of the launch template used for managed node_groups
-    launch_template_version              = "$Latest"                                # The lastest version of the launch template to use in the autoscaling group
+    launch_template_version              = "$Latest"                                # The latest version of the launch template to use in the autoscaling and node groups. Must be explicitly set in `worker_groups_launch_template`.
+    use_latest_version                   = true                                     # Set the autoscaling group to use the latest version of the launch template, otherwise the default template version will be used. Ignored when `launch_template_version` is set in `worker_groups_launch_template`.
+    update_default_version               = false                                    # Update the autoscaling group launch template's default version upon each update
     launch_template_placement_tenancy    = "default"                                # The placement tenancy for instances
     launch_template_placement_group      = null                                     # The name of the placement group into which to launch the instances, if any.
     root_encrypted                       = false                                    # Whether the volume should be encrypted or not

--- a/local.tf
+++ b/local.tf
@@ -75,8 +75,7 @@ locals {
     root_block_device_name               = data.aws_ami.eks_worker.root_device_name # Root device name for workers. If non is provided, will assume default AMI was used.
     root_kms_key_id                      = ""                                       # The KMS key to use when encrypting the root storage device
     launch_template_id                   = null                                     # The id of the launch template used for managed node_groups
-    launch_template_version              = "$Latest"                                # The latest version of the launch template to use in the autoscaling and node groups. Must be explicitly set in `worker_groups_launch_template`.
-    use_latest_version                   = true                                     # Set the autoscaling group to use the latest version of the launch template, otherwise the default template version will be used. Ignored when `launch_template_version` is set in `worker_groups_launch_template`.
+    launch_template_version              = "$Latest"                                # The latest version of the launch template to use in the autoscaling group
     update_default_version               = false                                    # Update the autoscaling group launch template's default version upon each update
     launch_template_placement_tenancy    = "default"                                # The placement tenancy for instances
     launch_template_placement_group      = null                                     # The name of the placement group into which to launch the instances, if any.

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -141,7 +141,13 @@ resource "aws_autoscaling_group" "workers_launch_template" {
           version = lookup(
             var.worker_groups_launch_template[count.index],
             "launch_template_version",
-            local.workers_group_defaults["launch_template_version"],
+            lookup(
+              var.worker_groups_launch_template[count.index],
+              "use_latest_version",
+              local.workers_group_defaults["use_latest_version"]
+            )
+            ? aws_launch_template.workers_launch_template.*.latest_version[count.index]
+            : aws_launch_template.workers_launch_template.*.default_version[count.index]
           )
         }
 
@@ -169,7 +175,13 @@ resource "aws_autoscaling_group" "workers_launch_template" {
       version = lookup(
         var.worker_groups_launch_template[count.index],
         "launch_template_version",
-        local.workers_group_defaults["launch_template_version"],
+        lookup(
+          var.worker_groups_launch_template[count.index],
+          "use_latest_version",
+          local.workers_group_defaults["use_latest_version"]
+        )
+        ? aws_launch_template.workers_launch_template.*.latest_version[count.index]
+        : aws_launch_template.workers_launch_template.*.default_version[count.index]
       )
     }
   }
@@ -277,6 +289,12 @@ resource "aws_launch_template" "workers_launch_template" {
     "name",
     count.index,
   )}"
+
+  update_default_version = lookup(
+    var.worker_groups_launch_template[count.index],
+    "update_default_version",
+    local.workers_group_defaults["update_default_version"],
+  )
 
   network_interfaces {
     associate_public_ip_address = lookup(

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -143,9 +143,9 @@ resource "aws_autoscaling_group" "workers_launch_template" {
             "launch_template_version",
             lookup(
               var.worker_groups_launch_template[count.index],
-              "use_latest_version",
-              local.workers_group_defaults["use_latest_version"]
-            )
+              "launch_template_version",
+              local.workers_group_defaults["launch_template_version"]
+            ) == "$Latest"
             ? aws_launch_template.workers_launch_template.*.latest_version[count.index]
             : aws_launch_template.workers_launch_template.*.default_version[count.index]
           )
@@ -177,9 +177,9 @@ resource "aws_autoscaling_group" "workers_launch_template" {
         "launch_template_version",
         lookup(
           var.worker_groups_launch_template[count.index],
-          "use_latest_version",
-          local.workers_group_defaults["use_latest_version"]
-        )
+          "launch_template_version",
+          local.workers_group_defaults["launch_template_version"]
+        ) == "$Latest"
         ? aws_launch_template.workers_launch_template.*.latest_version[count.index]
         : aws_launch_template.workers_launch_template.*.default_version[count.index]
       )


### PR DESCRIPTION
Set an ASG's launch template version to an explicit version automatically. This will ensure that an instance refresh will be
triggered whenever the launch template changes.

# PR o'clock

## Description

In order to properly trigger instance refresh whenever a launch template is modified the version of the template must be updated in the autoscaling group. Previous versions of this module only supported setting the template version manually. This PR adds a new feature that will either set the version to the latest (real) version or the default (real) version with the use of the boolean `use_latest_version`.  It is still possible to pin a specific  version of template by setting `launch_template_version` in `worker_groups_launch_template`. The default `launch_template_version` is ignored in the case of autoscaling group launch template, however it is preserved for the `node_group` case.

This PR also adds the ability to optionally update the default version for any autoscaling group launch template.

Fixes: #1365 #1315 #1293

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
