### PR TITLE
fix: Correct `capacity_reservation_target` within launch templates of both EKS and self managed node groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
+    rev: v1.64.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/examples/self_managed_node_group/README.md
+++ b/examples/self_managed_node_group/README.md
@@ -49,6 +49,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Type |
 |------|------|
+| [aws_ec2_capacity_reservation.targeted](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_capacity_reservation) | resource |
 | [aws_key_pair.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_kms_key.ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |

--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -202,6 +202,12 @@ module "eks" {
         instance_metadata_tags      = "disabled"
       }
 
+      capacity_reservation_specification = {
+        capacity_reservation_target = {
+          capacity_reservation_id = aws_ec2_capacity_reservation.targeted.id
+        }
+      }
+
       create_iam_role          = true
       iam_role_name            = "self-managed-node-group-complete-example"
       iam_role_use_name_prefix = false
@@ -405,6 +411,14 @@ resource "aws_kms_key" "ebs" {
   description             = "Customer managed key to encrypt self managed node group volumes"
   deletion_window_in_days = 7
   policy                  = data.aws_iam_policy_document.ebs.json
+}
+
+resource "aws_ec2_capacity_reservation" "targeted" {
+  instance_type           = "m6i.large"
+  instance_platform       = "Linux/UNIX"
+  availability_zone       = "${local.region}a"
+  instance_count          = 1
+  instance_match_criteria = "targeted"
 }
 
 # This policy is required for the KMS key used for EKS root volumes, so the cluster is allowed to enc/dec/attach encrypted EBS volumes

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -94,7 +94,7 @@ resource "aws_launch_template" "this" {
       capacity_reservation_preference = lookup(capacity_reservation_specification.value, "capacity_reservation_preference", null)
 
       dynamic "capacity_reservation_target" {
-        for_each = lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
         content {
           capacity_reservation_id = lookup(capacity_reservation_target.value, "capacity_reservation_id", null)
         }

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -97,7 +97,7 @@ resource "aws_launch_template" "this" {
       capacity_reservation_preference = lookup(capacity_reservation_specification.value, "capacity_reservation_preference", null)
 
       dynamic "capacity_reservation_target" {
-        for_each = lookup(capacity_reservation_specification.value, "capacity_reservation_target", [])
+        for_each = try([capacity_reservation_specification.value.capacity_reservation_target], [])
         content {
           capacity_reservation_id = lookup(capacity_reservation_target.value, "capacity_reservation_id", null)
         }


### PR DESCRIPTION
## Description
- Correct `capacity_reservation_target` within launch templates of both EKS and self managed node groups

## Motivation and Context
- Closes #1897
- Closes #1898

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
