### PR TITLE
Allow setting instance weights for autoscaling

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -103,6 +103,7 @@ locals {
     metadata_http_put_response_hop_limit = null       # The desired HTTP PUT response hop limit for instance metadata requests.
     # Settings for launch templates with mixed instances policy
     override_instance_types                  = ["m5.large", "m5a.large", "m5d.large", "m5ad.large"] # A list of override instance types for mixed instances policy
+    instance_type_weights                    = {}                                                   # A map of instance types to their respective weights. You can use this to make a 2xlarge instance provide 2 instances while an xlarge instance only provides 1. If omitted, 1 will be used.
     on_demand_allocation_strategy            = null                                                 # Strategy to use when launching on-demand instances. Valid values: prioritized.
     on_demand_base_capacity                  = "0"                                                  # Absolute minimum amount of desired capacity that must be fulfilled by on-demand instances
     on_demand_percentage_above_base_capacity = "0"                                                  # Percentage split between on-demand and Spot instances above the base on-demand capacity

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -167,7 +167,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
           )
 
           content {
-            instance_type = override.value
+            instance_type     = override.value
             weighted_capacity = tostring(lookup(lookup(var.worker_groups_launch_template[count.index], "instance_type_weights", {}), override.value, "1"))
           }
         }

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -105,7 +105,9 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
   dynamic "mixed_instances_policy" {
     iterator = item
-    for_each = (lookup(var.worker_groups_launch_template[count.index], "override_instance_types", null) != null) || (lookup(var.worker_groups_launch_template[count.index], "on_demand_allocation_strategy", local.workers_group_defaults["on_demand_allocation_strategy"]) != null) ? [var.worker_groups_launch_template[count.index]] : []
+    for_each = (
+      lookup(var.worker_groups_launch_template[count.index], "override_instance_types", null) != null)
+      || (lookup(var.worker_groups_launch_template[count.index], "on_demand_allocation_strategy", local.workers_group_defaults["on_demand_allocation_strategy"]) != null) ? [var.worker_groups_launch_template[count.index]] : []
 
     content {
       instances_distribution {
@@ -166,6 +168,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
           content {
             instance_type = override.value
+            weighted_capacity = tostring(lookup(lookup(var.worker_groups_launch_template[count.index], "instance_type_weights", {}), override.value, "1"))
           }
         }
       }

--- a/workers_launch_template.tf
+++ b/workers_launch_template.tf
@@ -105,9 +105,7 @@ resource "aws_autoscaling_group" "workers_launch_template" {
 
   dynamic "mixed_instances_policy" {
     iterator = item
-    for_each = (
-      lookup(var.worker_groups_launch_template[count.index], "override_instance_types", null) != null)
-      || (lookup(var.worker_groups_launch_template[count.index], "on_demand_allocation_strategy", local.workers_group_defaults["on_demand_allocation_strategy"]) != null) ? [var.worker_groups_launch_template[count.index]] : []
+    for_each = (lookup(var.worker_groups_launch_template[count.index], "override_instance_types", null) != null) || (lookup(var.worker_groups_launch_template[count.index], "on_demand_allocation_strategy", local.workers_group_defaults["on_demand_allocation_strategy"]) != null) ? [var.worker_groups_launch_template[count.index]] : []
 
     content {
       instances_distribution {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allow users to set weighted_capacity on autoscaling groups created by this module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When autoscaling Kubernetes clusters, you usually have a cost or CPU limit in mind instead of a simple instance limit.
AWS allows this by assigning an arbitrary value to instance types (for example xlarge = 1, 2xlarge = 2, 4xlarge = 4).
This was however not possible using this module.

This also fixes #1302 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking change included

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
