### PR TITLE
fix: Bump `terraform-provider-http` required version to 2.4.1 to avoid TLS Cert Pool issue on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.37.0 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | >= 2.4.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 2.4.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.11.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
@@ -154,7 +154,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.37.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 2.4.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | >= 2.4.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.11.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 1.4 |
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     kubernetes = ">= 1.11.1"
     http = {
       source  = "terraform-aws-modules/http"
-      version = ">= 2.4.0"
+      version = ">= 2.4.1"
     }
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1384

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
