### PR TITLE
Output a generated aws-auth configmap

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,6 +37,35 @@ output "config_map_aws_auth" {
   value       = kubernetes_config_map.aws_auth.*
 }
 
+output "config_map_aws_auth_generated" {
+  description = "The generated aws-auth ConfigMap"
+  value = {
+    metadata = {
+      name      = "aws-auth"
+      namespace = "kube-system"
+      labels = merge(
+        {
+          "app.kubernetes.io/managed-by" = "Terraform"
+          # / are replaced by . because label validator fails in this lib
+          # https://github.com/kubernetes/apimachinery/blob/1bdd76d09076d4dc0362456e59c8f551f5f24a72/pkg/util/validation/validation.go#L166
+          "terraform.io/module" = "terraform-aws-modules.eks.aws"
+        },
+        var.aws_auth_additional_labels
+      )
+    },
+    data = {
+      mapRoles = yamlencode(
+        distinct(concat(
+          local.configmap_roles,
+          var.map_roles,
+        ))
+      )
+      mapUsers    = yamlencode(var.map_users)
+      mapAccounts = yamlencode(var.map_accounts)
+    },
+  }
+}
+
 output "cluster_iam_role_name" {
   description = "IAM role name of the EKS cluster."
   value       = local.cluster_iam_role_name


### PR DESCRIPTION
A user of this module can subsequently use this ConfigMap output
as they wish, in their own module, like so:

```
resource "kubernetes_config_map" "aws_auth" {

  metadata {
    name      = module.eks.config_map_aws_auth_yaml.metadata.name
    namespace = module.eks.config_map_aws_auth_yaml.metadata.namespace
    labels    = module.eks.config_map_aws_auth_yaml.metadata.labels
  }

  data = module.eks.config_map_aws_auth_yaml.data
}
```

This should help with issue https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1280

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
