### PR TITLE
fix: Add dependens_on eks cluster to the kubeconfig file

### DIFF
--- a/kubectl.tf
+++ b/kubectl.tf
@@ -4,4 +4,7 @@ resource "local_file" "kubeconfig" {
   filename             = substr(var.kubeconfig_output_path, -1, 1) == "/" ? "${var.kubeconfig_output_path}kubeconfig_${var.cluster_name}" : var.kubeconfig_output_path
   file_permission      = var.kubeconfig_file_permission
   directory_permission = "0755"
+  depends_on = [
+    aws_eks_cluster.this,
+  ]
 }


### PR DESCRIPTION
# PR o'clock

## Description

Simple depends_on addition. Prevent deletion/creation of kubeconfig file before the cluster actually exists or deleted.
In case the terraform destroy fails and the cluster is still there with some issue, we might need to use the kubeconfig.
Right now the behaviour deletes the kubeconfig file too early.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
