### PR TITLE
fix: unable to have more than one fargate profile

### DIFF
--- a/modules/fargate/fargate.tf
+++ b/modules/fargate/fargate.tf
@@ -14,7 +14,7 @@ resource "aws_iam_role_policy_attachment" "eks_fargate_pod" {
 }
 
 resource "aws_eks_fargate_profile" "this" {
-  for_each               = local.create_eks ? local.fargate_profiles_expanded : {}
+  for_each               = local.fargate_profiles_expanded
   cluster_name           = var.cluster_name
   fargate_profile_name   = lookup(each.value, "name", format("%s-fargate-%s", var.cluster_name, replace(each.key, "_", "-")))
   pod_execution_role_arn = local.pod_execution_role_arn


### PR DESCRIPTION
# PR o'clock

## Description

Resolves issue #1245

`local.fargate_profiles_expanded` is always empty when `local.create_eks` is false so the ternary operator here can be omitted.

`local.create_eks` is defined as `var.create_eks && length(var.fargate_profiles) > 0`

`local.fargate_profiles_expanded` is defined as `{ for k, v in var.fargate_profiles : k => merge(
    v,
    { tags = merge(var.tags, lookup(v, "tags", {})) },
  ) if var.create_eks }`

If `var.create_eks` is false, then `local.fargate_profiles_expanded` will have all entries filtered out by the conditional in the for expression.
If `var.fargate_profiles` is length 0, then `local.fargate_profiles_expanded` will have no entries to iterate over in the for expression.

### Checklist

- [x] Add semantics prefix to your PR or Commits (at least one of your commit groups)
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
