### PR TITLE
feat: Input prefix_separator for nodegroups resources

### DIFF
--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -142,6 +142,7 @@ module "eks_managed_node_group" {
 | <a name="input_platform"></a> [platform](#input\_platform) | Identifies if the OS platform is `bottlerocket` or `linux` based; `windows` is not supported | `string` | `"linux"` | no |
 | <a name="input_post_bootstrap_user_data"></a> [post\_bootstrap\_user\_data](#input\_post\_bootstrap\_user\_data) | User data that is appended to the user data script after of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
 | <a name="input_pre_bootstrap_user_data"></a> [pre\_bootstrap\_user\_data](#input\_pre\_bootstrap\_user\_data) | User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
+| <a name="input_prefix_separator"></a> [prefix\_separator](#input\_prefix\_separator) | The separator to use between the prefix and the generated timestamp for resource names | `string` | `"-"` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_remote_access"></a> [remote\_access](#input\_remote\_access) | Configuration block with remote access settings | `any` | `{}` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description for the security group created | `string` | `"EKS managed node group security group"` | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -360,7 +360,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}${var.prefix_separator}" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -423,7 +423,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -44,7 +44,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}${var.prefix_separator}" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -282,7 +282,7 @@ resource "aws_eks_node_group" "this" {
 
   # Optional
   node_group_name        = var.use_name_prefix ? null : var.name
-  node_group_name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  node_group_name_prefix = var.use_name_prefix ? "${var.name}${var.prefix_separator}" : null
 
   # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-custom-ami
   ami_type        = var.ami_id != "" ? null : var.ami_type

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 variable "platform" {
   description = "Identifies if the OS platform is `bottlerocket` or `linux` based; `windows` is not supported"
   type        = string

--- a/modules/fargate-profile/README.md
+++ b/modules/fargate-profile/README.md
@@ -70,6 +70,7 @@ No modules.
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `string` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the EKS Fargate Profile | `string` | `""` | no |
+| <a name="input_prefix_separator"></a> [prefix\_separator](#input\_prefix\_separator) | The separator to use between the prefix and the generated timestamp for resource names | `string` | `"-"` | no |
 | <a name="input_selectors"></a> [selectors](#input\_selectors) | Configuration block(s) for selecting Kubernetes Pods to execute with this Fargate Profile | `any` | `[]` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs for the EKS Fargate Profile | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/fargate-profile/variables.tf
+++ b/modules/fargate-profile/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 ################################################################################
 # IAM Role
 ################################################################################

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -146,6 +146,7 @@ module "self_managed_node_group" {
 | <a name="input_platform"></a> [platform](#input\_platform) | Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based | `string` | `"linux"` | no |
 | <a name="input_post_bootstrap_user_data"></a> [post\_bootstrap\_user\_data](#input\_post\_bootstrap\_user\_data) | User data that is appended to the user data script after of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
 | <a name="input_pre_bootstrap_user_data"></a> [pre\_bootstrap\_user\_data](#input\_pre\_bootstrap\_user\_data) | User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `platform` = `bottlerocket` | `string` | `""` | no |
+| <a name="input_prefix_separator"></a> [prefix\_separator](#input\_prefix\_separator) | The separator to use between the prefix and the generated timestamp for resource names | `string` | `"-"` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -48,7 +48,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}${var.prefix_separator}" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -261,7 +261,7 @@ resource "aws_autoscaling_group" "this" {
   count = var.create ? 1 : 0
 
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.use_name_prefix ? "${var.name}${var.prefix_separator}" : null
 
   dynamic "launch_template" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
@@ -442,7 +442,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}${var.prefix_separator}" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -507,7 +507,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_instance_profile ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 
@@ -536,7 +536,7 @@ resource "aws_iam_instance_profile" "this" {
   role = aws_iam_role.this[0].name
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
 
   lifecycle {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -10,6 +10,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "prefix_separator" {
+  description = "The separator to use between the prefix and the generated timestamp for resource names"
+  type        = string
+  default     = "-"
+}
+
 variable "platform" {
   description = "Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based"
   type        = string

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -196,6 +196,8 @@ module "fargate_profile" {
 
   create = try(each.value.create, true)
 
+  prefix_separator = try(each.value.prefix_separator, var.eks_managed_node_group_defaults.prefix_separator, "-")
+
   # Fargate Profile
   cluster_name      = aws_eks_cluster.this[0].name
   cluster_ip_family = var.cluster_ip_family
@@ -236,8 +238,9 @@ module "eks_managed_node_group" {
   cluster_ip_family         = var.cluster_ip_family
 
   # EKS Managed Node Group
-  name            = try(each.value.name, each.key)
-  use_name_prefix = try(each.value.use_name_prefix, var.eks_managed_node_group_defaults.use_name_prefix, true)
+  name             = try(each.value.name, each.key)
+  use_name_prefix  = try(each.value.use_name_prefix, var.eks_managed_node_group_defaults.use_name_prefix, true)
+  prefix_separator = try(each.value.prefix_separator, var.eks_managed_node_group_defaults.prefix_separator, "-")
 
   subnet_ids = try(each.value.subnet_ids, var.eks_managed_node_group_defaults.subnet_ids, var.subnet_ids)
 
@@ -341,8 +344,9 @@ module "self_managed_node_group" {
   cluster_ip_family = var.cluster_ip_family
 
   # Autoscaling Group
-  name            = try(each.value.name, each.key)
-  use_name_prefix = try(each.value.use_name_prefix, var.self_managed_node_group_defaults.use_name_prefix, true)
+  name             = try(each.value.name, each.key)
+  use_name_prefix  = try(each.value.use_name_prefix, var.self_managed_node_group_defaults.use_name_prefix, true)
+  prefix_separator = try(each.value.prefix_separator, var.eks_managed_node_group_defaults.prefix_separator, "-")
 
   availability_zones = try(each.value.availability_zones, var.self_managed_node_group_defaults.availability_zones, null)
   subnet_ids         = try(each.value.subnet_ids, var.self_managed_node_group_defaults.subnet_ids, var.subnet_ids)


### PR DESCRIPTION
## Description
Repeat as done for main module, with variable prefix_separator.
Inside modules, replace hardcoded `"-"` by `${var.prefix_separator}`.

## Motivation and Context
When upgrading prior v18 deployments, I cannot use prefix naming mechanism, because of "-" set at the end of the string.
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1925

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
