### PR TITLE
fix: Fixed launch_templates_with_managed_node_group example

### DIFF
--- a/examples/launch_templates_with_managed_node_groups/disk_encryption_policy.tf
+++ b/examples/launch_templates_with_managed_node_groups/disk_encryption_policy.tf
@@ -2,6 +2,7 @@
 resource "aws_iam_service_linked_role" "autoscaling" {
   aws_service_name = "autoscaling.amazonaws.com"
   description      = "Default Service-Linked Role enables access to AWS Services and Resources used or managed by Auto Scaling"
+  custom_suffix    = "lt_with_managed_node_groups" # the full name is "AWSServiceRoleForAutoScaling_lt_with_managed_node_groups" < 64 characters
 }
 
 #data "aws_caller_identity" "current" {}

--- a/examples/launch_templates_with_managed_node_groups/launchtemplate.tf
+++ b/examples/launch_templates_with_managed_node_groups/launchtemplate.tf
@@ -37,8 +37,6 @@ resource "aws_launch_template" "default" {
     }
   }
 
-  instance_type = var.instance_type
-
   monitoring {
     enabled = true
   }

--- a/examples/launch_templates_with_managed_node_groups/main.tf
+++ b/examples/launch_templates_with_managed_node_groups/main.tf
@@ -62,6 +62,8 @@ module "eks" {
       launch_template_id      = aws_launch_template.default.id
       launch_template_version = aws_launch_template.default.default_version
 
+      instance_types = var.instance_types
+
       additional_tags = {
         CustomTag = "EKS example"
       }

--- a/examples/launch_templates_with_managed_node_groups/variables.tf
+++ b/examples/launch_templates_with_managed_node_groups/variables.tf
@@ -1,6 +1,6 @@
-variable "instance_type" {
-  description = "Instance type"
+variable "instance_types" {
+  description = "Instance types"
   # Smallest recommended, where ~1.1Gb of 2Gb memory is available for the Kubernetes pods after ‘warming up’ Docker, Kubelet, and OS
-  type    = string
-  default = "t3.small"
+  type    = list(string)
+  default = ["t3.small"]
 }


### PR DESCRIPTION
remove `instance_type` in `aws_launch_template.default` to avoid this error:
```
│ Error: error creating EKS Node Group (test-eks-lt-URZJOIL1:test-eks-lt-URZJOIL1-example2021092307395969650000000f): InvalidRequestException: Cannot specify instance types in launch template and API request
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "bece44af-e7e0-4931-9725-4fb57a7de031"
│   },
│   ClusterName: "test-eks-lt-URZJOIL1",
│   Message_: "Cannot specify instance types in launch template and API request",
│   NodegroupName: "test-eks-lt-URZJOIL1-example2021092307395969650000000f"
│ }
│
│   with module.eks.module.node_groups.aws_eks_node_group.workers["example"],
│   on ../../modules/node_groups/main.tf line 1, in resource "aws_eks_node_group" "workers":
│    1: resource "aws_eks_node_group" "workers" {
```

replace it by `instance_types` in `node_groups` block of `module.eks`

add a `custom_suffix` in `aws_iam_service_linked_role.autoscaling` to avoid conflict like:
```
│ Error: Error creating service-linked role with name autoscaling.amazonaws.com: InvalidInput: Service role name AWSServiceRoleForAutoScaling has been taken in this account, please try a different suffix.
│     status code: 400, request id: e4ad4c1e-ad6e-4544-bed5-f3beeb148d29
│
│   with aws_iam_service_linked_role.autoscaling,
│   on disk_encryption_policy.tf line 2, in resource "aws_iam_service_linked_role" "autoscaling":
│    2: resource "aws_iam_service_linked_role" "autoscaling" {
```

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
