### PR TITLE
fix: Use split function to allow setting multiple source security group ids for remote_access

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -298,7 +298,7 @@ resource "aws_eks_node_group" "this" {
     for_each = length(var.remote_access) > 0 ? [var.remote_access] : []
     content {
       ec2_ssh_key               = try(remote_access.value.ec2_ssh_key, null)
-      source_security_group_ids = try(remote_access.value.source_security_group_ids, [])
+      source_security_group_ids = try(split(",", remote_access.value.source_security_group_ids), [])
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Creating a new managed node group in EKS using the `eks-managed-node-group` submodule when remote_access.{ec2_ssh_key, source_security_group_ids} values are set, fails with following error.

```
Error: Incorrect attribute value type

  on .terraform/modules/eks_devops_dev.eks_node_group.eks_managed_node_group/modules/eks-managed-node-group/main.tf line 301, in resource "aws_eks_node_group" "this":
 301:       source_security_group_ids = try(remote_access.value.source_security_group_ids, []) 

Inappropriate value for attribute "source_security_group_ids": set of string
required.
```

Based on AWS API documentation [here](https://docs.aws.amazon.com/eks/latest/APIReference/API_RemoteAccessConfig.html) and eks_node_group documentation using Terraform AWS provider [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#remote_access-configuration-block), `remote_access.source_security_group_ids` should be a set of security group IDs. Although, `remote_access` defined in [variables.tf](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/eks-managed-node-group/variables.tf#L335) type map(string) which only allows managing source_security_group_ids as a string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Managing `remote_access` as type map(string) is probably fine, we can define multiple security group IDs with values in comma separated string as below. Change added as part of pull request simply splits the string to a set of string IDs that gets assigned as required to `eks_node_group` resource.

```
  remote_access = {
     ec2_ssh_key = "ec2-ssh-key"
     source_security_group_ids = "security-group-id-1,security-group-id-2"
  }
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No, this fixes an issue with setting source_security_group_ids as part of remote_access map.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Produces output for remote_access block as,

```
+ remote_access {
          + ec2_ssh_key               = "ec2-ssh-key"
          + source_security_group_ids = [
              + "security-group-id-1",
              + "security-group-id-2",
            ]
```
