### PR TITLE
improvement: match block_device_mappings with workers_launch_template in node group 

### DIFF
--- a/modules/node_groups/README.md
+++ b/modules/node_groups/README.md
@@ -29,6 +29,10 @@ The role ARN specified in `var.default_iam_role_arn` will be used by default. In
 | disk\_type | Workers' disk type. Require `create_launch_template` to be `true`| string | Provider default behavior |
 | disk\_throughput | Workers' disk throughput. Require `create_launch_template` to be `true` and `disk_type` to be `gp3`| number | Provider default behavior |
 | disk\_iops | Workers' disk IOPS. Require `create_launch_template` to be `true` and `disk_type` to be `gp3`| number | Provider default behavior |
+| delete\_on\_termination | Whether the volume should be destroyed on instance termination | bool | true |
+| additional\_ebs\_volumes | A list of additional volumes to be attached to the instances on this Auto Scaling group. Each volume should be an object with the following: `block_device_name` (required), `disk_size`, `disk_type`, `disk_iops`, `disk_throughput`, `disk_encrypted`, `disk_kms_key_id` (only on launch-template), `delete_on_termination`, `snapshot_id`. Optional values are grabbed from root volume | list(map) | [] |
+| additional\_instance\_store\_volumes | A list of additional instance store (local disk) volumes to be attached to the instances on this Auto Scaling group. Each volume should be an object with the following: `block_device_name` (required), `virtual_name` | list(map) | [] |
+| instance\_store\_virtual\_name | `virtual_name` of the instance store volume | sring | `ephemeral0` |
 | ebs\_optimized | Enables/disables EBS optimization. Require `create_launch_template` to be `true` | bool | `true` if defined `instance\_types` are not present in `var.ebs\_optimized\_not\_supported` |
 | enable_monitoring | Enables/disables detailed monitoring. Require `create_launch_template` to be `true`| bool | `true` |
 | eni_delete | Delete the Elastic Network Interface (ENI) on termination (if set to false you will have to manually delete before destroying) | bool | `true` |

--- a/modules/node_groups/launch_template.tf
+++ b/modules/node_groups/launch_template.tf
@@ -38,7 +38,7 @@ resource "aws_launch_template" "workers" {
   update_default_version = lookup(each.value, "update_default_version", true)
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = lookup(each.value, "root_block_device_name", null)
 
     ebs {
       volume_size           = lookup(each.value, "disk_size", null)
@@ -47,7 +47,97 @@ resource "aws_launch_template" "workers" {
       throughput            = lookup(each.value, "disk_throughput", null)
       encrypted             = lookup(each.value, "disk_encrypted", null)
       kms_key_id            = lookup(each.value, "disk_kms_key_id", null)
-      delete_on_termination = true
+      delete_on_termination = lookup(each.value, "delete_on_termination", true)
+    }
+  }
+
+  dynamic "block_device_mappings" {
+    for_each = lookup(each.value, "additional_ebs_volumes", null)
+    content {
+      device_name = block_device_mappings.value.block_device_name
+
+      ebs {
+        volume_size = lookup(
+          block_device_mappings.value,
+          "disk_size",
+          lookup(
+            each.value,
+            "disk_size",
+            null,
+          ),
+        )
+        volume_type = lookup(
+          block_device_mappings.value,
+          "disk_type",
+          lookup(
+            each.value,
+            "disk_type",
+            null,
+          ),
+        )
+        iops = lookup(
+          block_device_mappings.value,
+          "disk_iops",
+          lookup(
+            each.value,
+            "disk_iops",
+            null,
+          ),
+        )
+        throughput = lookup(
+          block_device_mappings.value,
+          "disk_throughput",
+          lookup(
+            each.value,
+            "disk_throughput",
+            null,
+          ),
+        )
+        encrypted = lookup(
+          block_device_mappings.value,
+          "disk_encrypted",
+          lookup(
+            each.value,
+            "disk_encrypted",
+            null,
+          ),
+        )
+        kms_key_id = lookup(
+          block_device_mappings.value,
+          "disk_kms_key_id",
+          lookup(
+            each.value,
+            "disk_kms_key_id",
+            null,
+          ),
+        )
+        snapshot_id = lookup(
+          block_device_mappings.value,
+          "snapshot_id",
+          null,
+        )
+        delete_on_termination = lookup(
+          block_device_mappings.value,
+          "delete_on_termination",
+          true,
+        )
+      }
+    }
+  }
+
+  dynamic "block_device_mappings" {
+    for_each = lookup(each.value, "additional_instance_store_volumes", null)
+    content {
+      device_name  = block_device_mappings.value.block_device_name
+      virtual_name = lookup(
+        block_device_mappings.value,
+        "virtual_name",
+        lookup(
+          each.value,
+          "instance_store_virtual_name",
+          null,
+        ),
+      )
     }
   }
 

--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -15,12 +15,17 @@ locals {
       create_launch_template               = false
       bootstrap_env                        = {}
       kubelet_extra_args                   = var.workers_group_defaults["kubelet_extra_args"]
+      root_block_device_name               = var.workers_group_defaults["root_block_device_name"]
       disk_size                            = var.workers_group_defaults["root_volume_size"]
       disk_type                            = var.workers_group_defaults["root_volume_type"]
       disk_iops                            = var.workers_group_defaults["root_iops"]
       disk_throughput                      = var.workers_group_defaults["root_volume_throughput"]
       disk_encrypted                       = var.workers_group_defaults["root_encrypted"]
       disk_kms_key_id                      = var.workers_group_defaults["root_kms_key_id"]
+      delete_on_termination                = true
+      additional_ebs_volumes               = []
+      additional_instance_store_volumes    = []
+      instance_store_virtual_name          = var.workers_group_defaults["instance_store_virtual_name"]
       enable_monitoring                    = var.workers_group_defaults["enable_monitoring"]
       eni_delete                           = var.workers_group_defaults["eni_delete"]
       public_ip                            = var.workers_group_defaults["public_ip"]


### PR DESCRIPTION
## Description
In https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/workers_launch_template.tf, the module support `root_block_device_name ` as variable, and also added support for `additional_ebs_volumes` and `additional_instance_store_volumes`, It will be nice if we can match the same flexibility as we support node groups as now we are supporting custom AMI image. 

## Motivation and Context
It starts with issue fix: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1714.  Thought why don't we want to do more

## Breaking Changes
N/A

## How Has This Been Tested?
We have a batch version fixed the issue(https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1714) deployed in our prod account.
for `additional_ebs_volumes`, `additional_instance_store_volumes`, we don't have any usage yet, we only did `terraform plan` for test scenario. 
