### PR TITLE
fix: userdata_template_file in workers_group_defaults is now used if defined

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -189,8 +189,8 @@ locals {
         var.worker_groups[index],
         "userdata_template_file",
         lookup(var.worker_groups[index], "platform", local.workers_group_defaults["platform"]) == "windows"
-        ? "${path.module}/templates/userdata_windows.tpl"
-        : "${path.module}/templates/userdata.sh.tpl"
+        ? coalesce(local.workers_group_defaults["userdata_template_file"], "${path.module}/templates/userdata_windows.tpl")
+        : coalesce(local.workers_group_defaults["userdata_template_file"], "${path.module}/templates/userdata.sh.tpl")
       ),
       merge({
         platform            = lookup(var.worker_groups[index], "platform", local.workers_group_defaults["platform"])


### PR DESCRIPTION
…] if defined

# PR o'clock

## Description

I am trying to create a company specific wrapper around this module to simplify usage and standardize a few things. We are using our own customized AMIs which work a little bit different then the default AMIs provided by AWS.

I wanted to define a default `userdata_template_file` that is used for all workers created via `worker_groups` without asking users to provide this every time.

I quickly realized that `workers_group_defaults` are not used for userdata in general. My PR tried to fix this behavior. It should be a non breaking change and only affect deployments which actually defined a default.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
