### PR TITLE
feat: Add ability for tagging AWS-generated ASGs when using managed node groups

### DIFF
--- a/examples/managed_node_groups/main.tf
+++ b/examples/managed_node_groups/main.tf
@@ -42,6 +42,9 @@ module "eks" {
         GithubRepo = "terraform-aws-eks"
         GithubOrg  = "terraform-aws-modules"
       }
+      asg_tags = {
+        "k8s.io/cluster-autoscaler/node-template/label/monitoring" = true
+      }
       additional_tags = {
         ExtraTag = "example"
       }

--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -20,6 +20,8 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | ami\_type | AMI Type. See Terraform or AWS docs | string | Provider default behavior |
 | ami\_id | ID of custom AMI. If you use a custom AMI, you need to set `ami_is_eks_optimized` | string | Provider default behavior |
 | ami\_is\_eks\_optimized | If the custom AMI is an EKS optimised image, ignored if `ami_id` is not set. If this is `true` then `bootstrap.sh` is called automatically (max pod logic needs to be manually set), if this is `false` you need to provide all the node configuration in `pre_userdata` | bool | `true` |
+| asg\_tags | Tags to be added to the autoscaling group that is generated automatically by AWS as part of the managed node group creation | map(string) |
+| asg\_tags\_propagate\_at\_launch | Controls whether or not the tags defined in `asg_tags` will be propagated to the instances generated from the autoscaling group | bool |
 | capacity\_type | Type of instance capacity to provision. Options are `ON_DEMAND` and `SPOT` | string | Provider default behavior |
 | create_launch_template | Create and use a default launch template | bool |  `false` |
 | desired\_capacity | Desired number of workers | number | `var.workers_group_defaults[asg_desired_capacity]` |

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -48,4 +48,17 @@ locals {
       join("-", [var.cluster_name, k])
     )
   ) }
+
+  asg_tag_list = flatten([
+    for name, info in aws_eks_node_group.workers : [
+      [
+        for key, value in lookup(local.node_groups_expanded[name], "asg_tags", []) : {
+          asg_name  = info.resources[0].autoscaling_groups[0].name
+          key       = key
+          propagate = try(local.node_groups_expanded[name].asg_tags_propagate_at_launch, false)
+          value     = value
+        }
+      ]
+    ]
+  ])
 }

--- a/modules/node_groups/main.tf
+++ b/modules/node_groups/main.tf
@@ -103,3 +103,14 @@ resource "aws_eks_node_group" "workers" {
   }
 
 }
+
+resource "aws_autoscaling_group_tag" "tag" {
+  for_each = { for map in local.asg_tag_list : "${map.asg_name}_${map.key}" => map if length(local.asg_tag_list) > 0 }
+
+  autoscaling_group_name = replace(each.key, "_${each.value.key}", "")
+  tag {
+    key                 = each.value.key
+    value               = each.value.value
+    propagate_at_launch = each.value.propagate
+  }
+}


### PR DESCRIPTION
## Description
- Add ability for tagging AWS generated autoscaling groups when using managed node groups

## Motivation and Context
- This change comes from the personal need of having the asg tagged in a certain way for allowing cluster-autoscaler to increase managed node groups when they are set initially to 0. However, this change also allows to tag the asgs in any other required case.

## Breaking Changes
None as the module behaves the same when not using this functionality.

## How Has This Been Tested?
- ✅ I have tested and validate these changes by using this module with the proposed changes over my AWS account from a personal Terraform project. 

