### PR TITLE
fix: Fixed variable reference for snapshot_id

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -345,7 +345,7 @@ resource "aws_launch_configuration" "workers" {
         local.workers_group_defaults["root_encrypted"],
       )
       snapshot_id = lookup(
-        block_device_mappings.value,
+        ebs_block_device.value,
         "snapshot_id",
         local.workers_group_defaults["snapshot_id"],
       )


### PR DESCRIPTION
# PR o'clock

## Description

https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1431 introduced a new option to set snapshot_id, however the variable it points at in https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1431/files#diff-abc45b07ed4bab6d21313623302e9685703e3b4ad4a981fd57fe91c4c70095edR348 is a copy-paste from https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1431/files#diff-20ed3fefbb3f6838784a6f0bbd11bbef818670a86cab676afefe1bed893f4d3dR528

Changed it to point at the right variable.

This is currently breaking our pipeline with the following error:
```
Error: Reference to undeclared resource on .terraform/modules/eks/workers.tf line 348, in resource "aws_launch_configuration" "workers":
  348:         block_device_mappings.value, 
A managed resource "block_device_mappings" "value" has not been declared in module.eks.
```
Please treat it as a hotfix.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
