### PR TITLE
feat: optional cpu_credits support added for node_groups submodule

### DIFF
--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -47,6 +47,13 @@ resource "aws_launch_template" "workers" {
 
   instance_type = each.value["set_instance_types_on_lt"] ? element(each.value.instance_types, 0) : null
 
+  dynamic "credit_specification" {
+    for_each = lookup(each.value, "cpu_credits", null) != null ? [""] : []
+    content {
+      cpu_credits = each.value.cpu_credits
+    }
+  }
+
   monitoring {
     enabled = lookup(each.value, "enable_monitoring", null)
   }

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -30,6 +30,7 @@ locals {
       metadata_http_endpoint               = var.workers_group_defaults["metadata_http_endpoint"]
       metadata_http_tokens                 = var.workers_group_defaults["metadata_http_tokens"]
       metadata_http_put_response_hop_limit = var.workers_group_defaults["metadata_http_put_response_hop_limit"]
+      cpu_credits                          = null
     },
     var.node_groups_defaults,
     v,


### PR DESCRIPTION
# PR o'clock

## Description

cpu_credits is not supported for managed node groups with launch_template creation option.
This PR adds this optional support (and only works if any not-null `cpu_credits` value is provided.

Potentially can fix https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1530.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
