### PR TITLE
feat: Add support for autoscaling group AMI override

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -270,4 +270,10 @@ locals {
       )
     )
   ]
+
+  launch_templates_with_instance_ami = merge(values(
+    { for k, v in { for i, t in var.worker_groups_launch_template : i => merge(lookup(t, "override_instance_ami", {}), { "default" : null }) } :
+    k => { for instance, ami in v : "${k}-${instance}" => { launch_template : k, ami : ami } } }
+  )...)
+
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -126,17 +126,17 @@ output "workers_default_ami_id_windows" {
 
 output "workers_launch_template_ids" {
   description = "IDs of the worker launch templates."
-  value       = aws_launch_template.workers_launch_template.*.id
+  value       = { for k, v in aws_launch_template.workers_launch_template : k => v.id }
 }
 
 output "workers_launch_template_arns" {
   description = "ARNs of the worker launch templates."
-  value       = aws_launch_template.workers_launch_template.*.arn
+  value       = { for k, v in aws_launch_template.workers_launch_template : k => v.arn }
 }
 
 output "workers_launch_template_latest_versions" {
   description = "Latest versions of the worker launch templates."
-  value       = aws_launch_template.workers_launch_template.*.latest_version
+  value       = { for k, v in aws_launch_template.workers_launch_template : k => v.latest_version }
 }
 
 output "worker_security_group_id" {


### PR DESCRIPTION
# PR o'clock

## Description

Resolves #1498 
Allow users to specify different AMIs based on the instance type ( more details in #1498 )

Since aws has introduced eks support for [arm instances](https://aws.amazon.com/it/about-aws/whats-new/2020/08/amazon-eks-support-for-arm-based-instances-powered-by-aws-graviton-now-generally-available/)  the module should also support the creation of asg with mixed instance type (arm64, x64).

The [suggested way](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-launch-template-overrides.html) to implement this feature is to create multiple `launchtemplates` and overriding the default launch template with a specific one related to the instance type.

Example 
```hcl
module "eks" {
  ...
  worker_groups_launch_template = [
    {
      name = "spot-1"
      override_instance_types = [
        "m5.large",
        "t4g.medium"
      ]
      override_instance_ami = {
        "t4g.medium" : "<custom_ami>"
      }
    },
  ]
}
```

This change introduce more complexity in the `aws_launch_template` creation since we now have to create multiple `aws_launch_template` for the same `aws_autoscaling_group` if `override_instance_ami` is specified.

In order to avoid the duplication of `aws_launch_template.workers_launch_template` the resource is not created using a `for_each` which creates a launch template for every node group * n. of specified overrides.

### Checklist

- [ X ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
