### PR TITLE
fix: Update autoscaling group `tags` -> `tag` to support v4 of AWS provider

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.64.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/examples/irsa_autoscale_refresh/main.tf
+++ b/examples/irsa_autoscale_refresh/main.tf
@@ -54,11 +54,7 @@ module "eks" {
         triggers = ["tag"]
       }
 
-      propogate_tags = [{
-        key                 = "aws-node-termination-handler/managed"
-        value               = true
-        propagate_at_launch = true
-      }]
+      tags = { "aws-node-termination-handler/managed" = "true" }
     }
 
     mixed_instance = {
@@ -82,11 +78,7 @@ module "eks" {
         ]
       }
 
-      propogate_tags = [{
-        key                 = "aws-node-termination-handler/managed"
-        value               = true
-        propagate_at_launch = true
-      }]
+      tags = { "aws-node-termination-handler/managed" = "true" }
     }
 
     spot = {
@@ -96,12 +88,7 @@ module "eks" {
       }
 
       bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
-
-      propogate_tags = [{
-        key                 = "aws-node-termination-handler/managed"
-        value               = true
-        propagate_at_launch = true
-      }]
+      tags                 = { "aws-node-termination-handler/managed" = "true" }
     }
   }
 

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -146,7 +146,7 @@ module "self_managed_node_group" {
 | <a name="input_platform"></a> [platform](#input\_platform) | Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based | `string` | `"linux"` | no |
 | <a name="input_post_bootstrap_user_data"></a> [post\_bootstrap\_user\_data](#input\_post\_bootstrap\_user\_data) | User data that is appended to the user data script after of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
 | <a name="input_pre_bootstrap_user_data"></a> [pre\_bootstrap\_user\_data](#input\_pre\_bootstrap\_user\_data) | User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
-| <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | A list of tag blocks. Each element should have keys named `key`, `value`, and `propagate_at_launch` | `list(map(string))` | `[]` | no |
+| <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | A list of tag blocks. Each element should have keys named `key`, `value` | `map(string)` | `{}` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -146,7 +146,6 @@ module "self_managed_node_group" {
 | <a name="input_platform"></a> [platform](#input\_platform) | Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based | `string` | `"linux"` | no |
 | <a name="input_post_bootstrap_user_data"></a> [post\_bootstrap\_user\_data](#input\_post\_bootstrap\_user\_data) | User data that is appended to the user data script after of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
 | <a name="input_pre_bootstrap_user_data"></a> [pre\_bootstrap\_user\_data](#input\_pre\_bootstrap\_user\_data) | User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
-| <a name="input_propagate_tags"></a> [propagate\_tags](#input\_propagate\_tags) | A list of tag blocks. Each element should have keys named `key`, `value` | `map(string)` | `{}` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -85,7 +85,7 @@ module "self_managed_node_group" {
 | <a name="input_cluster_auth_base64"></a> [cluster\_auth\_base64](#input\_cluster\_auth\_base64) | Base64 encoded CA of associated EKS cluster | `string` | `""` | no |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint of associated EKS cluster | `string` | `""` | no |
 | <a name="input_cluster_ip_family"></a> [cluster\_ip\_family](#input\_cluster\_ip\_family) | The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6` | `string` | `null` | no |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of associated EKS cluster | `string` | `null` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of associated EKS cluster | `string` | `""` | no |
 | <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | Cluster control plane security group ID | `string` | `null` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes cluster version - used to lookup default AMI ID if one is not provided | `string` | `null` | no |
 | <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | The CPU options for the instance | `map(string)` | `null` | no |

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -255,15 +255,6 @@ locals {
   launch_template_name = try(aws_launch_template.this[0].name, var.launch_template_name)
   # Change order to allow users to set version priority before using defaults
   launch_template_version = coalesce(var.launch_template_version, try(aws_launch_template.this[0].default_version, "$Default"))
-
-  asg_tags = merge(
-    {
-      "Name"                                      = var.name
-      "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-      "k8s.io/cluster/${var.cluster_name}"        = "owned"
-    },
-    var.propagate_tags,
-  )
 }
 
 resource "aws_autoscaling_group" "this" {
@@ -388,7 +379,15 @@ resource "aws_autoscaling_group" "this" {
   }
 
   dynamic "tag" {
-    for_each = local.asg_tags
+    for_each = merge(
+      {
+        "Name"                                      = var.name
+        "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+        "k8s.io/cluster/${var.cluster_name}"        = "owned"
+      },
+      var.tags,
+    )
+
     content {
       key                 = tag.key
       value               = tag.value

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -259,27 +259,23 @@ locals {
   asg_tags = concat(
     [
       {
-        key                 = "Name"
-        value               = var.name
-        propagate_at_launch = true
+        key   = "Name"
+        value = var.name
       },
       {
-        key                 = "kubernetes.io/cluster/${var.cluster_name}"
-        value               = "owned"
-        propagate_at_launch = true
+        key   = "kubernetes.io/cluster/${var.cluster_name}"
+        value = "owned"
       },
       {
-        key                 = "k8s.io/cluster/${var.cluster_name}"
-        value               = "owned"
-        propagate_at_launch = true
+        key   = "k8s.io/cluster/${var.cluster_name}"
+        value = "owned"
       },
     ],
     var.propagate_tags,
     [for k, v in var.tags :
       {
-        key                 = k
-        value               = v
-        propagate_at_launch = true
+        key   = k
+        value = v
       }
     ]
   )
@@ -411,7 +407,7 @@ resource "aws_autoscaling_group" "this" {
     content {
       key                 = tag.value.key
       value               = tag.value.value
-      propagate_at_launch = tag.value.propagate_at_launch
+      propagate_at_launch = try(tag.value.propagate_at_launch, true)
     }
   }
 

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -23,7 +23,7 @@ variable "platform" {
 variable "cluster_name" {
   description = "Name of associated EKS cluster"
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "cluster_endpoint" {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -447,9 +447,9 @@ variable "delete_timeout" {
 }
 
 variable "propagate_tags" {
-  description = "A list of tag blocks. Each element should have keys named `key`, `value`, and `propagate_at_launch`"
-  type        = list(map(string))
-  default     = []
+  description = "A list of tag blocks. Each element should have keys named `key`, `value`"
+  type        = map(string)
+  default     = {}
 }
 
 ################################################################################

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -446,12 +446,6 @@ variable "delete_timeout" {
   default     = null
 }
 
-variable "propagate_tags" {
-  description = "A list of tag blocks. Each element should have keys named `key`, `value`"
-  type        = map(string)
-  default     = {}
-}
-
 ################################################################################
 # Autoscaling group schedule
 ################################################################################

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -451,5 +451,5 @@ module "self_managed_node_group" {
   security_group_tags            = try(each.value.security_group_tags, var.self_managed_node_group_defaults.security_group_tags, {})
 
   tags           = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))
-  propagate_tags = try(each.value.propagate_tags, var.self_managed_node_group_defaults.propagate_tags, [])
+  propagate_tags = try(each.value.propagate_tags, var.self_managed_node_group_defaults.propagate_tags, {})
 }

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -450,6 +450,5 @@ module "self_managed_node_group" {
   security_group_rules           = try(each.value.security_group_rules, var.self_managed_node_group_defaults.security_group_rules, {})
   security_group_tags            = try(each.value.security_group_tags, var.self_managed_node_group_defaults.security_group_tags, {})
 
-  tags           = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))
-  propagate_tags = try(each.value.propagate_tags, var.self_managed_node_group_defaults.propagate_tags, {})
+  tags = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))
 }


### PR DESCRIPTION
## Description
- Update autoscaling group `tags` -> `tag` to support v4 of AWS provider. This is now a dynamic `tag` block and the current functionality has been preserved through a map comprehension statement. The variable `var.propagate_tags` has been removed as part of this change and users should pass any tags through the normal `var.tags` variable now

## Motivation and Context
- Closes #1874 
- Avoids showing users a deprecation statement for `tags` on autoscaling group

## Breaking Changes
- `var.propagate_tags` is removed and `var.tags` is used in its place so I am (controversially) electing to not mark this as a breaking change (does not affect a significant population of users and there is a clear path to mitigate without state changes or downtime)

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
