### PR TITLE
feat: Ignore NG's Launch Template Version Change

### DIFF
--- a/modules/node_groups/node_groups.tf
+++ b/modules/node_groups/node_groups.tf
@@ -82,7 +82,10 @@ resource "aws_eks_node_group" "workers" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [scaling_config.0.desired_size]
+    ignore_changes        = [
+      scaling_config.0.desired_size,
+      launch_template.0.version
+    ]
   }
 
   depends_on = [var.ng_depends_on]


### PR DESCRIPTION
# PR o'clock
As a heavy user of this module, every time I run the `terraform apply` I get frustrated by the fact I all of my managed nodegroups are updated, regardless of the change I made to the TF stack.
The update is to the LT version, from "2" to "$Latest", even though in my configuration the version is already set to "latest":

My configuration look like this:
```terrraform

module "eks" {
  source          = "terraform-aws-modules/eks/aws"
  .....
  workers_group_defaults = {
    .....
    create_launch_template   = true
    launch_template_version = "$Latest"
  }
}
```

But when I run terraform plan, I see that terraform is aiming to change the version:
![image](https://user-images.githubusercontent.com/41479945/129190729-2177d5bb-0699-4c29-9b8e-1015857b11ae.png)

## Description
I added the LT version to the ignore list in hope this may help other people using this module

