### PR TITLE
fix: remove node group aws_eks_cluster data source

### DIFF
--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -14,8 +14,6 @@ data "cloudinit_config" "workers_userdata" {
         ami_id               = lookup(each.value, "ami_id", "")
         ami_is_eks_optimized = each.value["ami_is_eks_optimized"]
         cluster_name         = var.cluster_name
-        cluster_endpoint     = data.aws_eks_cluster.default[0].endpoint
-        cluster_ca           = data.aws_eks_cluster.default[0].certificate_authority[0].data
         capacity_type        = lookup(each.value, "capacity_type", "ON_DEMAND")
         append_labels        = length(lookup(each.value, "k8s_labels", {})) > 0 ? ",${join(",", [for k, v in lookup(each.value, "k8s_labels", {}) : "${k}=${v}"])}" : ""
       }

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -1,9 +1,3 @@
-data "aws_eks_cluster" "default" {
-  count = var.create_eks ? 1 : 0
-
-  name = var.cluster_name
-}
-
 locals {
   # Merge defaults and per-group values to make code cleaner
   node_groups_expanded = { for k, v in var.node_groups : k => merge(

--- a/modules/node_groups/templates/userdata.sh.tpl
+++ b/modules/node_groups/templates/userdata.sh.tpl
@@ -6,8 +6,6 @@ sed -i '/^KUBELET_EXTRA_ARGS=/a KUBELET_EXTRA_ARGS+=" ${kubelet_extra_args}"' /e
 %{else ~}
 
 # Set variables for custom AMI
-API_SERVER_URL=${cluster_endpoint}
-B64_CLUSTER_CA=${cluster_ca}
 KUBELET_EXTRA_ARGS='--node-labels=eks.amazonaws.com/nodegroup-image=${ami_id},eks.amazonaws.com/capacityType=${capacity_type}${append_labels} ${kubelet_extra_args}'
 %{endif ~}
 
@@ -16,5 +14,5 @@ ${pre_userdata}
 %{ if length(ami_id) > 0 && ami_is_eks_optimized ~}
 
 # Call bootstrap for EKS optimised custom AMI
-/etc/eks/bootstrap.sh ${cluster_name} --apiserver-endpoint "$${API_SERVER_URL}" --b64-cluster-ca "$${B64_CLUSTER_CA}" --kubelet-extra-args "$${KUBELET_EXTRA_ARGS}"
+/etc/eks/bootstrap.sh ${cluster_name} --kubelet-extra-args "$${KUBELET_EXTRA_ARGS}"
 %{ endif ~}


### PR DESCRIPTION
# PR o'clock

## Description

closes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1635

Seems bootstrap.sh script is able to auto get certificate and endpoint info using aws cli. In that case we dont need this code which is causing a issue


### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
