### PR TITLE
feat: Allow multiple SGs to added to EKS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ MIT Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-a
 | cluster\_log\_kms\_key\_id | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `""` | no |
 | cluster\_log\_retention\_in\_days | Number of days to retain log events. Default retention - 90 days. | `number` | `90` | no |
 | cluster\_name | Name of the EKS cluster. Also used as a prefix in names of related resources. | `string` | n/a | yes |
-| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
+| cluster\_security\_group\_id | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers. | `string` | `""` | no |
+| cluster\_additional\_security\_group\_ids | If provided, additional security groups will be attachjed to EKS cluster. If not given, cluster\_security\_group\_id will be used instead. | `list(string)` | `[]` | no |
 | cluster\_service\_ipv4\_cidr | service ipv4 cidr for the kubernetes cluster | `string` | `null` | no |
 | cluster\_version | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
 | config\_output\_path | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | `string` | `"./"` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -15,7 +15,7 @@ resource "aws_eks_cluster" "this" {
   tags                      = var.tags
 
   vpc_config {
-    security_group_ids      = compact([local.cluster_security_group_id])
+    security_group_ids      = compact(concat(tolist([local.cluster_security_group_id]), local.cluster_additional_security_group_ids))
     subnet_ids              = var.subnets
     endpoint_private_access = var.cluster_endpoint_private_access
     endpoint_public_access  = var.cluster_endpoint_public_access

--- a/local.tf
+++ b/local.tf
@@ -1,10 +1,11 @@
 locals {
 
-  cluster_security_group_id         = var.cluster_create_security_group ? join("", aws_security_group.cluster.*.id) : var.cluster_security_group_id
-  cluster_primary_security_group_id = var.cluster_version >= 1.14 ? element(concat(aws_eks_cluster.this[*].vpc_config[0].cluster_security_group_id, list("")), 0) : null
-  cluster_iam_role_name             = var.manage_cluster_iam_resources ? join("", aws_iam_role.cluster.*.name) : var.cluster_iam_role_name
-  cluster_iam_role_arn              = var.manage_cluster_iam_resources ? join("", aws_iam_role.cluster.*.arn) : join("", data.aws_iam_role.custom_cluster_iam_role.*.arn)
-  worker_security_group_id          = var.worker_create_security_group ? join("", aws_security_group.workers.*.id) : var.worker_security_group_id
+  cluster_security_group_id             = var.cluster_create_security_group ? join("", aws_security_group.cluster.*.id) : var.cluster_security_group_id
+  cluster_primary_security_group_id     = var.cluster_version >= 1.14 ? element(concat(aws_eks_cluster.this[*].vpc_config[0].cluster_security_group_id, list("")), 0) : null
+  cluster_additional_security_group_ids = var.cluster_additional_security_group_ids
+  cluster_iam_role_name                 = var.manage_cluster_iam_resources ? join("", aws_iam_role.cluster.*.name) : var.cluster_iam_role_name
+  cluster_iam_role_arn                  = var.manage_cluster_iam_resources ? join("", aws_iam_role.cluster.*.arn) : join("", data.aws_iam_role.custom_cluster_iam_role.*.arn)
+  worker_security_group_id              = var.worker_create_security_group ? join("", aws_security_group.workers.*.id) : var.worker_security_group_id
 
   default_iam_role_id    = concat(aws_iam_role.workers.*.id, [""])[0]
   default_ami_id_linux   = coalesce(local.workers_group_defaults.ami_id, data.aws_ami.eks_worker.id)

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "cluster_security_group_id" {
   default     = ""
 }
 
+variable "cluster_additional_security_group_ids" {
+  description = "A list of additional security group ids to attach to EKS cluster"
+  type        = list(string)
+  default     = []
+}
+
 variable "cluster_version" {
   description = "Kubernetes version to use for the EKS cluster."
   type        = string


### PR DESCRIPTION
# PR o'clock

## Description

Added logic to allow adding existing AWS Security Groups to EKS endpoint.

### Checklist

- [] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
