### PR TITLE
feat: Allow EKS cluster security group to be included in node group launch template

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -107,6 +107,10 @@ module "eks" {
   }
 
   # EKS Managed Node Group(s)
+
+  # Extend list of configured security groups on nodes to include the AWS-created cluster security group
+  include_cluster_security_group = true
+
   eks_managed_node_group_defaults = {
     ami_type               = "AL2_x86_64"
     disk_size              = 50

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -223,6 +223,9 @@ module "fargate_profile" {
 # EKS Managed Node Group
 ################################################################################
 
+locals {
+  cluster_base_security_group_id = var.include_cluster_security_group ? aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id : null
+}
 module "eks_managed_node_group" {
   source = "./modules/eks-managed-node-group"
 
@@ -281,7 +284,7 @@ module "eks_managed_node_group" {
 
   ebs_optimized                          = try(each.value.ebs_optimized, var.eks_managed_node_group_defaults.ebs_optimized, null)
   key_name                               = try(each.value.key_name, var.eks_managed_node_group_defaults.key_name, null)
-  vpc_security_group_ids                 = compact(concat([local.node_security_group_id], try(each.value.vpc_security_group_ids, var.eks_managed_node_group_defaults.vpc_security_group_ids, [])))
+  vpc_security_group_ids                 = compact(concat([local.cluster_base_security_group_id], [local.node_security_group_id], try(each.value.vpc_security_group_ids, var.eks_managed_node_group_defaults.vpc_security_group_ids, [])))
   launch_template_default_version        = try(each.value.launch_template_default_version, var.eks_managed_node_group_defaults.launch_template_default_version, null)
   update_launch_template_default_version = try(each.value.update_launch_template_default_version, var.eks_managed_node_group_defaults.update_launch_template_default_version, true)
   disable_api_termination                = try(each.value.disable_api_termination, var.eks_managed_node_group_defaults.disable_api_termination, null)
@@ -405,7 +408,7 @@ module "self_managed_node_group" {
   instance_type   = try(each.value.instance_type, var.self_managed_node_group_defaults.instance_type, "m6i.large")
   key_name        = try(each.value.key_name, var.self_managed_node_group_defaults.key_name, null)
 
-  vpc_security_group_ids                 = compact(concat([local.node_security_group_id], try(each.value.vpc_security_group_ids, var.self_managed_node_group_defaults.vpc_security_group_ids, [])))
+  vpc_security_group_ids                 = compact(concat([local.cluster_base_security_group_id], [local.node_security_group_id], try(each.value.vpc_security_group_ids, var.self_managed_node_group_defaults.vpc_security_group_ids, [])))
   cluster_security_group_id              = local.cluster_security_group_id
   launch_template_default_version        = try(each.value.launch_template_default_version, var.self_managed_node_group_defaults.launch_template_default_version, null)
   update_launch_template_default_version = try(each.value.update_launch_template_default_version, var.self_managed_node_group_defaults.update_launch_template_default_version, true)

--- a/variables.tf
+++ b/variables.tf
@@ -181,6 +181,12 @@ variable "cluster_security_group_tags" {
   default     = {}
 }
 
+variable "include_cluster_security_group" {
+  description = "Determines if cluster security group should be included in node launch templates"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # EKS IPV6 CNI Policy
 ################################################################################


### PR DESCRIPTION
## Description
Allow including EKS cluster security group in module created launch templates

~In order to effectively use this feature, additional cluster security groups may not be specified at cluster creation
which does not work right now. Fix is added for that (Fixes #1892)~ Rebased on top of #1934

## Motivation and Context
The behavior of EKS's launch template support today is that if any node security groups are
specified in the launch template configuration, EKS will not automatically add the cluster security group.
If no security groups are specified, the cluster security group is added by default.
(ref: https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html)

For users that want to preserve similar behavior, when including additional node security groups,
optionally allow the cluster security group to be added to the launch template generated
by the EKS Cluster terraform module

## Breaking Changes
* existing behavior preserved with default value (`include_cluster_security_group = false`)

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
