### PR TITLE
fix: Add missing `launch_template_use_name_prefix` parameter to the root module

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -385,10 +385,11 @@ module "self_managed_node_group" {
   user_data_template_path  = try(each.value.user_data_template_path, var.self_managed_node_group_defaults.user_data_template_path, "")
 
   # Launch Template
-  create_launch_template      = try(each.value.create_launch_template, var.self_managed_node_group_defaults.create_launch_template, true)
-  launch_template_name        = try(each.value.launch_template_name, each.key)
-  launch_template_version     = try(each.value.launch_template_version, var.self_managed_node_group_defaults.launch_template_version, null)
-  launch_template_description = try(each.value.launch_template_description, var.self_managed_node_group_defaults.launch_template_description, "Custom launch template for ${try(each.value.name, each.key)} self managed node group")
+  create_launch_template          = try(each.value.create_launch_template, var.self_managed_node_group_defaults.create_launch_template, true)
+  launch_template_name            = try(each.value.launch_template_name, each.key)
+  launch_template_use_name_prefix = try(each.value.launch_template_use_name_prefix, var.self_managed_node_group_defaults.launch_template_use_name_prefix, true)
+  launch_template_version         = try(each.value.launch_template_version, var.self_managed_node_group_defaults.launch_template_version, null)
+  launch_template_description     = try(each.value.launch_template_description, var.self_managed_node_group_defaults.launch_template_description, "Custom launch template for ${try(each.value.name, each.key)} self managed node group")
 
   ebs_optimized   = try(each.value.ebs_optimized, var.self_managed_node_group_defaults.ebs_optimized, null)
   ami_id          = try(each.value.ami_id, var.self_managed_node_group_defaults.ami_id, "")


### PR DESCRIPTION
## Description
* Add missing `launch_template_use_name_prefix` parameter to the root module

## Motivation and Context
* Currently `self-managed-node-group`'s `launch_template_use_name_prefix` variable is not passed to the module, this PR is intended to solve this

## How Has This Been Tested?
* Tested by using the `self-managed-node-group` sub-module with `launch_template_use_name_prefix` set to `True`/`False` and verifying that `aws_launch_template` resource's `name_prefix`/`name` arguments are being set accordingly and the launch template is created as expected
