### PR TITLE
fix: add missing prefix_separator to submodules

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -38,7 +38,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}${var.prefix_separator}" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -276,7 +276,7 @@ resource "aws_eks_node_group" "this" {
 
   # Optional
   node_group_name        = var.use_name_prefix ? null : var.name
-  node_group_name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  node_group_name_prefix = var.use_name_prefix ? "${var.name}${var.prefix_separator}" : null
 
   # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-custom-ami
   ami_type        = var.ami_id != "" ? null : var.ami_type
@@ -354,7 +354,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}${var.prefix_separator}" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -417,7 +417,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -16,6 +16,12 @@ variable "platform" {
   default     = "linux"
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 ################################################################################
 # User Data
 ################################################################################

--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/fargate-profile/variables.tf
+++ b/modules/fargate-profile/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 ################################################################################
 # IAM Role
 ################################################################################

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}${var.prefix_separator}" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -261,7 +261,7 @@ resource "aws_autoscaling_group" "this" {
   count = var.create ? 1 : 0
 
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.use_name_prefix ? "${var.name}${var.prefix_separator}" : null
 
   dynamic "launch_template" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
@@ -453,7 +453,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}${var.prefix_separator}" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -519,7 +519,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_instance_profile ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 
@@ -548,7 +548,7 @@ resource "aws_iam_instance_profile" "this" {
   role = aws_iam_role.this[0].name
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
 
   lifecycle {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -16,6 +16,12 @@ variable "platform" {
   default     = "linux"
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 ################################################################################
 # User Data
 ################################################################################

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -214,7 +214,8 @@ module "fargate_profile" {
   iam_role_attach_cni_policy    = try(each.value.iam_role_attach_cni_policy, var.fargate_profile_defaults.iam_role_attach_cni_policy, true)
   iam_role_additional_policies  = try(each.value.iam_role_additional_policies, var.fargate_profile_defaults.iam_role_additional_policies, [])
 
-  tags = merge(var.tags, try(each.value.tags, var.fargate_profile_defaults.tags, {}))
+  tags             = merge(var.tags, try(each.value.tags, var.fargate_profile_defaults.tags, {}))
+  prefix_separator = var.prefix_separator
 }
 
 ################################################################################
@@ -318,7 +319,8 @@ module "eks_managed_node_group" {
   security_group_rules           = try(each.value.security_group_rules, var.eks_managed_node_group_defaults.security_group_rules, {})
   security_group_tags            = try(each.value.security_group_tags, var.eks_managed_node_group_defaults.security_group_tags, {})
 
-  tags = merge(var.tags, try(each.value.tags, var.eks_managed_node_group_defaults.tags, {}))
+  tags             = merge(var.tags, try(each.value.tags, var.eks_managed_node_group_defaults.tags, {}))
+  prefix_separator = var.prefix_separator
 }
 
 ################################################################################
@@ -440,6 +442,7 @@ module "self_managed_node_group" {
   security_group_rules           = try(each.value.security_group_rules, var.self_managed_node_group_defaults.security_group_rules, {})
   security_group_tags            = try(each.value.security_group_tags, var.self_managed_node_group_defaults.security_group_tags, {})
 
-  tags           = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))
-  propagate_tags = try(each.value.propagate_tags, var.self_managed_node_group_defaults.propagate_tags, [])
+  tags             = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))
+  propagate_tags   = try(each.value.propagate_tags, var.self_managed_node_group_defaults.propagate_tags, [])
+  prefix_separator = var.prefix_separator
 }


### PR DESCRIPTION
## Description
Add `prefix_separator` to submodules to make it easier to preserve existing resources during migration to 18.x.

## Motivation and Context
`prefix_separator` should be propagated to submodules.
