### PR TITLE
feat: Add support for addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,17 +152,18 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.40.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 2.4.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.11.1 |
-| <a name="provider_local"></a> [local](#provider\_local) | >= 1.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.45.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 2.4.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.3.2 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fargate"></a> [fargate](#module\_fargate) | ./modules/fargate |  |
-| <a name="module_node_groups"></a> [node\_groups](#module\_node\_groups) | ./modules/node_groups |  |
+| <a name="module_addons"></a> [addons](#module\_addons) | ./modules/addons | n/a |
+| <a name="module_fargate"></a> [fargate](#module\_fargate) | ./modules/fargate | n/a |
+| <a name="module_node_groups"></a> [node\_groups](#module\_node\_groups) | ./modules/node_groups | n/a |
 
 ## Resources
 
@@ -240,8 +241,11 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
 | <a name="input_cluster_service_ipv4_cidr"></a> [cluster\_service\_ipv4\_cidr](#input\_cluster\_service\_ipv4\_cidr) | service ipv4 cidr for the kubernetes cluster | `string` | `null` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
+| <a name="input_create_coredns_addon"></a> [create\_coredns\_addon](#input\_create\_coredns\_addon) | Controls if coredns addon should be deployed | `bool` | `true` | no |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_create_fargate_pod_execution_role"></a> [create\_fargate\_pod\_execution\_role](#input\_create\_fargate\_pod\_execution\_role) | Controls if the EKS Fargate pod execution IAM role should be created. | `bool` | `true` | no |
+| <a name="input_create_kube_proxy_addon"></a> [create\_kube\_proxy\_addon](#input\_create\_kube\_proxy\_addon) | Controls if kube proxy addon should be deployed | `bool` | `true` | no |
+| <a name="input_create_vpc_cni_addon"></a> [create\_vpc\_cni\_addon](#input\_create\_vpc\_cni\_addon) | Controls if vpc cni addon should be deployed | `bool` | `true` | no |
 | <a name="input_eks_oidc_root_ca_thumbprint"></a> [eks\_oidc\_root\_ca\_thumbprint](#input\_eks\_oidc\_root\_ca\_thumbprint) | Thumbprint of Root CA for EKS OIDC, Valid until 2037 | `string` | `"9e99a48a9960b14926bb7f3b02e22da2b0ab7280"` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Whether to create OpenID Connect Provider for EKS to enable IRSA | `bool` | `false` | no |
 | <a name="input_fargate_pod_execution_role_name"></a> [fargate\_pod\_execution\_role\_name](#input\_fargate\_pod\_execution\_role\_name) | The IAM Role that provides permissions for the EKS Fargate Profile. | `string` | `null` | no |
@@ -266,7 +270,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. Tags added to launch configuration or templates override these values for ASG Tags only. | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC where the cluster and workers will be deployed. | `string` | n/a | yes |
-| <a name="input_wait_for_cluster_timeout"></a> [wait\_for\_cluster\_timeout](#wait\_for\_cluster\_timeout) | Allows for a configurable timeout (in seconds) when waiting for a cluster to come up | `number` | `300` | no |
+| <a name="input_wait_for_cluster_timeout"></a> [wait\_for\_cluster\_timeout](#input\_wait\_for\_cluster\_timeout) | A timeout (in seconds) to wait for cluster to be available. | `number` | `300` | no |
 | <a name="input_worker_additional_security_group_ids"></a> [worker\_additional\_security\_group\_ids](#input\_worker\_additional\_security\_group\_ids) | A list of additional security group ids to attach to worker instances | `list(string)` | `[]` | no |
 | <a name="input_worker_ami_name_filter"></a> [worker\_ami\_name\_filter](#input\_worker\_ami\_name\_filter) | Name filter for AWS EKS worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |
 | <a name="input_worker_ami_name_filter_windows"></a> [worker\_ami\_name\_filter\_windows](#input\_worker\_ami\_name\_filter\_windows) | Name filter for AWS EKS Windows worker AMI. If not provided, the latest official AMI for the specified 'cluster\_version' is used. | `string` | `""` | no |

--- a/addons.tf
+++ b/addons.tf
@@ -1,0 +1,16 @@
+module "addons" {
+  source                   = "./modules/addons"
+  cluster_name             = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
+  cluster_version          = var.cluster_version
+  create_vpc_cni_addon     = var.create_vpc_cni_addon
+  create_kube_proxy_addon  = var.create_kube_proxy_addon
+  create_coredns_addon     = var.create_coredns_addon
+  cluster_oidc_issuer_url  = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
+  enable_irsa              = var.enable_irsa
+
+  eks_depends_on = [
+    aws_eks_cluster.this,
+    kubernetes_config_map.aws_auth
+  ]
+}
+

--- a/addons.tf
+++ b/addons.tf
@@ -1,12 +1,12 @@
 module "addons" {
-  source                   = "./modules/addons"
-  cluster_name             = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
-  cluster_version          = var.cluster_version
-  create_vpc_cni_addon     = var.create_vpc_cni_addon
-  create_kube_proxy_addon  = var.create_kube_proxy_addon
-  create_coredns_addon     = var.create_coredns_addon
-  cluster_oidc_issuer_url  = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
-  enable_irsa              = var.enable_irsa
+  source                  = "./modules/addons"
+  cluster_name            = coalescelist(aws_eks_cluster.this[*].name, [""])[0]
+  cluster_version         = var.cluster_version
+  create_vpc_cni_addon    = var.create_vpc_cni_addon
+  create_kube_proxy_addon = var.create_kube_proxy_addon
+  create_coredns_addon    = var.create_coredns_addon
+  cluster_oidc_issuer_url = flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0]
+  enable_irsa             = var.enable_irsa
 
   eks_depends_on = [
     aws_eks_cluster.this,

--- a/modules/addons/README.md
+++ b/modules/addons/README.md
@@ -1,0 +1,149 @@
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 0.13.0)
+
+- <a name="requirement_aws"></a> [aws](#requirement\_aws) (>= 3.43.0)
+
+## Providers
+
+The following providers are used by this module:
+
+- <a name="provider_aws"></a> [aws](#provider\_aws) (3.45.0)
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_iam_assumable_role_with_oidc"></a> [iam\_assumable\_role\_with\_oidc](#module\_iam\_assumable\_role\_with\_oidc)
+
+Source: terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc
+
+Version: v4.1.0
+
+## Resources
+
+The following resources are used by this module:
+
+- [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) (resource)
+- [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) (resource)
+- [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) (resource)
+
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name)
+
+Description: Name of parent cluster
+
+Type: `string`
+
+### <a name="input_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#input\_cluster\_oidc\_issuer\_url)
+
+Description: The cluster oidc issuer url
+
+Type: `string`
+
+### <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version)
+
+Description: Kubernetes version to use for the EKS cluster.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_coredns_versions"></a> [coredns\_versions](#input\_coredns\_versions)
+
+Description: The CoreDns plugin version for the corresponding version
+
+Type: `map(any)`
+
+Default:
+
+```json
+{
+  "1.18": "v1.8.3-eksbuild.1",
+  "1.19": "v1.8.3-eksbuild.1",
+  "1.20": "v1.8.3-eksbuild.1"
+}
+```
+
+### <a name="input_create_coredns_addon"></a> [create\_coredns\_addon](#input\_create\_coredns\_addon)
+
+Description: Controls if coredns addon should be deployed
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_create_kube_proxy_addon"></a> [create\_kube\_proxy\_addon](#input\_create\_kube\_proxy\_addon)
+
+Description: Controls if kube proxy addon should be deployed
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_create_vpc_cni_addon"></a> [create\_vpc\_cni\_addon](#input\_create\_vpc\_cni\_addon)
+
+Description: Controls if vpc cni addon should be deployed
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_eks_depends_on"></a> [eks\_depends\_on](#input\_eks\_depends\_on)
+
+Description: List of references to other resources this submodule depends on.
+
+Type: `any`
+
+Default: `null`
+
+### <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa)
+
+Description: Whether to create iam role for vpc cni and attach it to the service account
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_kube_proxy_versions"></a> [kube\_proxy\_versions](#input\_kube\_proxy\_versions)
+
+Description: The Kube proxy plugin version for the corresponding eks version
+
+Type: `map(any)`
+
+Default:
+
+```json
+{
+  "1.18": "v1.18.8-eksbuild.1",
+  "1.19": "v1.19.6-eksbuild.2",
+  "1.20": "v1.20.4-eksbuild.2"
+}
+```
+
+### <a name="input_vpc_cni_versions"></a> [vpc\_cni\_versions](#input\_vpc\_cni\_versions)
+
+Description: The VPC CNI plugin version for the corresponding eks version
+
+Type: `map(any)`
+
+Default:
+
+```json
+{
+  "1.18": "v1.7.10-eksbuild.1",
+  "1.19": "v1.7.10-eksbuild.1",
+  "1.20": "v1.7.10-eksbuild.1"
+}
+```
+
+## Outputs
+
+No outputs.

--- a/modules/addons/README.md
+++ b/modules/addons/README.md
@@ -106,7 +106,7 @@ Default: `null`
 
 ### <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa)
 
-Description: Whether to create iam role for vpc cni and attach it to the service account
+Description: Whether to create iam role for vpc cni and attach it to the service account, if irsa=false vpc cni plugin will not be deployed
 
 Type: `bool`
 

--- a/modules/addons/addons_roles.tf
+++ b/modules/addons/addons_roles.tf
@@ -1,8 +1,8 @@
 module "iam_assumable_role_with_oidc" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "v4.1.0"
-  create_role                   = true
-  role_name                     = join("_", [var.cluster_name, "vpc_cni"])
+  source      = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version     = "v4.1.0"
+  create_role = true
+  role_name   = join("_", [var.cluster_name, "vpc_cni"])
   # provider_url                  = replace(flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0], "https://", "")
   provider_url                  = replace(var.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = ["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]

--- a/modules/addons/addons_roles.tf
+++ b/modules/addons/addons_roles.tf
@@ -1,0 +1,10 @@
+module "iam_assumable_role_with_oidc" {
+  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version                       = "v4.1.0"
+  create_role                   = true
+  role_name                     = join("_", [var.cluster_name, "vpc_cni"])
+  # provider_url                  = replace(flatten(concat(aws_eks_cluster.this[*].identity[*].oidc.0.issuer, [""]))[0], "https://", "")
+  provider_url                  = replace(var.cluster_oidc_issuer_url, "https://", "")
+  role_policy_arns              = ["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:aws-node"]
+}

--- a/modules/addons/coredns.tf
+++ b/modules/addons/coredns.tf
@@ -1,0 +1,12 @@
+resource "aws_eks_addon" "coredns" {
+  count = var.create_coredns_addon ? 1 : 0
+
+  cluster_name      = var.cluster_name
+  addon_name        = "coredns"
+  resolve_conflicts = "OVERWRITE"
+  addon_version     = lookup(var.coredns_versions, var.cluster_version, "Not Found")
+
+  depends_on = [
+    var.eks_depends_on
+  ]
+}

--- a/modules/addons/kube_proxy.tf
+++ b/modules/addons/kube_proxy.tf
@@ -1,0 +1,12 @@
+resource "aws_eks_addon" "kube_proxy" {
+  count = var.create_kube_proxy_addon ? 1 : 0
+
+  cluster_name      = var.cluster_name
+  addon_name        = "kube-proxy"
+  resolve_conflicts = "OVERWRITE"
+  addon_version     = lookup(var.kube_proxy_versions, var.cluster_version, "Not Found")
+
+  depends_on = [
+    var.eks_depends_on
+  ]
+}

--- a/modules/addons/outputs.tf
+++ b/modules/addons/outputs.tf
@@ -1,0 +1,5 @@
+# output "iam_role_arn" {
+#   description = "role arn"
+#   value       = module.iam_assumable_role_with_oidc.iam_role_arn
+# }
+

--- a/modules/addons/outputs.tf
+++ b/modules/addons/outputs.tf
@@ -1,5 +1,0 @@
-# output "iam_role_arn" {
-#   description = "role arn"
-#   value       = module.iam_assumable_role_with_oidc.iam_role_arn
-# }
-

--- a/modules/addons/variables.tf
+++ b/modules/addons/variables.tf
@@ -77,7 +77,7 @@ variable "cluster_oidc_issuer_url" {
 
 variable "enable_irsa" {
   type        = bool
-  description = "Whether to create iam role for vpc cni and attach it to the service account"
+  description = "Whether to create iam role for vpc cni and attach it to the service account, if irsa=false vpc cni plugin will not be deployed"
   default     = true
 }
 

--- a/modules/addons/variables.tf
+++ b/modules/addons/variables.tf
@@ -1,0 +1,83 @@
+variable "create_vpc_cni_addon" {
+  type        = bool
+  description = "Controls if vpc cni addon should be deployed"
+  default     = true
+}
+
+variable "create_kube_proxy_addon" {
+  type        = bool
+  description = "Controls if kube proxy addon should be deployed"
+  default     = true
+}
+
+variable "create_coredns_addon" {
+  type        = bool
+  description = "Controls if coredns addon should be deployed"
+  default     = true
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of parent cluster"
+}
+
+
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes version to use for the EKS cluster."
+}
+
+variable "coredns_versions" {
+  # Versions are taken from https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html#updating-coredns-add-on
+  type        = map(any)
+  description = "The CoreDns plugin version for the corresponding version"
+  default = {
+    "1.18" = "v1.8.3-eksbuild.1"
+    "1.19" = "v1.8.3-eksbuild.1"
+    "1.20" = "v1.8.3-eksbuild.1"
+  }
+}
+
+
+variable "kube_proxy_versions" {
+  # Versions are taken from https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on
+  type        = map(any)
+  description = "The Kube proxy plugin version for the corresponding eks version"
+  default = {
+    "1.18" = "v1.18.8-eksbuild.1"
+    "1.19" = "v1.19.6-eksbuild.2"
+    "1.20" = "v1.20.4-eksbuild.2"
+  }
+}
+
+variable "vpc_cni_versions" {
+  # Versions are taken from https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-add-on
+  # Latest patch version is taken from https://github.com/aws/amazon-vpc-cni-k8s
+  type        = map(any)
+  description = "The VPC CNI plugin version for the corresponding eks version"
+  default = {
+    "1.18" = "v1.7.10-eksbuild.1"
+    "1.19" = "v1.7.10-eksbuild.1"
+    "1.20" = "v1.7.10-eksbuild.1"
+  }
+}
+
+# Hack for a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
+# Will be removed in Terraform 0.13 with the support of module's `depends_on` https://github.com/hashicorp/terraform/issues/10462
+variable "eks_depends_on" {
+  description = "List of references to other resources this submodule depends on."
+  type        = any
+  default     = null
+}
+
+variable "cluster_oidc_issuer_url" {
+  type        = string
+  description = "The cluster oidc issuer url"
+}
+
+variable "enable_irsa" {
+  type        = bool
+  description = "Whether to create iam role for vpc cni and attach it to the service account"
+  default     = true
+}
+

--- a/modules/addons/versions.tf
+++ b/modules/addons/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    aws = ">= 3.43.0"
+  }
+}

--- a/modules/addons/vpc_cni.tf
+++ b/modules/addons/vpc_cni.tf
@@ -1,0 +1,13 @@
+resource "aws_eks_addon" "vpc_cni" {
+  count = var.create_vpc_cni_addon ? 1 : 0
+
+  cluster_name             = var.cluster_name
+  addon_name               = "vpc-cni"
+  resolve_conflicts        = "OVERWRITE"
+  addon_version            = lookup(var.vpc_cni_versions, var.cluster_version, "Not Found")
+  service_account_role_arn = module.iam_assumable_role_with_oidc.iam_role_arn
+
+  depends_on = [
+    var.eks_depends_on
+  ]
+}

--- a/modules/addons/vpc_cni.tf
+++ b/modules/addons/vpc_cni.tf
@@ -1,5 +1,5 @@
 resource "aws_eks_addon" "vpc_cni" {
-  count = var.create_vpc_cni_addon ? 1 : 0
+  count = var.create_vpc_cni_addon && var.enable_irsa ? 1 : 0
 
   cluster_name             = var.cluster_name
   addon_name               = "vpc-cni"

--- a/modules/fargate/README.md
+++ b/modules/fargate/README.md
@@ -27,7 +27,7 @@ Helper submodule to create and manage resources related to `aws_eks_fargate_prof
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.40.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.45.0 |
 
 ## Modules
 

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -58,8 +58,8 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.43.0 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.45.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.2.0 |
 
 ## Modules
 

--- a/variables.tf
+++ b/variables.tf
@@ -393,3 +393,21 @@ variable "wait_for_cluster_timeout" {
   type        = number
   default     = 300
 }
+
+variable "create_vpc_cni_addon" {
+  type        = bool
+  description = "Controls if vpc cni addon should be deployed"
+  default     = true
+}
+
+variable "create_kube_proxy_addon" {
+  type        = bool
+  description = "Controls if kube proxy addon should be deployed"
+  default     = true
+}
+
+variable "create_coredns_addon" {
+  type        = bool
+  description = "Controls if coredns addon should be deployed"
+  default     = true
+}


### PR DESCRIPTION
# PR o'clock

## Description

Add support for eks addons recommended by was
1. VPC CNI
2. CoreDns
3. kube-proxy

The default behavior is to install the addons to the cluster.

Requires irsa to be enabled to deploy the VPC CNI addon

### Checklist

- [V] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
