### PR TITLE
fix: Add missing quotes to block_duration_minutes

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -158,7 +158,7 @@ resource "aws_launch_template" "this" {
       dynamic "spot_options" {
         for_each = lookup(instance_market_options.value, "spot_options", null) != null ? [instance_market_options.value.spot_options] : []
         content {
-          block_duration_minutes         = lookup(spot_options.value, block_duration_minutes, null)
+          block_duration_minutes         = lookup(spot_options.value, "block_duration_minutes", null)
           instance_interruption_behavior = lookup(spot_options.value, "instance_interruption_behavior", null)
           max_price                      = lookup(spot_options.value, "max_price", null)
           spot_instance_type             = lookup(spot_options.value, "spot_instance_type", null)


### PR DESCRIPTION
## Description
Adds missing quotes to the `block_duration_minutes` value in `spot_options`. 

## Motivation and Context
Without these quotes terraform will think it's a resource and will throw an `Invalid reference` error : 

```
│ Error: Invalid reference
│ 
│   on .terraform/modules/reactive_cluster.eks.eks/modules/self-managed-node-group/main.tf line 161, in resource "aws_launch_template" "this":
│  161:           block_duration_minutes         = lookup(spot_options.value, block_duration_minutes, null)
│ 
│ A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
```

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects

