### PR TITLE
fix: Sub-modules output the correct eks worker iam arn when workers utilize custom iam role

### DIFF
--- a/modules/eks-managed-node-group/outputs.tf
+++ b/modules/eks-managed-node-group/outputs.tf
@@ -66,7 +66,7 @@ output "iam_role_name" {
 
 output "iam_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the IAM role"
-  value       = try(aws_iam_role.this[0].arn, "")
+  value       = try(aws_iam_role.this[0].arn, var.iam_role_arn)
 }
 
 output "iam_role_unique_id" {

--- a/modules/fargate-profile/outputs.tf
+++ b/modules/fargate-profile/outputs.tf
@@ -9,7 +9,7 @@ output "iam_role_name" {
 
 output "iam_role_arn" {
   description = "The Amazon Resource Name (ARN) specifying the IAM role"
-  value       = try(aws_iam_role.this[0].arn, "")
+  value       = try(aws_iam_role.this[0].arn, var.iam_role_arn)
 }
 
 output "iam_role_unique_id" {

--- a/modules/self-managed-node-group/outputs.tf
+++ b/modules/self-managed-node-group/outputs.tf
@@ -124,7 +124,7 @@ output "iam_role_unique_id" {
 
 output "iam_instance_profile_arn" {
   description = "ARN assigned by AWS to the instance profile"
-  value       = try(aws_iam_instance_profile.this[0].arn, "")
+  value       = try(aws_iam_instance_profile.this[0].arn, var.iam_instance_profile_arn)
 }
 
 output "iam_instance_profile_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -171,8 +171,8 @@ output "aws_auth_configmap_yaml" {
   value = templatefile("${path.module}/templates/aws_auth_cm.tpl",
     {
       eks_managed_role_arns                   = [for group in module.eks_managed_node_group : group.iam_role_arn]
-      self_managed_role_arns                  = [for group in module.self_managed_node_group : group.iam_instance_profile_arn if group.platform != "windows"]
-      win32_self_managed_role_arns            = [for group in module.self_managed_node_group : group.iam_instance_profile_arn if group.platform == "windows"]
+      self_managed_role_arns                  = [for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"]
+      win32_self_managed_role_arns            = [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"]
       fargate_profile_pod_execution_role_arns = [for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn]
     }
   )

--- a/outputs.tf
+++ b/outputs.tf
@@ -171,8 +171,8 @@ output "aws_auth_configmap_yaml" {
   value = templatefile("${path.module}/templates/aws_auth_cm.tpl",
     {
       eks_managed_role_arns                   = [for group in module.eks_managed_node_group : group.iam_role_arn]
-      self_managed_role_arns                  = [for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"]
-      win32_self_managed_role_arns            = [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"]
+      self_managed_role_arns                  = [for group in module.self_managed_node_group : group.iam_instance_profile_arn if group.platform != "windows"]
+      win32_self_managed_role_arns            = [for group in module.self_managed_node_group : group.iam_instance_profile_arn if group.platform == "windows"]
       fargate_profile_pod_execution_role_arns = [for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn]
     }
   )


### PR DESCRIPTION
## Description
When sub-module generate outputs, it needs to consider if the worker instance is using custom iam role, if so, it should directly output the variable associated with it. otherwise, it will return empty string cause damage to the cluster if not carefully use these outputs.

## Motivation and Context
when we patch the aws_auth config following https://github.com/terraform-aws-modules/terraform-aws-eks/blob/9a99689cc13147f4afc426b34ba009875a28614e/examples/complete/main.tf#L301-L336.  

we found out that rolearn from `module.eks.aws_auth_configmap_yaml` was empty

```
 kubectl -n kube-system describe configmap/aws-auth
Name:         aws-auth
Namespace:    kube-system
Labels:       <none>
Annotations:  <none>

Data
====
mapRoles:
----
- rolearn:
  username: system:node:{{EC2PrivateDNSName}}
  groups:
    - system:bootstrappers
    - system:nodes
- rolearn: {custom_iam}
  username: {custom_iam}
  groups:
    - xxxx:xxxx

Events:  <none>
```

## Breaking Changes
n/a

## How Has This Been Tested?
After the update, the issue we saw has been fixed(we only use EKS managed node group). so the self managed nodegroup and fargate portion is unverified yet, but since it's an easy fix, kinda confident it will work.  
