### PR TITLE
docs: Add `iam:TagOpenIDConnectProvider` to list of necessary permissions

### DIFF
--- a/docs/iam-permissions.md
+++ b/docs/iam-permissions.md
@@ -124,6 +124,7 @@ Following IAM permissions are the minimum permissions needed for your IAM user o
                 "iam:PassRole",
                 "iam:PutRolePolicy",
                 "iam:RemoveRoleFromInstanceProfile",
+                "iam:TagOpenIDConnectProvider",
                 "iam:TagRole",
                 "iam:UntagRole",
                 "iam:UpdateAssumeRolePolicy",


### PR DESCRIPTION
docs(iam): add 'iam:TagOpenIDConnectProvider' to list of necessary permissions

# PR o'clock

## Description

Minor docs update.

* adds 'iam:TagOpenIDConnectProvider' to list of necessary permissions
  * might be worth considering to add `'iam:Tag*`?

This caused a permission error with IRSA enabled with this EKS module. Hope to prevent this for others in the future :)

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
  - don't think this applies as this is a pure and very minor docs update
