### PR TITLE
feat: Enable throughput & iops configs for managed node_groups

### DIFF
--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -74,9 +74,16 @@ module "eks" {
 
   node_groups = {
     example = {
+      create_launch_template = true
+
       desired_capacity = 1
       max_capacity     = 10
       min_capacity     = 1
+
+      disk_size       = 50
+      disk_type       = "gp3"
+      disk_throughput = 150
+      disk_iops       = 3000
 
       instance_types = ["t3.large"]
       capacity_type  = "SPOT"

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -27,7 +27,9 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | disk\_encrypted | Whether the root disk will be encrypyted. Requires `create_launch_template` to be `true` and `disk_kms_key_id` to be set | bool | false |
 | disk\_kms\_key\_id | KMS Key used to encrypt the root disk. Requires both `create_launch_template` and `disk_encrypted` to be `true` | string | "" |
 | disk\_size | Workers' disk size | number | Provider default behavior |
-| disk\_type | Workers' disk type. Require `create_launch_template` to be `true`| number | `gp3` |
+| disk\_type | Workers' disk type. Require `create_launch_template` to be `true`| string | Provider default behavior |
+| disk\_throughput | Workers' disk throughput. Require `create_launch_template` to be `true` and `disk_type` to be `gp3`| number | Provider default behavior |
+| disk\_iops | Workers' disk IOPS. Require `create_launch_template` to be `true` and `disk_type` to be `gp3`| number | Provider default behavior |
 | ebs\_optimized | Enables/disables EBS optimization. Require `create_launch_template` to be `true` | bool | `true` if defined `instance\_types` are not present in `var.ebs\_optimized\_not\_supported` |
 | enable_monitoring | Enables/disables detailed monitoring. Require `create_launch_template` to be `true`| bool | `true` |
 | eni_delete | Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying) | bool | `true` |

--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -37,6 +37,8 @@ resource "aws_launch_template" "workers" {
     ebs {
       volume_size           = lookup(each.value, "disk_size", null)
       volume_type           = lookup(each.value, "disk_type", null)
+      iops                  = lookup(each.value, "disk_iops", null)
+      throughput            = lookup(each.value, "disk_throughput", null)
       encrypted             = lookup(each.value, "disk_encrypted", null)
       kms_key_id            = lookup(each.value, "disk_kms_key_id", null)
       delete_on_termination = true

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -16,6 +16,8 @@ locals {
       kubelet_extra_args                   = var.workers_group_defaults["kubelet_extra_args"]
       disk_size                            = var.workers_group_defaults["root_volume_size"]
       disk_type                            = var.workers_group_defaults["root_volume_type"]
+      disk_iops                            = var.workers_group_defaults["root_iops"]
+      disk_throughput                      = var.workers_group_defaults["root_volume_throughput"]
       disk_encrypted                       = var.workers_group_defaults["root_encrypted"]
       disk_kms_key_id                      = var.workers_group_defaults["root_kms_key_id"]
       enable_monitoring                    = var.workers_group_defaults["enable_monitoring"]


### PR DESCRIPTION
# PR o'clock

## Description

Fixes: #1567

This PR adds support for setting disk throughput and iops when `create_launch_template` is set to `true` for managed node groups.

Example usage:
```hcl
module "eks" {
  ...

  node_groups = {
    nodes_with_gp3_disks = {
      create_launch_template = true

      disk_size       = 50
      disk_type       = "gp3"
      disk_throughput = 150
      disk_iops       = 3000

      ...

    }
  }
```

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation