### PR TITLE
docs: Add use case examples to the 18.x upgrade guide

### DIFF
--- a/UPGRADE-18.0.md
+++ b/UPGRADE-18.0.md
@@ -551,3 +551,38 @@ module "cluster_after" {
   }
 }
 ```
+
+## Upgrade Use Case Examples
+
+### Attaching an IAM role policy to a Fargate profile
+
+#### Before 17.x
+
+```hcl
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = module.eks.fargate_iam_role_name
+  policy_arn = aws_iam_policy.default.arn
+}
+```
+
+#### After 18.x
+
+```hcl
+# Attach the policy to an "example" Fargate profile
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = module.eks.fargate_profiles["example"].iam_role_name
+  policy_arn = aws_iam_policy.default.arn
+}
+```
+
+Or:
+
+```hcl
+# Attach the policy to all Fargate profiles
+resource "aws_iam_role_policy_attachment" "default" {
+  for_each = module.eks.fargate_profiles
+
+  role       = each.value.iam_role_name
+  policy_arn = aws_iam_policy.default.arn
+}
+```

--- a/UPGRADE-18.0.md
+++ b/UPGRADE-18.0.md
@@ -552,8 +552,6 @@ module "cluster_after" {
 }
 ```
 
-## Upgrade Use Case Examples
-
 ### Attaching an IAM role policy to a Fargate profile
 
 #### Before 17.x


### PR DESCRIPTION
## Description

- Add a specific before / after example for using `fargate_profiles`

## Motivation and Context

I ran into a situation where I wasn't sure how to use the new `fargate_profiles` output so based on https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1777 @bryantbiggs and I determined adding additional examples to the upgrade guide was worth it to make it easier for folks to upgrade from 17.x to 18.x.

## Breaking Changes

None.

## How Has This Been Tested?

It's Markdown documentation.
