### PR TITLE
fix: Don't tag self managed node security group with kubernetes.io/cluster tag

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -456,10 +456,6 @@ resource "aws_security_group" "this" {
 
   tags = merge(
     var.tags,
-    {
-      "Name"                                      = local.security_group_name
-      "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    },
     var.security_group_tags
   )
 }


### PR DESCRIPTION
## Description
This removes the forced kubernetes.io/cluster tag in self managed node security groups in favor of the user supplying it themselves.

## Motivation and Context
We currently tag the created node security group with the `kubernetes.io/cluster/clustername = owned` tag. We are also tagging the self managed node security group with the same tag, which causes a conflict launching load balancers:

```
Error syncing load balancer: failed to ensure load balancer: Multiple tagged security groups found for instance i-aaaaaab0ab17adb5d; ensure only the k8s security group is tagged;
```

Since we don't add this tag to the EKS managed node security group, this will ensure consistency among node groups.

## Breaking Changes
No breaking change

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
