### PR TITLE
fix: assign the provided worker_security_group to node_groups that do…

### DIFF
--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -22,7 +22,7 @@ locals {
       eni_delete                           = var.workers_group_defaults["eni_delete"]
       public_ip                            = var.workers_group_defaults["public_ip"]
       pre_userdata                         = var.workers_group_defaults["pre_userdata"]
-      additional_security_group_ids        = var.workers_group_defaults["additional_security_group_ids"]
+      additional_security_group_ids        = try(v.create_launch_template, false) ? var.workers_group_defaults["additional_security_group_ids"] : concat(var.workers_group_defaults["additional_security_group_ids"], var.worker_security_group_id)
       taints                               = []
       timeouts                             = var.workers_group_defaults["timeouts"]
       update_default_version               = true

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -22,7 +22,7 @@ locals {
       eni_delete                           = var.workers_group_defaults["eni_delete"]
       public_ip                            = var.workers_group_defaults["public_ip"]
       pre_userdata                         = var.workers_group_defaults["pre_userdata"]
-      additional_security_group_ids        = try(v.create_launch_template, false) ? var.workers_group_defaults["additional_security_group_ids"] : concat(var.workers_group_defaults["additional_security_group_ids"], var.worker_security_group_id)
+      additional_security_group_ids        = try(v.create_launch_template, false) && try(v.launch_template_id, null) != null ? var.workers_group_defaults["additional_security_group_ids"] : concat(var.workers_group_defaults["additional_security_group_ids"], var.worker_security_group_id)
       taints                               = []
       timeouts                             = var.workers_group_defaults["timeouts"]
       update_default_version               = true

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -22,7 +22,7 @@ locals {
       eni_delete                           = var.workers_group_defaults["eni_delete"]
       public_ip                            = var.workers_group_defaults["public_ip"]
       pre_userdata                         = var.workers_group_defaults["pre_userdata"]
-      additional_security_group_ids        = try(v.create_launch_template, false) && try(v.launch_template_id, null) != null ? var.workers_group_defaults["additional_security_group_ids"] : concat(var.workers_group_defaults["additional_security_group_ids"], var.worker_security_group_id)
+      additional_security_group_ids        = try(v.create_launch_template, false) || try(v.launch_template_id, null) != null ? var.workers_group_defaults["additional_security_group_ids"] : concat(var.workers_group_defaults["additional_security_group_ids"], var.worker_security_group_id)
       taints                               = []
       timeouts                             = var.workers_group_defaults["timeouts"]
       update_default_version               = true


### PR DESCRIPTION
Should resolve #1616  the missing security group id on eks node_groups when create_launch_template===false and when the node_group does not have a launch_template defined. 

# PR o'clock

## Description

Makes sure that a valid security group_id is assigned to a node_group when created.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
