### PR TITLE
chore: Remove incorrect AutoScaling Group resource ARNs for CloudWatch event rule

### DIFF
--- a/examples/irsa_autoscale_refresh/charts.tf
+++ b/examples/irsa_autoscale_refresh/charts.tf
@@ -270,7 +270,6 @@ resource "aws_cloudwatch_event_rule" "aws_node_termination_handler_spot" {
   event_pattern = jsonencode({
     "source" : ["aws.ec2"],
     "detail-type" : ["EC2 Spot Instance Interruption Warning"]
-    "resources" : [for group in module.eks.self_managed_node_groups : group.autoscaling_group_arn]
   })
 }
 


### PR DESCRIPTION
## Description
- remove incorrect resource ARNs for cloudwatch event rule; event rule is matched on `aws.ec2` and not `aws.autoscaling` so the autoscaling ARNs in the resources block is incorrect

## Motivation and Context
- Closes #1850 

## Breaking Changes
- No

## How Has This Been Tested?
- N/A
