### PR TITLE
fix: avoid cluster recreation when migrating from v17.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_eks_cluster" "this" {
   enabled_cluster_log_types = var.cluster_enabled_log_types
 
   vpc_config {
-    security_group_ids      = distinct(concat(var.cluster_additional_security_group_ids, [local.cluster_security_group_id]))
+    security_group_ids      = var.cluster_additional_security_group_ids    
     subnet_ids              = var.subnet_ids
     endpoint_private_access = var.cluster_endpoint_private_access
     endpoint_public_access  = var.cluster_endpoint_public_access
@@ -140,6 +140,29 @@ resource "aws_security_group_rule" "cluster" {
     try(each.value.source_node_security_group, false) ? local.node_security_group_id : null
   )
 }
+
+resource "aws_security_group_rule" "cluster_existing" {
+  for_each = { for k, v in var.cluster_security_group_additional_rules : k => v if !local.create_cluster_sg }
+
+  # Required
+  security_group_id = var.cluster_security_group_id
+  protocol          = each.value.protocol
+  from_port         = each.value.from_port
+  to_port           = each.value.to_port
+  type              = each.value.type
+
+  # Optional
+  description      = try(each.value.description, null)
+  cidr_blocks      = try(each.value.cidr_blocks, null)
+  ipv6_cidr_blocks = try(each.value.ipv6_cidr_blocks, null)
+  prefix_list_ids  = try(each.value.prefix_list_ids, [])
+  self             = try(each.value.self, null)
+  source_security_group_id = try(
+    each.value.source_security_group_id,
+    try(each.value.source_node_security_group, false) ? local.node_security_group_id : null
+  )
+}
+
 
 ################################################################################
 # IRSA


### PR DESCRIPTION
## Description
Solves two issues:
1. Avoids recreation of the cluster during migration from v17.24 to v18.x.
2. Adds support for additional cluster security group rules without the need to create a new security group (which causes cluster recreation)

## Motivation and Context
We are migrating the module from v17.24.0 to v18.x and the changes force a cluster replacement, which is not acceptable in our context.

The v17.24 cluster is being created like this:

```
module "cluster" {
  source           = "terraform-aws-modules/eks/aws"
  version          = "17.24.0"
  cluster_name     = local.stamp_name
  cluster_version  = local.kubernetes_version
  subnets          = module.vpc.private_subnets
  vpc_id           = module.vpc.vpc_id
  enable_irsa      = true
  write_kubeconfig = false
  manage_aws_auth  = false

  manage_worker_iam_resources  = false
  manage_cluster_iam_resources = false
  cluster_iam_role_name        = aws_iam_role.cluster_controlplane.name

  cluster_enabled_log_types     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
  cluster_log_retention_in_days = 365

  worker_create_security_group  = false
  cluster_create_security_group = false

  tags = merge(local.common_tags, {
    Name = local.stamp_name
  })

  node_groups_defaults = {
    iam_role_arn = aws_iam_role.cluster_nodes.arn

    tags = [
      {
        "key"                 = "k8s.io/cluster-autoscaler/enabled"
        "propagate_at_launch" = "false"
        "value"               = "true"
      },
      {
        "key"                 = "k8s.io/cluster-autoscaler/${local.stamp_name}"
        "propagate_at_launch" = "false"
        "value"               = "true"
      }
    ]

    kubelet_extra_args     = var.kubelet_extra_args
    create_launch_template = true
  }

  node_groups = {
    pool-main-1 = {
      name_prefix      = "pool-main-1-"
      version          = local.kubernetes_nodes_version
      desired_capacity = var.initial_capacity
      max_capacity     = var.maximum_capacity
      min_capacity     = var.minimum_capacity
      instance_types   = [var.instance_type]
    }

    pool-jobs-1 = {
      name_prefix      = "pool-jobs-1-"
      version          = local.kubernetes_nodes_version
      desired_capacity = var.initial_capacity
      max_capacity     = var.maximum_capacity
      min_capacity     = var.minimum_capacity
      instance_types   = [var.instance_type_jobs]

      create_launch_template = true
  depends_on = [
     ...
  ]
}
```
The with v18.8.1 we converted it to:

```
module "cluster" {
  source = "github.com/renato0307/terraform-aws-eks?ref=v18.8.1-os"
  #source          = "terraform-aws-modules/eks/aws"
  #version         = "18.8.1"
  cluster_name    = local.stamp_name
  cluster_version = local.kubernetes_version
  subnet_ids      = module.vpc.private_subnets # RENAME
  vpc_id          = module.vpc.vpc_id
  enable_irsa     = true

  create_iam_role          = false                                 # NEW
  iam_role_arn             = aws_iam_role.cluster_controlplane.arn # RENAME
  iam_role_use_name_prefix = false                                 # NEW

  cluster_enabled_log_types              = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
  cloudwatch_log_group_retention_in_days = 365

  create_node_security_group = true        # NEW
  node_security_group_additional_rules = { # NEW
    cluster_rule = {
      source_cluster_security_group = true
      description                   = "Access from the cluster"
      protocol                      = "-1"
      from_port                     = 0
      to_port                       = 0
      type                          = "ingress"
    }
  }

  create_cluster_security_group = false                             # NEW
  cluster_security_group_id     = var.tmp_cluster_security_group_id # NEW
  cluster_security_group_additional_rules = {                       # NEW
    cluster_rule = {
      source_node_security_group = true
      description                = "Access from node_security_group"
      protocol                   = "-1"
      from_port                  = 0
      to_port                    = 0
      type                       = "ingress"
    }
  }

  # This is not needed since we are using managed nodes
  # NOT_SUPPORTED:worker_create_security_group  = false
  # NOT_SUPPORTED:cluster_create_security_group = false
  # NOT_SUPPORTED:write_kubeconfig = false
  # NOT_SUPPORTED:manage_aws_auth  = false
  # NOT_SUPPORTED:manage_worker_iam_resources  = false
  # NOT_SUPPORTED:manage_cluster_iam_resources = false

  tags = merge(local.common_tags, {
    Name = local.stamp_name
  })

  eks_managed_node_group_defaults = { # RENAME
    iam_role_arn = aws_iam_role.cluster_nodes.arn

    tags = { # NOT A LIST ANYMORE
      "k8s.io/cluster-autoscaler/enabled" : "true",
      "k8s.io/cluster-autoscaler/${local.stamp_name}" : "true"
    }

    kubelet_extra_args     = var.kubelet_extra_args
    create_launch_template = true
  }

  eks_managed_node_groups = {
    pool-main-1 = {
      name_prefix      = "pool-main-1-"
      version          = local.kubernetes_nodes_version
      desired_capacity = var.initial_capacity
      max_capacity     = var.maximum_capacity
      min_capacity     = var.minimum_capacity
      instance_types   = [var.instance_type]
    }

    pool-jobs-1 = {
      name_prefix      = "pool-jobs-1-"
      version          = local.kubernetes_nodes_version
      desired_capacity = var.initial_capacity
      max_capacity     = var.maximum_capacity
      min_capacity     = var.minimum_capacity
      instance_types   = [var.instance_type_jobs]

      create_launch_template = true
    }
  }

  # Ensure the creation order but most important the delete order
  depends_on = [
...
  ]
}
```


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
