### PR TITLE
fix: Fargate profile execution role output

### DIFF
--- a/modules/fargate-profile/outputs.tf
+++ b/modules/fargate-profile/outputs.tf
@@ -38,5 +38,5 @@ output "fargate_profile_status" {
 
 output "fargate_profile_pod_execution_role_arn" {
   description = "Amazon Resource Name (ARN) of the EKS Fargate Profile Pod execution role ARN"
-  value       = try(aws_eks_fargate_profile.this[0].pod_execution_role_arn, "")
+  value       = try(var.create_iam_role ? aws_iam_role.this[0].arn : var.iam_role_arn, "")
 }


### PR DESCRIPTION
Signed-off-by: Ivan Dechovski <ivan.dechovski@kpn.com>

## Description
Update the fargate profile execution role ARN output to be fetched from the IAM role attribute or the IAM role ARN variable, instead of referencing the EKS fargate profile resource attribute. 

## Motivation and Context
This change allows us to get the output in the root module `aws_auth_configmap_yaml` as soon as the fargate IAM role ARN is available. Currently, the output `aws_auth_configmap_yaml` is only made available when the profile is created, delaying us with updating the aws-auth configmap. In some cases, creating a fargate profile can take upwards of 10minutes during which non of the node groups would have permissions to join the cluster.
