### PR TITLE
fix: truncate iam_role_name to 38 characters

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -389,7 +389,7 @@ resource "aws_security_group_rule" "this" {
 ################################################################################
 
 locals {
-  iam_role_name     = coalesce(var.iam_role_name, "${var.name}-eks-node-group")
+  iam_role_name     = coalesce(var.iam_role_name, "${substr(var.name, 0, 21)}-eks-node-group")
   policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
 }
 


### PR DESCRIPTION
IAM roles name can't be longer than 38 characters so we have to truncate it.
