### PR TITLE
docs: Adding Information on reusing Cluster IAM Role

### DIFF
--- a/UPGRADE-18.0.md
+++ b/UPGRADE-18.0.md
@@ -584,3 +584,22 @@ resource "aws_iam_role_policy_attachment" "default" {
   policy_arn = aws_iam_policy.default.arn
 }
 ```
+### Reusing existing Cluster IAM Role
+
+If you allowed the module to create your Cluster IAM Role
+and want to reuse it moving forward you must
+migrate it into the state.
+
+#### Pre-Upgrade
+
+```hcl
+terraform state mv 'module.eks.aws_iam_role.cluster[0]' 'module.eks.aws_iam_role.this[0]'
+```
+
+```hcl
+  prefix_separator         = ""
+  create_iam_role          = true
+  iam_role_use_name_prefix = false
+  iam_role_name            = "EXISTING ROLE NAME"
+  iam_role_arn             = "EXISTING ROLE ARN"
+```


### PR DESCRIPTION
## Description
Documenting how to keep the existing cluster iam role post upgrade.

## Motivation and Context
This information allowed me to upgrad my existing cluster without recreating it.

## Breaking Changes
None

## How Has This Been Tested?
This is the process I used in my own upgrade