### PR TITLE
fix: The data.aws_ami.eks_default filter requires sting and got null

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -7,7 +7,7 @@ data "aws_ami" "eks_default" {
 
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${var.cluster_version}-v*"]
+    values = ["amazon-eks-node-${var.cluster_version != null ? var.cluster_version : "*"}-v*"]
   }
 
   most_recent = true


### PR DESCRIPTION
## Description
The `data.aws_ami.eks_default` filter requires sting and get null by default.

## Motivation and Context

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1959#issuecomment-1077670471

## Breaking Changes
N/A

## How Has This Been Tested?
- comment out the `cluster_version` in the [self_managed_node_group_example](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/examples/self_managed_node_group/main.tf#L27) and let it default to null
- run a plan
```bash
╷
│ Error: Invalid template interpolation value
│ 
│   on ../../modules/self-managed-node-group/main.tf line 10, in data "aws_ami" "eks_default":
│   10:     values = ["amazon-eks-node-${var.cluster_version}-v*"]
│     ├────────────────
│     │ var.cluster_version is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
╵
╷
│ Error: Invalid template interpolation value
│ 
│   on ../../modules/self-managed-node-group/main.tf line 10, in data "aws_ami" "eks_default":
│   10:     values = ["amazon-eks-node-${var.cluster_version}-v*"]
│     ├────────────────
│     │ var.cluster_version is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
╵
╷
│ Error: Invalid template interpolation value
│ 
│   on ../../modules/self-managed-node-group/main.tf line 10, in data "aws_ami" "eks_default":
│   10:     values = ["amazon-eks-node-${var.cluster_version}-v*"]
│     ├────────────────
│     │ var.cluster_version is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
╵
╷
│ Error: Invalid template interpolation value
│ 
│   on ../../modules/self-managed-node-group/main.tf line 10, in data "aws_ami" "eks_default":
│   10:     values = ["amazon-eks-node-${var.cluster_version}-v*"]
│     ├────────────────
│     │ var.cluster_version is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
╵
```

