### PR TITLE
feat: Add support for Managed Node Groups (`node_groups`) taints

### DIFF
--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -88,6 +88,13 @@ module "eks" {
       additional_tags = {
         ExtraTag = "example"
       }
+      taints = [
+        {
+          key    = "dedicated"
+          value  = "gpuGroup"
+          effect = "NO_SCHEDULE"
+        }
+      ]
     }
   }
 

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -44,6 +44,7 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | source\_security\_group\_ids | Source security groups for remote access to workers | list(string) | If key\_name is specified: THE REMOTE ACCESS WILL BE OPENED TO THE WORLD |
 | subnets | Subnets to contain workers | list(string) | `var.workers_group_defaults[subnets]` |
 | version | Kubernetes version | string | Provider default behavior |
+| taints | Kubernetes node taints | list(map) | empty |
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -51,13 +52,13 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.40.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.43.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.40.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43.0 |
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
 
 ## Modules

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -21,6 +21,7 @@ locals {
       public_ip                     = var.workers_group_defaults["public_ip"]
       pre_userdata                  = var.workers_group_defaults["pre_userdata"]
       additional_security_group_ids = var.workers_group_defaults["additional_security_group_ids"]
+      taints                        = []
     },
     var.node_groups_defaults,
     v,

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -57,6 +57,16 @@ resource "aws_eks_node_group" "workers" {
     }
   }
 
+  dynamic "taint" {
+    for_each = each.value["taints"]
+
+    content {
+      key    = taint.value["key"]
+      value  = taint.value["value"]
+      effect = taint.value["effect"]
+    }
+  }
+
   version = lookup(each.value, "version", null)
 
   labels = merge(

--- a/modules/node_groups/versions.tf
+++ b/modules/node_groups/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.40.0"
+    aws = ">= 3.43.0"
   }
 }


### PR DESCRIPTION
## Description

Add support for set taints on managed node groups, Resolve #1403

Ref:
https://docs.aws.amazon.com/eks/latest/userguide/node-taints-managed-node-groups.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#taint-configuration-block

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
