### PR TITLE
fix: Add node group dependency for EKS addons resource creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -234,6 +234,16 @@ resource "aws_eks_addon" "this" {
     ]
   }
 
+  # Note: if an addon needs to be provisioned ahead of a node group users will
+  # need to create the addon outside of this module until a 2nd addon resource is added
+  # to the module (here) that is not dependent on node groups
+  # Or if addon management improves, this dependency can be removed https://github.com/aws/containers-roadmap/issues/1389
+  depends_on = [
+    module.fargate_profile,
+    module.eks_managed_node_group,
+    module.self_managed_node_group,
+  ]
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## Description
- Add node group dependency for EKS addons resource creation
- Added note regarding future addons that may need to be provisioned ahead of node groups; we can add a separate resource for those addons or re-visit if the lifecycle of addons has been fixed upstream. However, for now I think we can live with this change without much issue

## Motivation and Context
- Closes #1801

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Tested with `eks-managed-node-group` example
