### PR TITLE
feat: Ability to specify cluster update timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraf
 | <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | If provided, the EKS cluster will be attached to this security group. If not given, a security group will be created with necessary ingress/egress to work with the workers | `string` | `""` | no |
 | <a name="input_cluster_service_ipv4_cidr"></a> [cluster\_service\_ipv4\_cidr](#input\_cluster\_service\_ipv4\_cidr) | service ipv4 cidr for the kubernetes cluster | `string` | `null` | no |
 | <a name="input_cluster_tags"></a> [cluster\_tags](#input\_cluster\_tags) | A map of tags to add to just the eks resource. | `map(string)` | `{}` | no |
+| <a name="input_cluster_update_timeout"></a> [cluster\_update\_timeout](#input\_cluster\_update\_timeout) | Timeout value when updating the EKS cluster. | `string` | `"60m"` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for the EKS cluster. | `string` | `null` | no |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_create_fargate_pod_execution_role"></a> [create\_fargate\_pod\_execution\_role](#input\_create\_fargate\_pod\_execution\_role) | Controls if the EKS Fargate pod execution IAM role should be created. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ resource "aws_eks_cluster" "this" {
   timeouts {
     create = var.cluster_create_timeout
     delete = var.cluster_delete_timeout
+    update = var.cluster_update_timeout
   }
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -234,6 +234,12 @@ variable "cluster_delete_timeout" {
   default     = "15m"
 }
 
+variable "cluster_update_timeout" {
+  description = "Timeout value when updating the EKS cluster."
+  type        = string
+  default     = "60m"
+}
+
 variable "cluster_create_security_group" {
   description = "Whether to create a security group for the cluster or attach the cluster to `cluster_security_group_id`."
   type        = bool


### PR DESCRIPTION
# PR o'clock

## Description

Our intent is to update our exising EKS cluster with `cluster_encryption_config` as it was introduced here:
- https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-eks-supports-adding-kms-envelope-encryption-to-existing-clusters/?nc1=h_ls
- https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#enable-kms
- https://aws.amazon.com/de/blogs/containers/using-eks-encryption-provider-support-for-defense-in-depth/

Unfortunately updating the cluster with `cluster_encryption_config` consumes more than 1h (at least in euc1).

As a default I used what's default in the resource `aws_eks_cluster`: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#timeouts

### Checklist

- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
