### PR TITLE
chore: change default aws authenticator command to aws eks get-token instead of aws-iam-authenticator

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -2,6 +2,8 @@ data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 data "aws_iam_policy_document" "workers_assume_role_policy" {
   statement {
     sid = "EKSWorkerAssumeRole"

--- a/locals.tf
+++ b/locals.tf
@@ -162,13 +162,22 @@ locals {
     "t2.xlarge"
   ]
 
+  default_kubeconfig_aws_authenticator_command_args = [
+    "eks",
+    "get-token",
+    "--cluster-name",
+    local.cluster_name,
+    "--region",
+    data.aws_region.current.name
+  ]
+
   kubeconfig = var.create_eks ? templatefile("${path.module}/templates/kubeconfig.tpl", {
     kubeconfig_name                         = coalesce(var.kubeconfig_name, "eks_${var.cluster_name}")
     endpoint                                = local.cluster_endpoint
     cluster_auth_base64                     = local.cluster_auth_base64
     aws_authenticator_kubeconfig_apiversion = var.kubeconfig_api_version
     aws_authenticator_command               = var.kubeconfig_aws_authenticator_command
-    aws_authenticator_command_args          = coalescelist(var.kubeconfig_aws_authenticator_command_args, ["token", "-i", local.cluster_name])
+    aws_authenticator_command_args          = coalescelist(var.kubeconfig_aws_authenticator_command_args, local.default_kubeconfig_aws_authenticator_command_args)
     aws_authenticator_additional_args       = var.kubeconfig_aws_authenticator_additional_args
     aws_authenticator_env_variables         = var.kubeconfig_aws_authenticator_env_variables
   }) : ""

--- a/variables.tf
+++ b/variables.tf
@@ -200,17 +200,17 @@ variable "kubeconfig_api_version" {
 variable "kubeconfig_aws_authenticator_command" {
   description = "Command to use to fetch AWS EKS credentials."
   type        = string
-  default     = "aws-iam-authenticator"
+  default     = "aws"
 }
 
 variable "kubeconfig_aws_authenticator_command_args" {
-  description = "Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name]."
+  description = "Default arguments passed to the authenticator command. Defaults to [\"eks\", \"get-token\", \"--cluster-name\", --$cluster-name, \"--region\", --$region]."
   type        = list(string)
   default     = []
 }
 
 variable "kubeconfig_aws_authenticator_additional_args" {
-  description = "Any additional arguments to pass to the authenticator such as the role to assume. e.g. [\"-r\", \"MyEksRole\"]."
+  description = "Any additional arguments to pass to the authenticator such as the role to assume. e.g. [\"--role-arn\", \"arn:aws:iam::012345678910:role/MyEksRole\"]."
   type        = list(string)
   default     = []
 }
@@ -433,4 +433,3 @@ variable "openid_connect_audiences" {
   type        = list(string)
   default     = []
 }
-


### PR DESCRIPTION
## Description
This PR changes default aws authenticator command to `aws eks get-token` instead of `aws-iam-authenticator` since it's already deprecated. Fixes #957.

The next step is to drop `aws-iam-authenticator` support from the terraform-aws-eks module.

## Motivation and Context
Fixes #957.

## Breaking Changes
No breaking changes here, just kubconfig file updates.

## How Has This Been Tested?
EKS cluster was deployed from the master branch and updated with the suggested changes successfully.
Pre-commit hook was run.

