### PR TITLE
Accurate description for workers_additional_policies

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "worker_sg_ingress_from_port" {
 }
 
 variable "workers_additional_policies" {
-  description = "Additional policies to be added to workers"
+  description = "List of additional policy ARNs to be added to the default worker/managed node role"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION


## Description
* Description should mention it is a list of ARNs
* It seems that `workers_additional_policies` are also effective for managed nodes (needs confirmation)
* When you pass a custom role for your worker/managed node, it seems that the additional policies are overridden (needs confirmation)

## Motivation and Context
I think the description is not precise.

## Breaking Changes
None.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
Haven't tested.