### PR TITLE
fix: Set default cluster sg description eq 17.24

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -154,7 +154,7 @@ variable "cluster_security_group_use_name_prefix" {
 variable "cluster_security_group_description" {
   description = "Description of the cluster security group created"
   type        = string
-  default     = "EKS cluster security group"
+  default     = "EKS cluster security group."
 }
 
 variable "cluster_security_group_additional_rules" {


### PR DESCRIPTION
## Description
Set the default value of the cluster security group description eq to the default value of 17.24

## Motivation and Context
a change in the description of the cluster security group forces recreation of the security group as well as the eks cluster
as a change of the cluster security group triggers the replacement of the eks cluster
#1744 
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
