### PR TITLE
feat: Update TLS provider and remove unnecessary cloud init version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,14 +807,14 @@ Full contributing [guidelines are covered here](https://github.com/terraform-aws
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 2.2 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
 
 ## Modules
 

--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -568,6 +568,12 @@ resource "aws_launch_template" "external" {
     enabled = true
   }
 
+  # Disabling due to https://github.com/hashicorp/terraform-provider-aws/issues/23766
+  # network_interfaces {
+  #   associate_public_ip_address = false
+  #   delete_on_termination       = true
+  # }
+
   # if you want to use a custom AMI
   # image_id      = var.ami_id
 

--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -568,11 +568,6 @@ resource "aws_launch_template" "external" {
     enabled = true
   }
 
-  network_interfaces {
-    associate_public_ip_address = false
-    delete_on_termination       = true
-  }
-
   # if you want to use a custom AMI
   # image_id      = var.ami_id
 

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -50,7 +50,6 @@ module "eks_managed_node_group" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
-| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | >= 2.0 |
 
 ## Providers
 

--- a/modules/eks-managed-node-group/versions.tf
+++ b/modules/eks-managed-node-group/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.72"
     }
-    cloudinit = {
-      source  = "hashicorp/cloudinit"
-      version = ">= 2.0"
-    }
   }
 }

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -41,7 +41,6 @@ module "self_managed_node_group" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
-| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | >= 2.0 |
 
 ## Providers
 

--- a/modules/self-managed-node-group/versions.tf
+++ b/modules/self-managed-node-group/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.72"
     }
-    cloudinit = {
-      source  = "hashicorp/cloudinit"
-      version = ">= 2.0"
-    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 2.2"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
## Description
- Update TLS provider to require at least v3.0; there are no code changes required for this
- Remove unnecessary cloud init version requirements in the EKS managed node group and self managed node group modules; the version is constrained in the user data module which both of those module use, rendering their requirements redundant

## Motivation and Context
- Keep providers up to date and clean up redundant requirements

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Tested on `eks-managed-node-group` example
