### PR TITLE
self managed node group fails with default cluster_version = null

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -2,12 +2,15 @@ data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
 data "aws_ami" "eks_default" {
   count = var.create ? 1 : 0
 
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-v*"]
+    values = ["amazon-eks-node-${var.cluster_version != null ? var.cluster_version : data.aws_eks_cluster.cluster.version}-v*"]
   }
 
   most_recent = true

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -211,7 +211,7 @@ variable "ami_id" {
 }
 
 variable "cluster_version" {
-  description = "Kubernetes cluster version - used to lookup default AMI ID if one is not provided"
+  description = "Kubernetes cluster version - used to lookup default AMI ID if one is not provided. Defaults to the EKS cluster version."
   type        = string
   default     = null
 }


### PR DESCRIPTION
self managed node group fails with default cluster_version = null

## Description

The self managed node group uses the [cluster_version input](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/modules/self-managed-node-group#input_cluster_version) used to lookup default AMI ID if one is not provided. But the default for `cluster_version` is `null`.

The `data.aws_ami.eks_default` data resource will fail to [filter](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/self-managed-node-group/main.tf#L10) with the null value. e.g. `amazon-eks-node-null-v*`

## Motivation and Context

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1959

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- I tested locally.
