### PR TITLE
fix: worker security group handling when worker_create_security_group=false

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "cluster_egress_internet" {
 }
 
 resource "aws_security_group_rule" "cluster_https_worker_ingress" {
-  count                    = var.cluster_create_security_group && var.create_eks ? 1 : 0
+  count                    = var.cluster_create_security_group && var.create_eks && var.worker_create_security_group ? 1 : 0
   description              = "Allow pods to communicate with the EKS cluster API."
   protocol                 = "tcp"
   security_group_id        = local.cluster_security_group_id

--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "workers" {
   network_interfaces {
     associate_public_ip_address = lookup(each.value, "public_ip", null)
     delete_on_termination       = lookup(each.value, "eni_delete", null)
-    security_groups = flatten([
+    security_groups = compact(flatten([
       var.worker_security_group_id,
       var.worker_additional_security_group_ids,
       lookup(
@@ -56,7 +56,7 @@ resource "aws_launch_template" "workers" {
         "additional_security_group_ids",
         null,
       ),
-    ])
+    ]))
   }
 
   # if you want to use a custom AMI


### PR DESCRIPTION
# PR o'clock

## Description
Currently when you enable create_launch_template=true on the nodegroup, it switches from using primary cluster security group to worker security group which can cause various problems.

The first work around attempted was to use cluster_primary_security_group_id as worker_security_group_id, but that caused variable cycle error.
```
Error: Cycle: module.eks.local.cluster_primary_security_group_id (expand), module.eks.output.cluster_primary_security_group_id (expand), module.eks.var.worker_security_group_id (expand), module.eks.local.worker_security_group_id (expand), module.eks.aws_security_group_rule.cluster_https_worker_ingress, module.eks.aws_eks_cluster.this
```

The second workaround was to add the primary security group as worker_additional_security_group_ids, however that causes the ALB ingress controller to fail in AWS because the ingress controller cannot work when there are multiple SG attached to the network interface.

The solution was to delete the unused worker security group, however that causes the failure on launch template creation due to the empty security group id.

This PR cleans up the security groups for launch template if theres an empty string in the list.
There was also a `cluster_private_access_sg_source` rule which was trying to add the worker security group when the worker security group didn't exist, which is fixed in this PR.

### Checklist

- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
