### PR TITLE
fix: Windows platform worker group does not find an AMI

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -16,7 +16,7 @@ locals {
   worker_group_launch_template_count = length(var.worker_groups_launch_template)
 
   worker_has_linux_ami   = length([for x in concat(var.worker_groups, var.worker_groups_launch_template) : x if lookup(x, "platform", "linux") == "linux"]) > 0
-  worker_has_windows_ami = length([for x in concat(var.worker_groups, var.worker_groups_launch_template) : x if lookup(x, "platform", "linux") == "windows"]) > 0
+  worker_has_windows_ami = length([for x in concat(var.worker_groups, var.worker_groups_launch_template) : x if lookup(x, "platform", "windows") == "windows"]) > 0
 
   worker_ami_name_filter = var.worker_ami_name_filter != "" ? var.worker_ami_name_filter : "amazon-eks-node-${var.cluster_version}-v*"
   # Windows nodes are available from k8s 1.14. If cluster version is less than 1.14, fix ami filter to some constant to not fail on 'terraform plan'.


### PR DESCRIPTION
Fixes #1410 - windows platform in `workers_group_default` results in a lookup for a windows node in the linux map. A windows AMI should be refereced to the windows map, and the default map should look for Linux.

# PR o'clock

## Description

Set a windows platform on the worker groups fails, unable to set an AMI. This is due to a windows lookup from a linux map.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
