### PR TITLE
fix: The `block_duration_minutes` attribute under launch template `spot_options` is not a required

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -192,6 +192,10 @@ module "eks_managed_node_group" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
+  vpc_security_group_ids = [
+    module.eks.cluster_primary_security_group_id,
+    module.eks.cluster_security_group_id,
+  ]
 
   tags = merge(local.tags, { Separate = "eks-managed-node-group" })
 }

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -165,7 +165,7 @@ resource "aws_launch_template" "this" {
       dynamic "spot_options" {
         for_each = lookup(instance_market_options.value, "spot_options", null) != null ? [instance_market_options.value.spot_options] : []
         content {
-          block_duration_minutes         = spot_options.value.block_duration_minutes
+          block_duration_minutes         = lookup(spot_options.value, "block_duration_minutes", null)
           instance_interruption_behavior = lookup(spot_options.value, "instance_interruption_behavior", null)
           max_price                      = lookup(spot_options.value, "max_price", null)
           spot_instance_type             = lookup(spot_options.value, "spot_instance_type", null)

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -158,7 +158,7 @@ resource "aws_launch_template" "this" {
       dynamic "spot_options" {
         for_each = lookup(instance_market_options.value, "spot_options", null) != null ? [instance_market_options.value.spot_options] : []
         content {
-          block_duration_minutes         = spot_options.value.block_duration_minutes
+          block_duration_minutes         = lookup(spot_options.value, block_duration_minutes, null)
           instance_interruption_behavior = lookup(spot_options.value, "instance_interruption_behavior", null)
           max_price                      = lookup(spot_options.value, "max_price", null)
           spot_instance_type             = lookup(spot_options.value, "spot_instance_type", null)


### PR DESCRIPTION
## Description
- `block_duration_minutes` under launch template `spot_options` is not a required attribute
- Fix `compelte` example, external EKS managed node group module which was missing the security group IDs and failing to join the cluster

## Motivation and Context
- This was a bug found when investigating #1844

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

