### PR TITLE
fix: Sub Module Prefix Separator

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -38,7 +38,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}${var.prefix_separator}" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -276,7 +276,7 @@ resource "aws_eks_node_group" "this" {
 
   # Optional
   node_group_name        = var.use_name_prefix ? null : var.name
-  node_group_name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  node_group_name_prefix = var.use_name_prefix ? "${var.name}${var.prefix_separator}" : null
 
   # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-custom-ami
   ami_type        = var.ami_id != "" ? null : var.ami_type
@@ -354,7 +354,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}${var.prefix_separator}" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -417,7 +417,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -272,6 +272,12 @@ variable "name" {
   default     = ""
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 variable "use_name_prefix" {
   description = "Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix"
   type        = bool

--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/fargate-profile/variables.tf
+++ b/modules/fargate-profile/variables.tf
@@ -96,6 +96,12 @@ variable "name" {
   default     = ""
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 variable "subnet_ids" {
   description = "A list of subnet IDs for the EKS Fargate Profile"
   type        = list(string)

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}${var.prefix_separator}" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -261,7 +261,7 @@ resource "aws_autoscaling_group" "this" {
   count = var.create ? 1 : 0
 
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.use_name_prefix ? "${var.name}${var.prefix_separator}" : null
 
   dynamic "launch_template" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
@@ -453,7 +453,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}${var.prefix_separator}" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -519,7 +519,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_instance_profile ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 
@@ -548,7 +548,7 @@ resource "aws_iam_instance_profile" "this" {
   role = aws_iam_role.this[0].name
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
 
   lifecycle {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -266,7 +266,6 @@ variable "prefix_separator" {
   default     = "-"
 }
 
-
 variable "use_name_prefix" {
   description = "Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix"
   type        = bool

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -260,6 +260,13 @@ variable "name" {
   default     = ""
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
+
 variable "use_name_prefix" {
   description = "Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix"
   type        = bool


### PR DESCRIPTION
## Description
This PR addresses the issue raised in issue [#1791](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1791) of different prefix separators being used pre v18.0.

- Add optional variable `prefix_separator` to `eks-managed-node-group`, `fargate-profile` and `self-managed-node-group` submodules that defaults to "-"
- Replace occurrences of hardcoded trailing "-" in name prefix fields with `prefix_separator` variable

## Motivation and Context
This PR addresses the issue raised in issue [#1791](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1791). When upgrading from v17.X to v18.X, many resources are replaced due to the previous default separator of empty string ("") not being used in all locations by sub modules. This PR adds support for passing a custom prefix separator to each sub module to address this.

## Breaking Changes
N/A

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - ran `terraform init` and `terraform plan` for the `eks_managed_node_group`, `fargate_profile` and `self_managed_node_group` examples. All successfully planned.
