### PR TITLE
feat: Create SG rule for each new cluster_endpoint_private_access_cidr block

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -88,13 +88,13 @@ resource "aws_security_group_rule" "cluster_https_worker_ingress" {
 }
 
 resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
-  count       = var.create_eks && var.cluster_create_endpoint_private_access_sg_rule && var.cluster_endpoint_private_access && var.cluster_endpoint_private_access_cidrs != null ? 1 : 0
+  for_each    = var.create_eks && var.cluster_create_endpoint_private_access_sg_rule && var.cluster_endpoint_private_access && var.cluster_endpoint_private_access_cidrs != null ? toset(var.cluster_endpoint_private_access_cidrs) : []
   description = "Allow private K8S API ingress from custom CIDR source."
   type        = "ingress"
   from_port   = 443
   to_port     = 443
   protocol    = "tcp"
-  cidr_blocks = var.cluster_endpoint_private_access_cidrs
+  cidr_blocks = [each.value]
 
   security_group_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
 }


### PR DESCRIPTION
Create separate sg rule for each new `cluster_endpoint_private_access_cidr` block in order to fix **A duplicate Security Group rule error** mentioned in #984 

# PR o'clock

## Description

At the moment, it isn't possible to update the `cluster_endpoint_private_access_cidrs` variable since terraform apply fails with the error described in the #984 

Initial settings:
```
module "eks" {
  source = "github.com/terraform-aws-modules/terraform-aws-eks.git?ref=v17.3.0"
...
  cluster_endpoint_private_access                           = true
  cluster_endpoint_private_access_cidrs                 = ["104.145.4.34/32"]
  cluster_create_endpoint_private_access_sg_rule = true
```
Updated settings:
```
module "eks" {
  source = "github.com/terraform-aws-modules/terraform-aws-eks.git?ref=v17.3.0"
...
  cluster_endpoint_private_access                           = true
  cluster_endpoint_private_access_cidrs                 = ["104.145.4.34/32", "64.114.102.2/32"]
  cluster_create_endpoint_private_access_sg_rule = true
```
terraform plan:
```
  # module.eks.aws_security_group_rule.cluster_private_access_cidrs_source[0] must be replaced
+/- resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
      ~ cidr_blocks              = [ # forces replacement
            "104.145.4.34/32",
          + "64.114.102.2/32",
        ]
      ~ id                       = "sgrule-3690564928" -> (known after apply)
      - ipv6_cidr_blocks         = [] -> null
      - prefix_list_ids          = [] -> null
      + source_security_group_id = (known after apply)
        # (7 unchanged attributes hidden)
    }
```

terraform apply:
```
module.eks.aws_security_group_rule.cluster_private_access_cidrs_source[0]: Creating...

Error: [WARN] A duplicate Security Group rule was found on (sg-00e1d0309e2738140). This may be
a side effect of a now-fixed Terraform issue causing two security groups with
identical attributes but different source_security_group_ids to overwrite each
other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: 104.145.4.34/32, TCP, from port: 443, to port: 443, ALLOW" already exists
	status code: 400, request id: ec240586-97ee-4d49-8153-4624cc3f0a41

  on .terraform/modules/eks/cluster.tf line 90, in resource "aws_security_group_rule" "cluster_private_access_cidrs_source":
  90: resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {

```

After proposed fix applied the separate SG rules will be created for each CIDR block in a list resolving the described issue:
```
  # module.eks.aws_security_group_rule.cluster_private_access_cidrs_source will be destroyed
  - resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
      - cidr_blocks       = [
          - "104.145.4.34/32",
        ] -> null
      - description       = "Allow private K8S API ingress from custom CIDR source." -> null
      - from_port         = 443 -> null
      - id                = "sgrule-3690564928" -> null
      - ipv6_cidr_blocks  = [] -> null
      - prefix_list_ids   = [] -> null
      - protocol          = "tcp" -> null
      - security_group_id = "sg-00e1d0309e2738140" -> null
      - self              = false -> null
      - to_port           = 443 -> null
      - type              = "ingress" -> null
    }

  # module.eks.aws_security_group_rule.cluster_private_access_cidrs_source["104.145.4.34/32"] will be created
  + resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
      + cidr_blocks              = [
          + "104.145.4.34/32",
        ]
      + description              = "Allow private K8S API ingress from custom CIDR source."
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-00e1d0309e2738140"
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

  # module.eks.aws_security_group_rule.cluster_private_access_cidrs_source["64.114.102.2/32"] will be created
  + resource "aws_security_group_rule" "cluster_private_access_cidrs_source" {
      + cidr_blocks              = [
          + "64.114.102.2/32",
        ]
      + description              = "Allow private K8S API ingress from custom CIDR source."
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-00e1d0309e2738140"
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }
```
### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
