### PR TITLE
feat: Removed ng_depends_on variable and related hack

### DIFF
--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -97,7 +97,6 @@ No modules.
 | <a name="input_create_eks"></a> [create\_eks](#input\_create\_eks) | Controls if EKS resources should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_default_iam_role_arn"></a> [default\_iam\_role\_arn](#input\_default\_iam\_role\_arn) | ARN of the default IAM worker role to use if one is not specified in `var.node_groups` or `var.node_groups_defaults` | `string` | `""` | no |
 | <a name="input_ebs_optimized_not_supported"></a> [ebs\_optimized\_not\_supported](#input\_ebs\_optimized\_not\_supported) | List of instance types that do not support EBS optimization | `list(string)` | `[]` | no |
-| <a name="input_ng_depends_on"></a> [ng\_depends\_on](#input\_ng\_depends\_on) | List of references to other resources this submodule depends on | `any` | `null` | no |
 | <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Map of maps of `eks_node_groups` to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | `{}` | no |
 | <a name="input_node_groups_defaults"></a> [node\_groups\_defaults](#input\_node\_groups\_defaults) | map of maps of node groups to create. See "`node_groups` and `node_groups_defaults` keys" section in README.md for more details | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/node_groups/main.tf
+++ b/modules/node_groups/main.tf
@@ -102,5 +102,4 @@ resource "aws_eks_node_group" "workers" {
     ignore_changes        = [scaling_config[0].desired_size]
   }
 
-  depends_on = [var.ng_depends_on]
 }

--- a/modules/node_groups/variables.tf
+++ b/modules/node_groups/variables.tf
@@ -64,14 +64,6 @@ variable "node_groups" {
   default     = {}
 }
 
-# Hack for a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
-# Will be removed in Terraform 0.13 with the support of module's `depends_on` https://github.com/hashicorp/terraform/issues/10462
-variable "ng_depends_on" {
-  description = "List of references to other resources this submodule depends on"
-  type        = any
-  default     = null
-}
-
 variable "ebs_optimized_not_supported" {
   description = "List of instance types that do not support EBS optimization"
   type        = list(string)

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -18,14 +18,8 @@ module "node_groups" {
 
   tags = var.tags
 
-  # Hack to ensure ordering of resource creation.
-  # This is a homemade `depends_on` https://discuss.hashicorp.com/t/tips-howto-implement-module-depends-on-emulation/2305/2
-  # Do not create node_groups before other resources are ready and removes race conditions
-  # Ensure these resources are created before "unlocking" the data source.
-  # Will be removed in Terraform 0.13
-  ng_depends_on = [
+  depends_on = [
     aws_eks_cluster.this,
-    kubernetes_config_map.aws_auth,
     aws_iam_role_policy_attachment.workers_AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.workers_AmazonEKS_CNI_Policy,
     aws_iam_role_policy_attachment.workers_AmazonEC2ContainerRegistryReadOnly


### PR DESCRIPTION
# PR o'clock

## Description

removing legacies related to pre terraform 0.13 hack dependencies between modules. I have tested 2 examples in following combination:
1. apply from scratch
2. modify config and reapply
3. destroy example

in each case it was working without issues. Also this is transparent change to existing clusters (just refresh on state is happening)

resolves #1574

### Checklist

- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
