### PR TITLE
feat: Support default_tags in aws_autoscaling_group

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,5 +1,11 @@
 provider "aws" {
   region = local.region
+
+  default_tags {
+    tags = {
+      ExampleDefaultTag = "ExampleDefaultValue"
+    }
+  }
 }
 
 locals {
@@ -215,6 +221,8 @@ module "self_managed_node_group" {
     module.eks.cluster_primary_security_group_id,
     module.eks.cluster_security_group_id,
   ]
+
+  use_default_tags = true
 
   tags = merge(local.tags, { Separate = "self-managed-node-group" })
 }

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -68,6 +68,7 @@ module "self_managed_node_group" {
 | [aws_security_group_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.eks_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_default_tags.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
@@ -161,6 +162,7 @@ module "self_managed_node_group" {
 | <a name="input_target_group_arns"></a> [target\_group\_arns](#input\_target\_group\_arns) | A set of `aws_alb_target_group` ARNs, for use with Application or Network Load Balancing | `list(string)` | `[]` | no |
 | <a name="input_termination_policies"></a> [termination\_policies](#input\_termination\_policies) | A list of policies to decide how the instances in the Auto Scaling Group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `OldestLaunchTemplate`, `AllocationStrategy`, `Default` | `list(string)` | `null` | no |
 | <a name="input_update_launch_template_default_version"></a> [update\_launch\_template\_default\_version](#input\_update\_launch\_template\_default\_version) | Whether to update Default Version each update. Conflicts with `launch_template_default_version` | `bool` | `true` | no |
+| <a name="input_use_default_tags"></a> [use\_default\_tags](#input\_use\_default\_tags) | Enables/disables the use of provider default tags in the tag\_specifications of the Auto Scaling group | `bool` | `false` | no |
 | <a name="input_use_mixed_instances_policy"></a> [use\_mixed\_instances\_policy](#input\_use\_mixed\_instances\_policy) | Determines whether to use a mixed instances policy in the autoscaling group or not | `bool` | `false` | no |
 | <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix | `bool` | `true` | no |
 | <a name="input_user_data_template_path"></a> [user\_data\_template\_path](#input\_user\_data\_template\_path) | Path to a local, custom user data template file to use when rendering user data | `string` | `""` | no |

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -2,6 +2,8 @@ data "aws_partition" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_default_tags" "current" {}
+
 data "aws_ami" "eks_default" {
   count = var.create ? 1 : 0
 
@@ -385,7 +387,7 @@ resource "aws_autoscaling_group" "this" {
         "kubernetes.io/cluster/${var.cluster_name}" = "owned"
         "k8s.io/cluster/${var.cluster_name}"        = "owned"
       },
-      var.tags,
+      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
     )
 
     content {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -452,6 +452,12 @@ variable "delete_timeout" {
   default     = null
 }
 
+variable "use_default_tags" {
+  description = "Enables/disables the use of provider default tags in the tag_specifications of the Auto Scaling group"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Autoscaling group schedule
 ################################################################################

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -381,7 +381,8 @@ module "self_managed_node_group" {
   create_schedule = try(each.value.create_schedule, var.self_managed_node_group_defaults.create_schedule, false)
   schedules       = try(each.value.schedules, var.self_managed_node_group_defaults.schedules, null)
 
-  delete_timeout = try(each.value.delete_timeout, var.self_managed_node_group_defaults.delete_timeout, null)
+  delete_timeout   = try(each.value.delete_timeout, var.self_managed_node_group_defaults.delete_timeout, null)
+  use_default_tags = try(each.value.use_default_tags, var.self_managed_node_group_defaults.use_default_tags, false)
 
   # User data
   platform                 = try(each.value.platform, var.self_managed_node_group_defaults.platform, "linux")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add new attribute `use_default_tags` to EKS self managed node group module definition. When set to `true`, the default tags configured on the provider will be added to the autoscaling_group tags.
* Update the root module to look at `var.self_managed_node_groups` or `var.self_managed_node_group_defaults` and pass the result to the self managed node group module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1916 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [✅ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [✅ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [✅ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
