### PR TITLE
fix: Don't add tags on network interfaces because it's not supported yet in `terraform-provider-aws`

### DIFF
--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -99,20 +99,6 @@ resource "aws_launch_template" "workers" {
     )
   }
 
-  # Supplying custom tags to EKS instances ENI's
-  tag_specifications {
-    resource_type = "network-interface"
-
-    tags = merge(
-      var.tags,
-      lookup(var.node_groups_defaults, "additional_tags", {}),
-      lookup(var.node_groups[each.key], "additional_tags", {}),
-      {
-        Name = local.node_groups_names[each.key]
-      }
-    )
-  }
-
   # Tag the LT itself
   tags = merge(
     var.tags,

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -563,24 +563,6 @@ resource "aws_launch_template" "workers_launch_template" {
     )
   }
 
-  tag_specifications {
-    resource_type = "network-interface"
-
-    tags = merge(
-      {
-        "Name" = "${coalescelist(aws_eks_cluster.this[*].name, [""])[0]}-${lookup(
-          var.worker_groups_launch_template[count.index],
-          "name",
-          count.index,
-        )}-eks_asg"
-      },
-      { for tag_key, tag_value in var.tags :
-        tag_key => tag_value
-        if tag_key != "Name" && !contains([for tag in lookup(var.worker_groups_launch_template[count.index], "tags", local.workers_group_defaults["tags"]) : tag["key"]], tag_key)
-      }
-    )
-  }
-
   tags = var.tags
 
   lifecycle {


### PR DESCRIPTION
# PR o'clock

## Description

Revert https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1362

This is a ongoing feature in the terraform-provider-aws. Here the related PR https://github.com/hashicorp/terraform-provider-aws/pull/18033.

Until that PR get merged, I'm reverting this.

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1406

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
