### PR TITLE
feat: Allow conditional creation of node groups to be set within node group definitions

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -331,6 +331,8 @@ module "self_managed_node_group" {
 
   for_each = { for k, v in var.self_managed_node_groups : k => v if var.create }
 
+  create = try(each.value.create, true)
+
   cluster_name      = aws_eks_cluster.this[0].name
   cluster_ip_family = var.cluster_ip_family
 

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -194,6 +194,8 @@ module "fargate_profile" {
 
   for_each = { for k, v in var.fargate_profiles : k => v if var.create }
 
+  create = try(each.value.create, true)
+
   # Fargate Profile
   cluster_name      = aws_eks_cluster.this[0].name
   cluster_ip_family = var.cluster_ip_family
@@ -225,6 +227,8 @@ module "eks_managed_node_group" {
   source = "./modules/eks-managed-node-group"
 
   for_each = { for k, v in var.eks_managed_node_groups : k => v if var.create }
+
+  create = try(each.value.create, true)
 
   cluster_name              = aws_eks_cluster.this[0].name
   cluster_version           = try(each.value.cluster_version, var.eks_managed_node_group_defaults.cluster_version, var.cluster_version)


### PR DESCRIPTION
## Description
- Allow conditional creation of self_managed_node_group by passing the variable "create" to the module
- If "create" is not present the default value "true" is used
- If "create" is set to "false" the module is not created

## Motivation and Context
We are using the same manifest for different stages. Some resources are created conditionally based on variables set for a specific stage. We defined multiple self managed node groups in the map self_managed_node_group, but not all of them are relevant for all stages. We would like to be able to create some of the entries conditionally on the "create" variable defined by the self_managed_node_group submodule.

## Breaking Changes
- No

## How Has This Been Tested?
I tested three different scenarios
1.  create = true -> The self_managed_node_group was created with all its resources
2. create = false -> The self_managed_node_group was ignored
3. create missing -> The self_managed_node_group was create with all its resources
