### PR TITLE
fix: Default to cluster version for EKS and self managed node groups when a `cluster_version` is not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ module "karpenter_irsa" {
   role_name                          = "karpenter_controller"
   attach_karpenter_controller_policy = true
 
-  karpenter_controller_cluster_ids        = [module.eks.cluster_id]
+  karpenter_controller_cluster_id         = module.eks.cluster_id
   karpenter_controller_node_iam_role_arns = [
     module.eks.eks_managed_node_groups["default"].iam_role_arn
   ]
@@ -938,6 +938,7 @@ Full contributing [guidelines are covered here](https://github.com/terraform-aws
 | <a name="output_cluster_security_group_arn"></a> [cluster\_security\_group\_arn](#output\_cluster\_security\_group\_arn) | Amazon Resource Name (ARN) of the cluster security group |
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | ID of the cluster security group |
 | <a name="output_cluster_status"></a> [cluster\_status](#output\_cluster\_status) | Status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED` |
+| <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The Kubernetes version for the cluster |
 | <a name="output_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#output\_eks\_managed\_node\_groups) | Map of attribute maps for all EKS managed node groups created |
 | <a name="output_eks_managed_node_groups_autoscaling_group_names"></a> [eks\_managed\_node\_groups\_autoscaling\_group\_names](#output\_eks\_managed\_node\_groups\_autoscaling\_group\_names) | List of the autoscaling group names created by EKS managed node groups |
 | <a name="output_fargate_profiles"></a> [fargate\_profiles](#output\_fargate\_profiles) | Map of attribute maps for all EKS Fargate Profiles created |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,9 +3,8 @@ provider "aws" {
 }
 
 locals {
-  name            = "ex-${replace(basename(path.cwd), "_", "-")}"
-  cluster_version = "1.21"
-  region          = "eu-west-1"
+  name   = "ex-${replace(basename(path.cwd), "_", "-")}"
+  region = "eu-west-1"
 
   tags = {
     Example    = local.name
@@ -22,7 +21,6 @@ module "eks" {
   source = "../.."
 
   cluster_name                    = local.name
-  cluster_version                 = local.cluster_version
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 
@@ -188,7 +186,7 @@ module "eks_managed_node_group" {
 
   name            = "separate-eks-mng"
   cluster_name    = module.eks.cluster_id
-  cluster_version = local.cluster_version
+  cluster_version = module.eks.cluster_version
 
   vpc_id                            = module.vpc.vpc_id
   subnet_ids                        = module.vpc.private_subnets
@@ -205,7 +203,7 @@ module "self_managed_node_group" {
 
   name                = "separate-self-mng"
   cluster_name        = module.eks.cluster_id
-  cluster_version     = local.cluster_version
+  cluster_version     = module.eks.cluster_version
   cluster_endpoint    = module.eks.cluster_endpoint
   cluster_auth_base64 = module.eks.cluster_certificate_authority_data
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "aws_eks_cluster" "this" {
 }
 
 resource "aws_ec2_tag" "cluster_primary_security_group" {
-  for_each = { for k, v in merge(var.tags, var.cluster_tags) : k => v if var.create }
+  for_each = { for k, v in merge(var.tags, var.cluster_tags) : k => v if local.create }
 
   resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
   key         = each.key

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -231,7 +231,7 @@ module "eks_managed_node_group" {
   create = try(each.value.create, true)
 
   cluster_name              = aws_eks_cluster.this[0].name
-  cluster_version           = try(each.value.cluster_version, var.eks_managed_node_group_defaults.cluster_version, var.cluster_version)
+  cluster_version           = try(each.value.cluster_version, var.eks_managed_node_group_defaults.cluster_version, aws_eks_cluster.this[0].version)
   cluster_security_group_id = local.cluster_security_group_id
   cluster_ip_family         = var.cluster_ip_family
 
@@ -402,7 +402,7 @@ module "self_managed_node_group" {
 
   ebs_optimized   = try(each.value.ebs_optimized, var.self_managed_node_group_defaults.ebs_optimized, null)
   ami_id          = try(each.value.ami_id, var.self_managed_node_group_defaults.ami_id, "")
-  cluster_version = try(each.value.cluster_version, var.self_managed_node_group_defaults.cluster_version, var.cluster_version)
+  cluster_version = try(each.value.cluster_version, var.self_managed_node_group_defaults.cluster_version, aws_eks_cluster.this[0].version)
   instance_type   = try(each.value.instance_type, var.self_managed_node_group_defaults.instance_type, "m6i.large")
   key_name        = try(each.value.key_name, var.self_managed_node_group_defaults.key_name, null)
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,11 @@ output "cluster_oidc_issuer_url" {
   value       = try(aws_eks_cluster.this[0].identity[0].oidc[0].issuer, "")
 }
 
+output "cluster_version" {
+  description = "The Kubernetes version for the cluster"
+  value       = try(aws_eks_cluster.this[0].version, "")
+}
+
 output "cluster_platform_version" {
   description = "Platform version for the cluster"
   value       = try(aws_eks_cluster.this[0].platform_version, "")


### PR DESCRIPTION
## Description
- Default to cluster version for EKS and self managed node groups when a `cluster_version` is not specified
- Add `cluster_version` output for users to use when using separate node group sub-modules (see updated `complete` example)
- Correct doc change for Karpenter IRSA example

## Motivation and Context
- Relates to #1959
- Relates to #1960
- Closes #1962
- The `version` on the EKS cluster resource is optional and will default to the latest Kubernetes version supported by EKS. However, if a version is not specified in the root module via `var.cluster_version`, then a version is not propagated to the sub-modules which can result in an error. By changing from the `var.cluster_version` to the EKS cluster resource output of `version` and using that as the default, we are able to achieve the same functionality when users do not specify a `var.cluster_version`

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Updated `complete` example and verified functionality