### PR TITLE
fix: Input capacity_reservation_target should be flattened as a nested dynamic

### DIFF
--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -195,6 +195,12 @@ module "eks" {
         }
       }
 
+      capacity_reservation_specification = { # only works with capacity_type=ON_DEMAND
+        capacity_reservation_target = {
+          capacity_reservation_id = aws_ec2_capacity_reservation.targeted.id
+        }
+      }
+
       metadata_options = {
         http_endpoint               = "enabled"
         http_tokens                 = "required"
@@ -461,4 +467,12 @@ data "aws_iam_policy_document" "ebs" {
       values   = ["true"]
     }
   }
+}
+
+resource "aws_ec2_capacity_reservation" "targeted" {
+  instance_type           = "t2.micro"
+  instance_platform       = "Linux/UNIX"
+  availability_zone       = "eu-west-1a"
+  instance_count          = 1
+  instance_match_criteria = "targeted"
 }

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -94,7 +94,7 @@ resource "aws_launch_template" "this" {
       capacity_reservation_preference = lookup(capacity_reservation_specification.value, "capacity_reservation_preference", null)
 
       dynamic "capacity_reservation_target" {
-        for_each = lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])
+        for_each = flatten([lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])])
         content {
           capacity_reservation_id = lookup(capacity_reservation_target.value, "capacity_reservation_id", null)
         }

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -95,7 +95,7 @@ resource "aws_launch_template" "this" {
       capacity_reservation_preference = lookup(capacity_reservation_specification.value, "capacity_reservation_preference", null)
 
       dynamic "capacity_reservation_target" {
-        for_each = lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])
+        for_each = flatten([lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])])
         content {
           capacity_reservation_id = lookup(capacity_reservation_target.value, "capacity_reservation_id", null)
         }


### PR DESCRIPTION
Fixes the invalid function error when specifying a capacity_reservation_target in both the aws managed node groups and self managed node groups

Link to issue: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1897