### PR TITLE
feat: Ability to tag just EKS cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster. Also used as a prefix in names of related resources. | `string` | n/a | yes |
 | <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
 | <a name="input_cluster_service_ipv4_cidr"></a> [cluster\_service\_ipv4\_cidr](#input\_cluster\_service\_ipv4\_cidr) | service ipv4 cidr for the kubernetes cluster | `string` | `null` | no |
+| <a name="input_cluster_tags"></a> [cluster_tags](#input\_cluster\_tags) | A map of tags to add to only the EKS resource | `map(string)` | `{}` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for the EKS cluster. | `string` | n/a | yes |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_create_fargate_pod_execution_role"></a> [create\_fargate\_pod\_execution\_role](#input\_create\_fargate\_pod\_execution\_role) | Controls if the EKS Fargate pod execution IAM role should be created. | `bool` | `true` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -12,7 +12,10 @@ resource "aws_eks_cluster" "this" {
   enabled_cluster_log_types = var.cluster_enabled_log_types
   role_arn                  = local.cluster_iam_role_arn
   version                   = var.cluster_version
-  tags                      = var.tags
+  tags                      = merge(
+    var.tags,
+    var.cluster_tags,
+  )
 
   vpc_config {
     security_group_ids      = compact([local.cluster_security_group_id])

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "cluster_tags" {
+  description = "A map of tags to add to just the eks resource."
+  type        = map(string)
+  default     = {}
+}
+
 variable "vpc_id" {
   description = "VPC where the cluster and workers will be deployed."
   type        = string


### PR DESCRIPTION
Signed-off-by: mmerril8 <mmerril8@its.jnj.com>

# PR o'clock

## Description

Update to provide ability to tag just EKS resources (#1470 )

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
