### PR TITLE
fix: Change `instance_metadata_tags` to default to `null`/`disabled` due to tag key pattern conflict

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -225,7 +225,7 @@ module "eks" {
         http_endpoint               = "enabled"
         http_tokens                 = "required"
         http_put_response_hop_limit = 2
-        instance_metadata_tags      = "enabled"
+        instance_metadata_tags      = "disabled"
       }
 
       create_iam_role          = true

--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -138,7 +138,7 @@ module "eks" {
         http_endpoint               = "enabled"
         http_tokens                 = "required"
         http_put_response_hop_limit = 2
-        instance_metadata_tags      = "enabled"
+        instance_metadata_tags      = "disabled"
       }
 
       create_iam_role          = true

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -3,7 +3,6 @@ locals {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
-    instance_metadata_tags      = "enabled"
   }
 }
 


### PR DESCRIPTION
## Description
- change `instance_metadata_tags` to default to `null`/`disabled` due to tag key pattern conflict

## Motivation and Context
- Closes #1785 
	- The default is `disabled` when a value is not provided. In hindsight, we should have matched the default behavior of the API and let users opt in. I don't know why there is a different tag restriction pattern for metadata tags but its currently causing issues for users so better to opt out and let them opt in as they see fit
	
## Breaking Changes
- Controversial, but I will say no

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
