### PR TITLE
feat: Make the tagging of IAM Policy and Profile optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | A list of subnets to place the EKS cluster and workers within. | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. Tags added to launch configuration or templates override these values for ASG Tags only. | `map(string)` | `{}` | no |
+| <a name="input_tag_iam_policy_and_profile"></a> [tag_iam_policy_and_profile](#input\_tag_iam_policy_and_profile) | Whether to apply the tags to the IAM Policy and Profile created | `bool` | `true` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | A map of timeouts for create/update/delete operations. | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC where the cluster and workers will be deployed. | `string` | n/a | yes |
 | <a name="input_wait_for_cluster_timeout"></a> [wait\_for\_cluster\_timeout](#input\_wait\_for\_cluster\_timeout) | A timeout (in seconds) to wait for cluster to be available. | `number` | `300` | no |

--- a/cluster.tf
+++ b/cluster.tf
@@ -168,7 +168,7 @@ resource "aws_iam_policy" "cluster_elb_sl_role_creation" {
   description = "Permissions for EKS to create AWSServiceRoleForElasticLoadBalancing service-linked role"
   policy      = data.aws_iam_policy_document.cluster_elb_sl_role_creation[0].json
   path        = var.iam_path
-  tags        = var.tags
+  tags        = var.tag_iam_policy_and_profile ? var.tags : null
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_elb_sl_role_creation" {

--- a/variables.tf
+++ b/variables.tf
@@ -418,3 +418,8 @@ variable "openid_connect_audiences" {
   default     = []
 }
 
+variable "tag_iam_policy_and_profile" {
+  description = "Whether to apply the provided tags to the IAM Policy and Profile created"
+  type        = bool
+  default     = true
+}

--- a/workers.tf
+++ b/workers.tf
@@ -479,7 +479,7 @@ resource "aws_iam_instance_profile" "workers" {
   )
 
   path = var.iam_path
-  tags = var.tags
+  tags = var.tag_iam_policy_and_profile ? var.tags : null
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# PR o'clock

## Description

This is to allow the disabling of the tagging of the IAM Policy and Profile created.
This is necessary for those whose IAM user is not allowed to tag these resources - which is typical in enterprise environment.

### Checklist

- [ x ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
