### PR TITLE
fix: Make minimum AWS provider version common

### DIFF
--- a/modules/fargate/versions.tf
+++ b/modules/fargate/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.40.0"
+    aws = ">= 3.43.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws        = ">= 3.40.0"
+    aws        = ">= 3.43.0"
     local      = ">= 1.4"
     kubernetes = ">= 1.11.1"
     http = {


### PR DESCRIPTION
# PR o'clock

## Description

The `node_group` module requires a more recent version of the AWS provider and as this is use by the EKS module, it should also have its version updated, and since the `fargate` module is called from the EKS module, it should also have it's version updated.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation

☝️ should happen via terraform-docs.