### PR TITLE
docs: Add missing comma to docs/iam-permissions.md

### DIFF
--- a/docs/iam-permissions.md
+++ b/docs/iam-permissions.md
@@ -109,7 +109,7 @@ Following IAM permissions are the minimum permissions needed for your IAM user o
                 "iam:DeleteInstanceProfile",
                 "iam:DeleteOpenIDConnectProvider",
                 "iam:DeletePolicy",
-                "iam:DeletePolicyVersion"
+                "iam:DeletePolicyVersion",
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
                 "iam:DeleteServiceLinkedRole",


### PR DESCRIPTION

# PR o'clock

## Description
Added a missing comma to `docs/iam-permissions.md` so that it's valid json. This is useful for folks copying those permissions. 

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
