### PR TITLE
fix: Use the prefix_seperator var for node sg prefix

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -106,7 +106,7 @@ resource "aws_security_group" "node" {
   count = local.create_node_sg ? 1 : 0
 
   name        = var.node_security_group_use_name_prefix ? null : local.node_sg_name
-  name_prefix = var.node_security_group_use_name_prefix ? "${local.node_sg_name}-" : null
+  name_prefix = var.node_security_group_use_name_prefix ? "${local.node_sg_name}${var.prefix_separator}" : null
   description = var.node_security_group_description
   vpc_id      = var.vpc_id
 


### PR DESCRIPTION
## Description
Use var.prefix_separator for the node security group prefix like in the cluster security group prefix

## Motivation and Context
so it is consistent with the cluster security group
## Breaking Changes
no
## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
