### PR TITLE
docs: Fix broken URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There is also a [complete example](https://github.com/terraform-aws-modules/terr
 
 Root module calls these modules which can also be used separately to create independent resources:
 
-- [fargate](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/fargate) - creates Fargate profiles, see [examples/fargate](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/fargat) for detailed examples.
+- [fargate](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/fargate) - creates Fargate profiles, see [examples/fargate](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/fargate) for detailed examples.
 <!--
 - [node_groups](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/node_groups) - creates Managed Node Group resources
 -->


### PR DESCRIPTION
# PR o'clock

## Description

Fixed typo I've noticed while using the docs.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
