### PR TITLE
fix: Allow instance `Name` tag to be overwritten

### DIFF
--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -77,11 +77,11 @@ resource "aws_launch_template" "workers" {
 
     tags = merge(
       var.tags,
-      lookup(var.node_groups_defaults, "additional_tags", {}),
-      lookup(var.node_groups[each.key], "additional_tags", {}),
       {
         Name = local.node_groups_names[each.key]
-      }
+      },
+      lookup(var.node_groups_defaults, "additional_tags", {}),
+      lookup(var.node_groups[each.key], "additional_tags", {})
     )
   }
 
@@ -91,11 +91,11 @@ resource "aws_launch_template" "workers" {
 
     tags = merge(
       var.tags,
-      lookup(var.node_groups_defaults, "additional_tags", {}),
-      lookup(var.node_groups[each.key], "additional_tags", {}),
       {
         Name = local.node_groups_names[each.key]
-      }
+      },
+      lookup(var.node_groups_defaults, "additional_tags", {}),
+      lookup(var.node_groups[each.key], "additional_tags", {})
     )
   }
 


### PR DESCRIPTION


# PR o'clock

## Description

Allow instance `Name` tag to be overwritten by the user-defined node-group variable `additional_tags`. Without this PR, it is impossible to define custom names for instances created as part of a managed node group while using a generated launch template. It was possible to affect the name of the instance by setting a different name for the node-group, but there does not appear to be a technical reason for this to be mandated. 

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
