### PR TITLE
fix: Not to iterate over remote_access object in dynamic block

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -173,6 +173,10 @@ module "eks" {
         }
       ]
 
+      remote_access = {
+        ec2_ssh_key = "my-ssh-key"
+      }
+
       update_config = {
         max_unavailable_percentage = 50 # or set `max_unavailable`
       }

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -295,10 +295,10 @@ resource "aws_eks_node_group" "this" {
   }
 
   dynamic "remote_access" {
-    for_each = var.remote_access
+    for_each = length(var.remote_access) > 0 ? [var.remote_access] : []
     content {
-      ec2_ssh_key               = lookup(remote_access.value, "ec2_ssh_key", null)
-      source_security_group_ids = lookup(remote_access.value, "source_security_group_ids", [])
+      ec2_ssh_key               = try(remote_access.value.ec2_ssh_key, null)
+      source_security_group_ids = try(remote_access.value.source_security_group_ids, [])
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently if user specifies `remote_access` in `eks_managed_node_groups`, terraform will throw an error since we iterate the `remote_access` object directly, which is not expected.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
