### PR TITLE
fix: Add missing `mixed_instances_policy` parameter to the root module

### DIFF
--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -118,6 +118,36 @@ module "eks" {
       EOT
     }
 
+    mixed = {
+      name = "mixed"
+
+      min_size     = 1
+      max_size     = 5
+      desired_size = 2
+
+      bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
+
+      use_mixed_instances_policy = true
+      mixed_instances_policy = {
+        instances_distribution = {
+          on_demand_base_capacity                  = 0
+          on_demand_percentage_above_base_capacity = 20
+          spot_allocation_strategy                 = "capacity-optimized"
+        }
+
+        override = [
+          {
+            instance_type     = "m5.large"
+            weighted_capacity = "1"
+          },
+          {
+            instance_type     = "m6i.large"
+            weighted_capacity = "2"
+          },
+        ]
+      }
+    }
+
     # Complete
     complete = {
       name            = "complete-self-mng"

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -367,6 +367,7 @@ module "self_managed_node_group" {
   initial_lifecycle_hooks    = try(each.value.initial_lifecycle_hooks, var.self_managed_node_group_defaults.initial_lifecycle_hooks, [])
   instance_refresh           = try(each.value.instance_refresh, var.self_managed_node_group_defaults.instance_refresh, null)
   use_mixed_instances_policy = try(each.value.use_mixed_instances_policy, var.self_managed_node_group_defaults.use_mixed_instances_policy, false)
+  mixed_instances_policy     = try(each.value.mixed_instances_policy, var.self_managed_node_group_defaults.mixed_instances_policy, null)
   warm_pool                  = try(each.value.warm_pool, var.self_managed_node_group_defaults.warm_pool, null)
 
   create_schedule = try(each.value.create_schedule, var.self_managed_node_group_defaults.create_schedule, false)


### PR DESCRIPTION
## Description
- add missing `mixed_instances_policy` parameter to the root module

## Motivation and Context
- Closes #1807

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Updated `self-managed-node-group` example for testing and validation