### PR TITLE
feat: add tag 'name' to iam roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_iam_role" "cluster" {
   tags = merge(
     var.tags,
     {
-      "Name" = var.cluster_iam_role_name != "" ? null : "${var.cluster_name}-eks_worker_iam_role"
+      "Name" = var.cluster_iam_role_name != "" ? null : "${var.cluster_name}-eks_cluster_iam_role"
     },
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_iam_role" "cluster" {
   tags = merge(
     var.tags,
     {
-      "Name" = var.cluster_iam_role_name != "" ? null : "${var.cluster_name}-eks_cluster_iam_role"
+      "Name" = var.cluster_iam_role_name != "" ? var.cluster_iam_role_name : var.cluster_name
     },
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,12 @@ resource "aws_iam_role" "cluster" {
   path                  = var.iam_path
   force_detach_policies = true
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.cluster_iam_role_name != "" ? null : "${var.cluster_name}-eks_worker_iam_role"
+    },
+  )
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {

--- a/workers.tf
+++ b/workers.tf
@@ -486,7 +486,7 @@ resource "aws_iam_role" "workers" {
   tags = merge(
     var.tags,
     {
-      "Name" = var.workers_role_name != "" ? null : "${var.cluster_name}-eks_worker_iam_role"
+      "Name" = var.workers_role_name != "" ? var.workers_role_name : local.cluster_name
     },
   )
 }

--- a/workers.tf
+++ b/workers.tf
@@ -483,7 +483,12 @@ resource "aws_iam_role" "workers" {
   path                  = var.iam_path
   force_detach_policies = true
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    {
+      "Name" = var.workers_role_name != "" ? null : "${var.cluster_name}-eks_worker_iam_role"
+    },
+  )
 }
 
 resource "aws_iam_instance_profile" "workers" {


### PR DESCRIPTION
# PR o'clock

## Description

The aws_iam_role does not have a specific tag 'name' and sometimes it can be problematic

I only add a tag name corresponding to the iam_role name

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
