### PR TITLE
fix: cluster_encryption_config format in for_each

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -32,7 +32,7 @@ resource "aws_eks_cluster" "this" {
   }
 
   dynamic "encryption_config" {
-    for_each = toset(var.cluster_encryption_config)
+    for_each = var.cluster_encryption_config
 
     content {
       provider {


### PR DESCRIPTION
# PR o'clock

## Description

Prevent the following error when using cluster_encryption_config.

 Error: Invalid dynamic for_each value
│ 
│   on .terraform/modules/eks-runners.eks/cluster.tf line 35, in resource "aws_eks_cluster" "this":
│   35:     for_each = toset(var.cluster_encryption_config)
│     ├────────────────
│     │ var.cluster_encryption_config is list of object with 1 element
│ 
│ **Cannot use a set of object value in for_each**. An iterable collection is required.

This error is produced with terraform 0.13<>1.0.3 and module aws-eks > 14 

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
