### PR TITLE
 improvement: Added variable for not hardcoding root device name in aws node group

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ There are detailed examples available for you to see how certain features of thi
 - [Complete](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/complete) - Create EKS Cluster with all available workers types in various combinations with many of supported features.
 - [Bottlerocket](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/bottlerocket) - Create EKS cluster using [Bottlerocket AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami-bottlerocket.html).
 - [Fargate](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/fargate) - Create EKS cluster with [Fargate profiles](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) and attach Fargate profiles to an existing EKS cluster.
-  
+
 ## Contributing
 
 Report issues/questions/feature requests on in the [issues](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/new) section.

--- a/locals.tf
+++ b/locals.tf
@@ -50,6 +50,7 @@ locals {
     instance_store_virtual_name       = "ephemeral0"                # "virtual_name" of the instance store volume.
     spot_price                        = ""                          # Cost of spot instance.
     placement_tenancy                 = ""                          # The tenancy of the instance. Valid values are "default" or "dedicated".
+    root_device_name                  = "/dev/xvda"                 # NOTE: Used only in aws managed node group, name of root block device of worker instances.
     root_volume_size                  = "100"                       # root volume size of workers instances.
     root_volume_type                  = "gp2"                       # root volume type of workers instances, can be "standard", "gp3", "gp2", or "io1"
     root_iops                         = "0"                         # The amount of provisioned IOPS. This must be set with a volume_type of "io1".

--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -38,7 +38,7 @@ resource "aws_launch_template" "workers" {
   update_default_version = lookup(each.value, "update_default_version", true)
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = lookup(each.value, "disk_device_name", null)
 
     ebs {
       volume_size           = lookup(each.value, "disk_size", null)

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -15,6 +15,7 @@ locals {
       create_launch_template               = false
       bootstrap_env                        = {}
       kubelet_extra_args                   = var.workers_group_defaults["kubelet_extra_args"]
+      disk_device_name                     = var.workers_group_defaults["root_device_name"]
       disk_size                            = var.workers_group_defaults["root_volume_size"]
       disk_type                            = var.workers_group_defaults["root_volume_type"]
       disk_iops                            = var.workers_group_defaults["root_iops"]


### PR DESCRIPTION
# PR o'clock

## Description

Due to hardcoded device_name https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/node_groups/launch_template.tf#L41. it's not possible to extend root block device.
### Checklist

- [*] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
