### PR TITLE
improvement: Allow interface_type to be specified in worker group configs which ar…

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -107,6 +107,7 @@ locals {
     launch_template_placement_group      = null                                                                # The name of the placement group into which to launch the instances, if any.
     root_encrypted                       = false                                                               # Whether the volume should be encrypted or not
     eni_delete                           = true                                                                # Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying)
+    interface_type                       = null                                                                # The type of network interface. To create an Elastic Fabric Adapter (EFA), specify 'efa'.
     cpu_credits                          = "standard"                                                          # T2/T3 unlimited mode, can be 'standard' or 'unlimited'. Used 'standard' mode as default to avoid paying higher costs
     market_type                          = null
     metadata_http_endpoint               = "enabled"  # The state of the metadata service: enabled, disabled.

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -312,6 +312,11 @@ resource "aws_launch_template" "workers_launch_template" {
       "eni_delete",
       local.workers_group_defaults["eni_delete"],
     )
+    interface_type = lookup(
+      var.worker_groups_launch_template[count.index],
+      "interface_type",
+      local.workers_group_defaults["interface_type"],
+    )
     security_groups = flatten([
       local.worker_security_group_id,
       var.worker_additional_security_group_ids,


### PR DESCRIPTION
…e passed into worker_groups_launch_template.

# PR o'clock

## Description

This really simple PR allows setting the "interface_type" for launch templates.  This is needed to use EFA interfaces.  The change doesn't appear to need and README.md updates.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
