### PR TITLE
feat: added metadata options to launch template for managed node groups

### DIFF
--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -37,6 +37,9 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | launch\_template_version | The version of the LT to use | string | none |
 | max\_capacity | Max number of workers | number | `var.workers_group_defaults[asg_max_size]` |
 | min\_capacity | Min number of workers | number | `var.workers_group_defaults[asg_min_size]` |
+| metadata_http_endpoint | Whether the metadata service is available. Can be `enabled` or `disabled`. Require `create_launch_template` to be `true`. | string | `enabled` |
+| metadata_http_tokens | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be `optional` or `required`. Require `create_launch_template` to be `true`. | string | `optional` |
+| metadata_http_put_response_hop_limit | The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Can be an integer from `1` to `64`. Require `create_launch_template` to be `true`. | string | `null` |
 | name | Name of the node group. If you don't really need this, we recommend you to use `name_prefix` instead. | string | Will use the autogenerate name prefix |
 | name_prefix | Name prefix of the node group | string | Auto generated |
 | pre_userdata | userdata to pre-append to the default userdata. Require `create_launch_template` to be `true`| string | "" |

--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -39,6 +39,12 @@ resource "aws_launch_template" "workers" {
     }
   }
 
+  metadata_options {
+    http_endpoint               = lookup(each.value, "metadata_http_endpoint", null)
+    http_tokens                 = lookup(each.value, "metadata_http_tokens", null)
+    http_put_response_hop_limit = lookup(each.value, "metadata_http_put_response_hop_limit", null)
+  }
+
   instance_type = each.value["set_instance_types_on_lt"] ? element(each.value.instance_types, 0) : null
 
   monitoring {

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -2,26 +2,29 @@ locals {
   # Merge defaults and per-group values to make code cleaner
   node_groups_expanded = { for k, v in var.node_groups : k => merge(
     {
-      desired_capacity              = var.workers_group_defaults["asg_desired_capacity"]
-      iam_role_arn                  = var.default_iam_role_arn
-      instance_types                = [var.workers_group_defaults["instance_type"]]
-      key_name                      = var.workers_group_defaults["key_name"]
-      launch_template_id            = var.workers_group_defaults["launch_template_id"]
-      launch_template_version       = var.workers_group_defaults["launch_template_version"]
-      set_instance_types_on_lt      = false
-      max_capacity                  = var.workers_group_defaults["asg_max_size"]
-      min_capacity                  = var.workers_group_defaults["asg_min_size"]
-      subnets                       = var.workers_group_defaults["subnets"]
-      create_launch_template        = false
-      kubelet_extra_args            = var.workers_group_defaults["kubelet_extra_args"]
-      disk_size                     = var.workers_group_defaults["root_volume_size"]
-      disk_type                     = var.workers_group_defaults["root_volume_type"]
-      enable_monitoring             = var.workers_group_defaults["enable_monitoring"]
-      eni_delete                    = var.workers_group_defaults["eni_delete"]
-      public_ip                     = var.workers_group_defaults["public_ip"]
-      pre_userdata                  = var.workers_group_defaults["pre_userdata"]
-      additional_security_group_ids = var.workers_group_defaults["additional_security_group_ids"]
-      taints                        = []
+      desired_capacity                     = var.workers_group_defaults["asg_desired_capacity"]
+      iam_role_arn                         = var.default_iam_role_arn
+      instance_types                       = [var.workers_group_defaults["instance_type"]]
+      key_name                             = var.workers_group_defaults["key_name"]
+      launch_template_id                   = var.workers_group_defaults["launch_template_id"]
+      launch_template_version              = var.workers_group_defaults["launch_template_version"]
+      set_instance_types_on_lt             = false
+      max_capacity                         = var.workers_group_defaults["asg_max_size"]
+      min_capacity                         = var.workers_group_defaults["asg_min_size"]
+      subnets                              = var.workers_group_defaults["subnets"]
+      create_launch_template               = false
+      kubelet_extra_args                   = var.workers_group_defaults["kubelet_extra_args"]
+      disk_size                            = var.workers_group_defaults["root_volume_size"]
+      disk_type                            = var.workers_group_defaults["root_volume_type"]
+      enable_monitoring                    = var.workers_group_defaults["enable_monitoring"]
+      eni_delete                           = var.workers_group_defaults["eni_delete"]
+      public_ip                            = var.workers_group_defaults["public_ip"]
+      pre_userdata                         = var.workers_group_defaults["pre_userdata"]
+      additional_security_group_ids        = var.workers_group_defaults["additional_security_group_ids"]
+      taints                               = []
+      metadata_http_endpoint               = var.workers_group_defaults["metadata_http_endpoint"]
+      metadata_http_tokens                 = var.workers_group_defaults["metadata_http_tokens"]
+      metadata_http_put_response_hop_limit = var.workers_group_defaults["metadata_http_put_response_hop_limit"]
     },
     var.node_groups_defaults,
     v,


### PR DESCRIPTION
# PR o'clock

## Description

Add metadata block to launch template for managed node groups.

This is based on this [issue](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1353) raised by another author.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
