### PR TITLE
fix: Add back `depends_on` for `data.wait_for_cluster`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 <a name="unreleased"></a>
 ## [Unreleased]
 
-ddd
+
 
 <a name="v16.2.0"></a>
 ## [v16.2.0] - 2021-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+ddd
 
 <a name="v16.2.0"></a>
 ## [v16.2.0] - 2021-05-24

--- a/data.tf
+++ b/data.tf
@@ -83,3 +83,15 @@ data "aws_iam_instance_profile" "custom_worker_group_launch_template_iam_instanc
 }
 
 data "aws_partition" "current" {}
+
+data "http" "wait_for_cluster" {
+  count          = var.create_eks && var.manage_aws_auth ? 1 : 0
+  url            = format("%s/healthz", aws_eks_cluster.this[0].endpoint)
+  ca_certificate = base64decode(coalescelist(aws_eks_cluster.this[*].certificate_authority[0].data, [""])[0])
+  timeout        = 300
+
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_security_group_rule.cluster_private_access,
+  ]
+}


### PR DESCRIPTION
# PR o'clock

## Description

Add back `depends_on` for `data.wait_for_cluster` which was dropped by error in https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1339

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
