### PR TITLE
chore: Update kubernetes provider's version in example to '>=2.0.0' and removed `load_config_file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
-  version                = "~> 1.9"
+  version                = "~> 2.0"
 }
 
 module "my-cluster" {
@@ -87,8 +86,7 @@ provider "kubernetes" {
   host                   = element(concat(data.aws_eks_cluster.cluster[*].endpoint, [""]), 0)
   cluster_ca_certificate = base64decode(element(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, [""]), 0))
   token                  = element(concat(data.aws_eks_cluster_auth.cluster[*].token, [""]), 0)
-  load_config_file       = false
-  version                = "1.10"
+  version                = "2.0.0"
 }
 
 # This cluster will not be created

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/create_false/main.tf
+++ b/examples/create_false/main.tf
@@ -16,7 +16,6 @@ provider "kubernetes" {
   host                   = element(concat(data.aws_eks_cluster.cluster[*].endpoint, [""]), 0)
   cluster_ca_certificate = base64decode(element(concat(data.aws_eks_cluster.cluster[*].certificate_authority.0.data, [""]), 0))
   token                  = element(concat(data.aws_eks_cluster_auth.cluster[*].token, [""]), 0)
-  load_config_file       = false
 }
 
 module "eks" {

--- a/examples/create_false/versions.tf
+++ b/examples/create_false/versions.tf
@@ -3,6 +3,6 @@ terraform {
 
   required_providers {
     aws        = ">= 3.22.0"
-    kubernetes = "~> 1.11"
+    kubernetes = "~> 2.0.0"
   }
 }

--- a/examples/create_false/versions.tf
+++ b/examples/create_false/versions.tf
@@ -3,6 +3,6 @@ terraform {
 
   required_providers {
     aws        = ">= 3.22.0"
-    kubernetes = "~> 2.0.0"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/fargate/main.tf
+++ b/examples/fargate/main.tf
@@ -18,7 +18,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/fargate/versions.tf
+++ b/examples/fargate/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/instance_refresh/main.tf
+++ b/examples/instance_refresh/main.tf
@@ -18,7 +18,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 provider "helm" {

--- a/examples/instance_refresh/versions.tf
+++ b/examples/instance_refresh/versions.tf
@@ -5,7 +5,7 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
     helm       = "~> 2.1.2"
   }
 }

--- a/examples/irsa/main.tf
+++ b/examples/irsa/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {}

--- a/examples/irsa/versions.tf
+++ b/examples/irsa/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/launch_templates/main.tf
+++ b/examples/launch_templates/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/launch_templates/versions.tf
+++ b/examples/launch_templates/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/launch_templates_with_managed_node_groups/main.tf
+++ b/examples/launch_templates_with_managed_node_groups/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/launch_templates_with_managed_node_groups/versions.tf
+++ b/examples/launch_templates_with_managed_node_groups/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/managed_node_groups/versions.tf
+++ b/examples/managed_node_groups/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/secrets_encryption/main.tf
+++ b/examples/secrets_encryption/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/secrets_encryption/versions.tf
+++ b/examples/secrets_encryption/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }

--- a/examples/spot_instances/main.tf
+++ b/examples/spot_instances/main.tf
@@ -14,7 +14,6 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
-  load_config_file       = false
 }
 
 data "aws_availability_zones" "available" {

--- a/examples/spot_instances/versions.tf
+++ b/examples/spot_instances/versions.tf
@@ -5,6 +5,6 @@ terraform {
     aws        = ">= 3.22.0"
     local      = ">= 1.4"
     random     = ">= 2.1"
-    kubernetes = "~> 1.11"
+    kubernetes = ">= 2.0.0"
   }
 }


### PR DESCRIPTION
# PR o'clock

## Description

## why

To make the example codes executable for newer versions of `kubernetes` provider.

[terraform-provider-kubernetes@2.0.0](https://github.com/hashicorp/terraform-provider-kubernetes/releases/tag/v2.0.0) removed `load_config_file` attribute from provider block.

## what
- remove `load_config_file` from kubernetes providers and changed the required provider's verson to `>=2.0.0` under `examples`

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
