### PR TITLE
chore: Update user data docs to correct mistake of showing `bootstrap_extra_args` when prepending user data (default AMI)

### DIFF
--- a/examples/user_data/main.tf
+++ b/examples/user_data/main.tf
@@ -34,11 +34,11 @@ module "eks_mng_linux_custom_ami" {
   enable_bootstrap_user_data = true
 
   pre_bootstrap_user_data = <<-EOT
-  echo "foo"
-  export FOO=bar
+  export CONTAINER_RUNTIME="containerd"
+  export USE_MAX_PODS=false
   EOT
 
-  bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
+  bootstrap_extra_args = "--container-runtime containerd --kubelet-extra-args '--max-pods=20 --instance-type t3a.large'"
 
   post_bootstrap_user_data = <<-EOT
   echo "All done"

--- a/examples/user_data/main.tf
+++ b/examples/user_data/main.tf
@@ -19,14 +19,7 @@ module "eks_mng_linux_additional" {
   source = "../../modules/_user_data"
 
   pre_bootstrap_user_data = <<-EOT
-  echo "foo"
-  export FOO=bar
-  EOT
-
-  bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
-
-  post_bootstrap_user_data = <<-EOT
-  echo "All done"
+  export CONTAINER_RUNTIME="containerd"
   EOT
 }
 

--- a/modules/_user_data/README.md
+++ b/modules/_user_data/README.md
@@ -21,7 +21,6 @@ When using an EKS managed node group, users have 2 primary routes for interactin
 
       ```hcl
       pre_bootstrap_user_data = "..."
-      bootstrap_extra_args    = "..."
       ```
 
 2. If the EKS managed node group does utilize a custom AMI, then per the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-custom-ami), users will need to supply the necessary bootstrap configuration via user data to ensure that the node is configured to register with the cluster when launched. There are two routes that users can utilize to facilitate this bootstrapping process:

--- a/modules/_user_data/main.tf
+++ b/modules/_user_data/main.tf
@@ -28,7 +28,7 @@ locals {
           cluster_endpoint    = var.cluster_endpoint
           cluster_auth_base64 = var.cluster_auth_base64
           # Optional - is appended if using EKS managed node group without custom AMI
-          # cluster_service_ipv4_cidr = var.cluster_service_ipv4_cidr # Not supported yet: https://github.com/bottlerocket-os/bottlerocket/issues/1866
+          # cluster_service_ipv4_cidr = var.cluster_service_ipv4_cidr # Bottlerocket pulls this automatically https://github.com/bottlerocket-os/bottlerocket/issues/1866
           bootstrap_extra_args = var.bootstrap_extra_args
         }
       )) : ""


### PR DESCRIPTION
## Description
- update user data docs to correct mistake of showing `bootstrap_extra_args` when prepending user data (default AMI)

## Motivation and Context

- Closes #1770

## Breaking Changes

- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- user data and eks managed node group examples