### PR TITLE
feat: Add tags to EKS created cluster security group to match rest of module tagging scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,7 @@ Full contributing [guidelines are covered here](https://github.com/terraform-aws
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ec2_tag.cluster_primary_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_eks_addon.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster) | resource |
 | [aws_eks_identity_provider_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_identity_provider_config) | resource |

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,14 @@ resource "aws_eks_cluster" "this" {
   ]
 }
 
+resource "aws_ec2_tag" "cluster_primary_security_group" {
+  for_each = { for k, v in merge(var.tags, var.cluster_tags) : k => v if var.create }
+
+  resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
+  key         = each.key
+  value       = each.value
+}
+
 resource "aws_cloudwatch_log_group" "this" {
   count = local.create && var.create_cloudwatch_log_group ? 1 : 0
 


### PR DESCRIPTION
## Description
- Add tags to EKS created cluster security group to match rest of module tagging scheme

## Motivation and Context
- I discovered that cluster tags are not propagated to the security group created by the EKS service https://github.com/aws/karpenter/pull/1332/files#diff-c996548a210a321770151def6b6f02b6204a8bcdda9a1e1d86973fa3fbda5e18R145-R152 - this will now add those tags similar to the scheme used on the cluster definition itself

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Tested on `complete` example