### PR TITLE
fix: Add dash suffix to name_prefix

### DIFF
--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -32,7 +32,7 @@ locals {
     lookup(
       v,
       "name_prefix",
-      join("-", [var.cluster_name, k])
+      join("-", [var.cluster_name, k, ""])
     )
   ) }
 }


### PR DESCRIPTION
## Description

This adds a dash suffix to the name_prefix

### Before
```
prod-eks-od20210602013534947400000001
```

### After

```
prod-eks-od-20210602013534947400000001
```

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
