### PR TITLE
feat: Add back in CloudWatch log group create deny policy to cluster IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,7 +227,7 @@ resource "aws_iam_role" "this" {
   dynamic "inline_policy" {
     for_each = var.create_cloudwatch_log_group ? [1] : []
     content {
-      name = var.iam_role_use_name_prefix ? null : local.iam_role_name
+      name = local.iam_role_name
 
       policy = jsonencode({
         Version = "2012-10-17"

--- a/main.tf
+++ b/main.tf
@@ -219,6 +219,29 @@ resource "aws_iam_role" "this" {
   permissions_boundary  = var.iam_role_permissions_boundary
   force_detach_policies = true
 
+  # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/920
+  # Resources running on the cluster are still generaring logs when destroying the module resources
+  # which results in the log group being re-created even after Terraform destroys it. Removing the
+  # ability for the cluster role to create the log group prevents this log group from being re-created
+  # outside of Terraform due to services still generating logs during destroy process
+  dynamic "inline_policy" {
+    for_each = var.create_cloudwatch_log_group ? [1] : []
+    content {
+      name = var.iam_role_use_name_prefix ? null : local.iam_role_name
+
+      policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Action   = ["logs:CreateLogGroup"]
+            Effect   = "Deny"
+            Resource = aws_cloudwatch_log_group.this[0].arn
+          },
+        ]
+      })
+    }
+  }
+
   tags = merge(var.tags, var.iam_role_tags)
 }
 


### PR DESCRIPTION
## Description
- Add back in CloudWatch log group create deny policy to cluster IAM role. A note has been added and reference to original issue to better explain the issue that is being solved

## Motivation and Context
- Relates to a prior issue https://github.com/terraform-aws-modules/terraform-aws-eks/issues/920 and uses a similar solution https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1594

## Breaking Changes
- No; to users the change will be functionally transparent but will show up in the next subsequent plan (if their use case creates an IAM role and CloudWatch log group)

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
  - Already in place
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- Validated with `examples/eks_managed_node_group`
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
