### PR TITLE
feat: define fargate pod execution role name

### DIFF
--- a/modules/fargate/main.tf
+++ b/modules/fargate/main.tf
@@ -32,7 +32,8 @@ data "aws_iam_role" "custom_fargate_iam_role" {
 resource "aws_iam_role" "eks_fargate_pod" {
   count = local.create_eks && var.create_fargate_pod_execution_role ? 1 : 0
 
-  name_prefix          = format("%s-fargate", substr(var.cluster_name, 0, 24))
+  name_prefix          = var.fargate_pod_execution_role_name != "" ? null : format("%s-fargate", substr(var.cluster_name, 0, 24))
+  name                 = var.fargate_pod_execution_role_name != "" ? var.fargate_pod_execution_role_name : null
   assume_role_policy   = data.aws_iam_policy_document.eks_fargate_pod_assume_role[0].json
   permissions_boundary = var.permissions_boundary
   tags                 = var.tags


### PR DESCRIPTION
Set a custom name to "fargate pod execution role" if variable `var.fargate_pod_execution_role_name` is defined.

# PR o'clock

## Description

When creating fargate profiles, we can't define the name of `fargate pod execution role` as we can do to other IAM Roles.

### Checklist

- [X] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
