### PR TITLE
docs: Link full changelog for 18.0 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,24 +58,14 @@ All notable changes to this project will be documented in this file.
 
 * Correct conditional map for cluster security group additional rules ([#1738](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1738)) ([a2c7caa](https://github.com/terraform-aws-modules/terraform-aws-eks/commit/a2c7caac9f01ef167994d8b62afb5f997d0fac66))
 
+
 ## [18.0.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v17.24.0...v18.0.0) (2022-01-05)
 
-
 ### ⚠ BREAKING CHANGES
+* Please read upgrade guide v17.x to v18.x [UPGRADE-18.0.md](UPGRADE-18.0.md)
 
-* Removed support for launch configuration and replace `count` with `for_each` (#1680)
-
-### Features
-
-* Removed support for launch configuration and replace `count` with `for_each` ([#1680](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1680)) ([ee9f0c6](https://github.com/terraform-aws-modules/terraform-aws-eks/commit/ee9f0c646a45ca9baa6174a036d1e09bcccb87b1))
-
-
-### Bug Fixes
-
-* Update preset rule on semantic-release to use conventional commits ([#1736](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1736)) ([be86c0b](https://github.com/terraform-aws-modules/terraform-aws-eks/commit/be86c0b898c34943e898e2ecd4994bb7904663ff))
 
 # [17.24.0](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/v17.23.0...v17.24.0) (2021-11-22)
-
 
 ### Bug Fixes
 


### PR DESCRIPTION
The CHANGELOG.md looks like complete but is missing the 18.0 upgrade guide. Removed the subset of changes and linked to the document.

This should allow users to migrate easily to the new version. Really appreciate the nice upgrade guide by the way.