### PR TITLE
fix: Default `root_volume_type` must be `gp2`

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -46,7 +46,7 @@ locals {
     spot_price                        = ""                          # Cost of spot instance.
     placement_tenancy                 = ""                          # The tenancy of the instance. Valid values are "default" or "dedicated".
     root_volume_size                  = "100"                       # root volume size of workers instances.
-    root_volume_type                  = "gp3"                       # root volume type of workers instances, can be "standard", "gp3", "gp2", or "io1"
+    root_volume_type                  = "gp2"                       # root volume type of workers instances, can be "standard", "gp3", "gp2", or "io1"
     root_iops                         = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".
     root_volume_throughput            = null                        # The amount of throughput to provision for a gp3 volume.
     key_name                          = ""                          # The key pair name that should be used for the instances in the autoscaling group


### PR DESCRIPTION
# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
