### PR TITLE
feat: Add `create_before_destroy` lifecycle hook to security groups created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,10 @@ resource "aws_security_group" "cluster" {
     { "Name" = local.cluster_sg_name },
     var.cluster_security_group_tags
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "cluster" {

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -372,6 +372,12 @@ resource "aws_security_group" "this" {
     { "Name" = local.security_group_name },
     var.security_group_tags
   )
+
+  # https://github.com/hashicorp/terraform-provider-aws/issues/2445
+  # https://github.com/hashicorp/terraform-provider-aws/issues/9692
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "this" {

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -458,6 +458,12 @@ resource "aws_security_group" "this" {
     },
     var.security_group_tags
   )
+
+  # https://github.com/hashicorp/terraform-provider-aws/issues/2445
+  # https://github.com/hashicorp/terraform-provider-aws/issues/9692
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "this" {

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -161,6 +161,10 @@ resource "aws_security_group" "node" {
     },
     var.node_security_group_tags
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "node" {


### PR DESCRIPTION
## Description
- Add `create_before_destroy` lifecycle hook to security groups created

## Motivation and Context
- This came up in testing how to remove the node group specific security group that is mostly unused by users. When trying to set `create_security_group` to `false` after it defaults to `true` and has been created, the security group is unable to detach and delete. Reading through the numerous issues, I am hopeful this might work for the autoscaling groups. If not, it should be in place regardless for when users re-name their security groups and they need to be re-created

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
