### PR TITLE
Fix missing comma in iam-permissions.md

### DIFF
--- a/docs/iam-permissions.md
+++ b/docs/iam-permissions.md
@@ -109,7 +109,7 @@ Following IAM permissions are the minimum permissions needed for your IAM user o
                 "iam:DeleteInstanceProfile",
                 "iam:DeleteOpenIDConnectProvider",
                 "iam:DeletePolicy",
-                "iam:DeletePolicyVersion"
+                "iam:DeletePolicyVersion",
                 "iam:DeleteRole",
                 "iam:DeleteRolePolicy",
                 "iam:DeleteServiceLinkedRole",


### PR DESCRIPTION
Policy was missing a comma

# PR o'clock

## Description

Yeah, just missing a comma.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
