### PR TITLE
fix: allow node_group attributes to be omitted

### DIFF
--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -32,13 +32,19 @@ locals {
     v,
   ) if var.create_eks }
 
-  node_groups_names = { for k, v in local.node_groups_expanded : k => lookup(
-    v,
-    "name",
-    lookup(
-      v,
-      "name_prefix",
-      join("-", [var.cluster_name, k])
-    )
-  ) }
+  # This node_groups_names construct is a consequence of not explicitly
+  # declaring the node_group object. For more information, refer to this issue:
+  # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1462
+  node_groups_names = {
+    for k, v in local.node_groups_expanded :
+      k => (
+        lookup(v, "name", null) != null
+          ? v["name"]
+          : (
+            lookup(v, "name_prefix", null) != null
+              ? v["name_prefix"]
+              : join("-", [var.cluster_name, k])
+          )
+      )
+  }
 }


### PR DESCRIPTION
# PR o'clock

## Description

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1462

This fix allows the node_group attributes name and name_prefix to be
explicitly omitted by setting them to null.

This fixes an edge case where the attribute was set, but null, which
would cause the conditional logic to be incorrect.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
