### PR TITLE
fix: Node Group Timeout Configuration

### DIFF
--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -80,6 +80,12 @@ resource "aws_eks_node_group" "workers" {
     lookup(var.node_groups[each.key], "additional_tags", {}),
   )
 
+  timeouts {
+    create = "2h"
+    update = "2h"
+    delete = "2h"
+  }
+
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [scaling_config.0.desired_size]

--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -81,9 +81,9 @@ resource "aws_eks_node_group" "workers" {
   )
 
   timeouts {
-    create = "2h"
-    update = "2h"
-    delete = "2h"
+    create = "3h"
+    update = "3h"
+    delete = "3h"
   }
 
   lifecycle {


### PR DESCRIPTION
# PR o'clock

## Description

Set the terraform 'Operation timeouts'[[0]] for the Node Groups[[1]].

I recently found that sometimes updating node groups with large nodes can sometimes take more than 1 hour which is the default. When terraform times out in these circumstances it gets into quite an ugly State mess.

This pull request handles these scenarios without requiring changes to any interfaces by just setting the defaults to 3 hours instead of 1.

I've tagged this as 'fix' because the default configuration causes errors within a fairly standard expected use-case. But, i'm comfortable changing that tag 🙂 

There is another PR open (but out of sync) which does the same work, but enables via a map var so that the timeouts are configurable. I honestly think this (change defaults to 3h) is sufficient and will immediately help users with minimal change and should be merged even if you ultimately want to make these values configurable.

This is currently blocking some users from using the module or causing them to maintain a fork.

**Linked Issues**
* https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1209
* https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1131


[0]: https://www.terraform.io/docs/language/resources/syntax.html#operation-timeouts
[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#timeouts
### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
