### PR TITLE
fix: Remove duplicated security group rule for EKS private access endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | [aws_security_group_rule.cluster_egress_internet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cluster_https_worker_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cluster_primary_ingress_workers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.cluster_private_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cluster_private_access_cidrs_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.cluster_private_access_sg_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.workers_egress_internet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/cluster.tf
+++ b/cluster.tf
@@ -89,6 +89,7 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
 
 resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
   count       = var.create_eks && var.cluster_create_endpoint_private_access_sg_rule && var.cluster_endpoint_private_access && var.cluster_endpoint_private_access_cidrs != null ? 1 : 0
+  description = "Allow private K8S API ingress from custom CIDR source."
   type        = "ingress"
   from_port   = 443
   to_port     = 443
@@ -100,23 +101,12 @@ resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
 
 resource "aws_security_group_rule" "cluster_private_access_sg_source" {
   count                    = var.create_eks && var.cluster_create_endpoint_private_access_sg_rule && var.cluster_endpoint_private_access && var.cluster_endpoint_private_access_sg != null ? length(var.cluster_endpoint_private_access_sg) : 0
+  description              = "Allow private K8S API ingress from custom Security Groups source."
   type                     = "ingress"
   from_port                = 443
   to_port                  = 443
   protocol                 = "tcp"
   source_security_group_id = var.cluster_endpoint_private_access_sg[count.index]
-
-  security_group_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
-}
-
-resource "aws_security_group_rule" "cluster_private_access" {
-  description = "Allow private K8S API ingress from custom source."
-  count       = var.create_eks && var.cluster_create_endpoint_private_access_sg_rule && var.cluster_endpoint_private_access ? 1 : 0
-  type        = "ingress"
-  from_port   = 443
-  to_port     = 443
-  protocol    = "tcp"
-  cidr_blocks = var.cluster_endpoint_private_access_cidrs
 
   security_group_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
 }

--- a/data.tf
+++ b/data.tf
@@ -94,6 +94,7 @@ data "http" "wait_for_cluster" {
 
   depends_on = [
     aws_eks_cluster.this,
-    aws_security_group_rule.cluster_private_access,
+    aws_security_group_rule.cluster_private_access_sg_source,
+    aws_security_group_rule.cluster_private_access_cidrs_source,
   ]
 }


### PR DESCRIPTION
# PR o'clock

## Description

This fix a bug introduced during a merge request conflict resolution in https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1274

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1409

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
