### PR TITLE
docs: Use IRSA for Node Termination Handler IAM policy attachement in Instance Refresh example

### DIFF
--- a/examples/instance_refresh/outputs.tf
+++ b/examples/instance_refresh/outputs.tf
@@ -25,10 +25,10 @@ output "region" {
 
 output "sqs_queue_asg_notification_arn" {
   description = "SQS queue ASG notification ARN"
-  value       = module.node_term_sqs.sqs_queue_arn
+  value       = module.aws_node_termination_handler_sqs.sqs_queue_arn
 }
 
 output "sqs_queue_asg_notification_url" {
   description = "SQS queue ASG notification URL"
-  value       = module.node_term_sqs.sqs_queue_id
+  value       = module.aws_node_termination_handler_sqs.sqs_queue_id
 }


### PR DESCRIPTION
# PR o'clock

## Description

I've updated the example for how to use instance refresh.

- Removed policy attachment to worker security group
- Added spot instance termination support
- Enable lifecycle for all worker groups
- Rename Terraform resources to make it clearer

### Checklist

- [ ] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
