### PR TITLE
fix: MNG cluster datasource errors

### DIFF
--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -84,13 +84,14 @@ No modules.
 |------|------|
 | [aws_eks_node_group.workers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group) | resource |
 | [aws_launch_template.workers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
-| [aws_eks_cluster.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [cloudinit_config.workers_userdata](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cluster_auth_base64"></a> [cluster\_auth\_base64](#input\_cluster\_auth\_base64) | Base64 encoded CA of parent cluster | `string` | `""` | no |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint of parent cluster | `string` | `""` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of parent cluster | `string` | `""` | no |
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_default_iam_role_arn"></a> [default\_iam\_role\_arn](#input\_default\_iam\_role\_arn) | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | `""` | no |

--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -14,8 +14,8 @@ data "cloudinit_config" "workers_userdata" {
         ami_id               = lookup(each.value, "ami_id", "")
         ami_is_eks_optimized = each.value["ami_is_eks_optimized"]
         cluster_name         = var.cluster_name
-        cluster_endpoint     = data.aws_eks_cluster.default[0].endpoint
-        cluster_ca           = data.aws_eks_cluster.default[0].certificate_authority[0].data
+        cluster_endpoint     = var.cluster_endpoint
+        cluster_auth_base64  = var.cluster_auth_base64
         capacity_type        = lookup(each.value, "capacity_type", "ON_DEMAND")
         append_labels        = length(lookup(each.value, "k8s_labels", {})) > 0 ? ",${join(",", [for k, v in lookup(each.value, "k8s_labels", {}) : "${k}=${v}"])}" : ""
       }

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -1,9 +1,3 @@
-data "aws_eks_cluster" "default" {
-  count = var.create_eks ? 1 : 0
-
-  name = var.cluster_name
-}
-
 locals {
   # Merge defaults and per-group values to make code cleaner
   node_groups_expanded = { for k, v in var.node_groups : k => merge(

--- a/modules/node_groups/templates/userdata.sh.tpl
+++ b/modules/node_groups/templates/userdata.sh.tpl
@@ -7,7 +7,7 @@ sed -i '/^KUBELET_EXTRA_ARGS=/a KUBELET_EXTRA_ARGS+=" ${kubelet_extra_args}"' /e
 
 # Set variables for custom AMI
 API_SERVER_URL=${cluster_endpoint}
-B64_CLUSTER_CA=${cluster_ca}
+B64_CLUSTER_CA=${cluster_auth_base64}
 KUBELET_EXTRA_ARGS='--node-labels=eks.amazonaws.com/nodegroup-image=${ami_id},eks.amazonaws.com/capacityType=${capacity_type}${append_labels} ${kubelet_extra_args}'
 %{endif ~}
 

--- a/modules/node_groups/variables.tf
+++ b/modules/node_groups/variables.tf
@@ -10,6 +10,18 @@ variable "cluster_name" {
   default     = ""
 }
 
+variable "cluster_endpoint" {
+  description = "Endpoint of parent cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_auth_base64" {
+  description = "Base64 encoded CA of parent cluster"
+  type        = string
+  default     = ""
+}
+
 variable "default_iam_role_arn" {
   description = "ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults`"
   type        = string

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -3,7 +3,10 @@ module "node_groups" {
 
   create_eks = var.create_eks
 
-  cluster_name                         = local.cluster_name
+  cluster_name        = local.cluster_name
+  cluster_endpoint    = local.cluster_endpoint
+  cluster_auth_base64 = local.cluster_auth_base64
+
   default_iam_role_arn                 = coalescelist(aws_iam_role.workers[*].arn, [""])[0]
   ebs_optimized_not_supported          = local.ebs_optimized_not_supported
   workers_group_defaults               = local.workers_group_defaults


### PR DESCRIPTION
# PR o'clock

## Description

This PR replaces the cluster lookup data source in the _node_groups_ module with variables being passed in.

Apologies for the issues with the current implementation, I'm still unsure as to why it fails when it does. With hindsight and re-reading the existing module code this implementation is a better fit.

Fixes #1635.
Closes #1636.
Closes #1638.

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
