### PR TITLE
Standardize local development with Docker!

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,60 @@
+FROM ubuntu:20.04
+
+ARG GO_VERSION="1.17.6" \
+    TERRAFORM_VERSION="latest" \
+    TERRAFORM_DOCS_VERSION="v0.16.0" \
+    TFLINT_VERSION="v0.34.1" \
+    TERRATEST_VERSION="v0.13.13" \
+    KUBERNETES_VERSION="1.21.2"
+
+ENV GOROOT=/usr/local/go \
+    GOPATH=/go \
+    PATH=/root/.tfenv/bin:${GOPATH}/bin:${GOROOT}/bin:${PATH}
+
+# Common
+RUN apt-get update && apt-get install -y curl unzip git python3-pip
+
+# Github CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+ && apt update \
+ && apt install gh
+
+# Golang
+RUN curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+ && tar -xzf /tmp/go.tar.gz -C /usr/local \
+ && ${GOROOT}/bin/go install -v golang.org/x/tools/gopls@latest
+
+# Terraform
+RUN git clone https://github.com/tfutils/tfenv.git /root/.tfenv \
+ && tfenv install ${TERRAFORM_VERSION} \
+ && tfenv use $(ls /root/.tfenv/versions)
+
+# Terraform-Docs
+RUN curl -sSLo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}-$(uname)-amd64.tar.gz \
+ && tar -xzf terraform-docs.tar.gz -C /usr/bin/ terraform-docs \
+ && rm terraform-docs.tar.gz 2> /dev/null
+
+# Tflint
+RUN curl -sSL "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip \
+ && unzip -qq tflint.zip tflint -d /usr/bin/ \
+ && rm tflint.zip 2> /dev/null
+
+# Terratest
+RUN curl -sSL -o /usr/local/bin/terratest_log_parser "https://github.com/gruntwork-io/terratest/releases/download/${TERRATEST_VERSION}/terratest_log_parser_linux_amd64" \
+ && chmod +x /usr/local/bin/terratest_log_parser
+
+# Pre-Commit
+RUN pip3 install -q --no-cache-dir pre-commit
+
+# AWSCLI
+RUN curl -sSL -o /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+ && unzip /tmp/awscliv2.zip -d /tmp \
+ && ./tmp/aws/install
+
+# Kubectl
+RUN curl -sSL -o /usr/bin/kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/${KUBERNETES_VERSION}/2021-07-05/bin/linux/amd64/kubectl \
+ && chmod +x /usr/bin/kubectl
+
+# Clean
+RUN rm -rf /tmp/* && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "terraform-aws-eks",
+    "build": { "dockerfile": "Dockerfile" },
+    "extensions": [
+        "hashicorp.terraform",
+        "golang.Go"
+    ],
+    "mounts": [
+        "source=${localEnv:HOME}/.aws,target=/root/.aws,type=bind",
+        "source=${localEnv:HOME}/.cache/pre-commit,target=/root/.cache/pre-commit,type=bind",
+    ]
+}


### PR DESCRIPTION
## Description

Standardize the local development environment with Docker! The `Dockerfile` describes the development tools needed to run `pre-commit`. Specifically:

```
TERRAFORM_VERSION="latest"
TERRAFORM_DOCS_VERSION="v0.16.0"
TFLINT_VERSION="v0.34.1"
KUBERNETES_VERSION="1.21.2"
```

## Motivation and Context

The [Pre-Commit](https://github.com/terraform-aws-modules/terraform-aws-eks/actions/workflows/pre-commit.yml) Github Action is great, but for major changes; you need a local development environment capable of running the terraform module end2end.

## How Has This Been Tested?

I used the [Visual Studio Code Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension to build and attach to the devcontainer running on the local Docker daemon.

<img width="1440" alt="Screen Shot 2022-03-05 at 7 52 46 PM" src="https://user-images.githubusercontent.com/7491003/156907403-9cad9999-af4f-4d73-a0a0-e716749d6edd.png">


