### PR TITLE
fix: Adding a 'legacy_names' var to support older v17 name schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `string` | `true` | no |
-
 | <a name="input_legacy_names"></a> [legacy\_name](#input\_legacy\_name) | Determines if resource names should be overriden with legacy naming conventions from v17 and earlier (`legacy_names`) is used as a prefix | `bool` | `false` | no |
-
 | <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source | `any` | `{}` | no |
 | <a name="input_node_security_group_description"></a> [node\_security\_group\_description](#input\_node\_security\_group\_description) | Description of the node security group created | `string` | `"EKS node shared security group"` | no |
 | <a name="input_node_security_group_id"></a> [node\_security\_group\_id](#input\_node\_security\_group\_id) | ID of an existing security group to attach to the node groups created | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `string` | `true` | no |
+
+| <a name="input_legacy_names"></a> [legacy\_name](#input\_legacy\_name) | Determines if resource names should be overriden with legacy naming conventions from v17 and earlier (`legacy_names`) is used as a prefix | `bool` | `false` | no |
+
 | <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source | `any` | `{}` | no |
 | <a name="input_node_security_group_description"></a> [node\_security\_group\_description](#input\_node\_security\_group\_description) | Description of the node security group created | `string` | `"EKS node shared security group"` | no |
 | <a name="input_node_security_group_id"></a> [node\_security\_group\_id](#input\_node\_security\_group\_id) | ID of an existing security group to attach to the node groups created | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ resource "aws_security_group" "cluster" {
   count = local.create_cluster_sg ? 1 : 0
 
   name        = var.cluster_security_group_use_name_prefix ? null : local.cluster_sg_name
-  name_prefix = var.cluster_security_group_use_name_prefix ? "${local.cluster_sg_name}${var.prefix_separator}" : null
+  name_prefix = var.legacy_names ? var.cluster_name : var.cluster_security_group_use_name_prefix ? "${local.cluster_sg_name}${var.prefix_separator}" : null
   description = var.cluster_security_group_description
   vpc_id      = var.vpc_id
 
@@ -215,7 +215,7 @@ resource "aws_iam_role" "this" {
   count = local.create_iam_role ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
+  name_prefix = var.legacy_names ? var.cluster_name : var.iam_role_use_name_prefix ? "${local.iam_role_name}${var.prefix_separator}" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -52,7 +52,7 @@ resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template ? 1 : 0
 
   name        = var.launch_template_use_name_prefix ? null : local.launch_template_name_int
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
+  name_prefix = var.legacy_names ? "${var.cluster_name}-${var.name}" : var.launch_template_use_name_prefix ? "${local.launch_template_name_int}-" : null
   description = var.launch_template_description
 
   ebs_optimized = var.ebs_optimized
@@ -266,7 +266,7 @@ resource "aws_autoscaling_group" "this" {
   count = var.create ? 1 : 0
 
   name        = var.use_name_prefix ? null : var.name
-  name_prefix = var.use_name_prefix ? "${var.name}-" : null
+  name_prefix = var.legacy_names ? "${var.cluster_name}-${var.name}" : var.use_name_prefix ? "${var.name}-" : null
 
   dynamic "launch_template" {
     for_each = var.use_mixed_instances_policy ? [] : [1]
@@ -447,7 +447,7 @@ resource "aws_security_group" "this" {
   count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
-  name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
+  name_prefix = var.legacy_names ? var.cluster_name : var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
   description = var.security_group_description
   vpc_id      = var.vpc_id
 
@@ -518,7 +518,7 @@ resource "aws_iam_role" "this" {
   count = var.create && var.create_iam_instance_profile ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.legacy_names ? var.cluster_name : var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
   path        = var.iam_role_path
   description = var.iam_role_description
 
@@ -547,7 +547,7 @@ resource "aws_iam_instance_profile" "this" {
   role = aws_iam_role.this[0].name
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
-  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  name_prefix = var.legacy_names ? var.cluster_name : var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
   path        = var.iam_role_path
 
   lifecycle {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -4,6 +4,12 @@ variable "create" {
   default     = true
 }
 
+variable "legacy_names" {
+  description = "Determines whether to use legacy naming conventions and prefixes from v17 or not"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -149,7 +149,7 @@ resource "aws_security_group" "node" {
   count = local.create_node_sg ? 1 : 0
 
   name        = var.node_security_group_use_name_prefix ? null : local.node_sg_name
-  name_prefix = var.node_security_group_use_name_prefix ? "${local.node_sg_name}${var.prefix_separator}" : null
+  name_prefix = var.legacy_names ? var.cluster_name : var.node_security_group_use_name_prefix ? "${local.node_sg_name}${var.prefix_separator}" : null
   description = var.node_security_group_description
   vpc_id      = var.vpc_id
 
@@ -344,6 +344,7 @@ module "self_managed_node_group" {
 
   cluster_name      = aws_eks_cluster.this[0].name
   cluster_ip_family = var.cluster_ip_family
+  legacy_names      = var.legacy_names
 
   # Autoscaling Group
   name            = try(each.value.name, each.key)

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "prefix_separator" {
   default     = "-"
 }
 
+variable "legacy_names" {
+  description = "Determines whether to use legacy naming conventions and prefixes from v17 or not"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Cluster
 ################################################################################


### PR DESCRIPTION
## Description
Adding a true/false variable like `legacy_names` shown here allows users to deploy the v18+ module using the older v17 style naming conventions for resources.

## Motivation and Context
One of the breaking changes introduced in v18 is [a change to the naming_prefixes](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/3ff17205a4ead51cca993547ef3de42cc080043b/docs/UPGRADE-18.0.md?plain=1#L33) used by almost all resources. These new naming prefixes cannot be overridden so previous "<worker_name>" resources will be destroyed and replaced by "<worker_name>-node-group" resources or the like.

Adding a `legacy_names` var allows small conditionals that can choose the new v18-style prefixes or the older v17-style prefixes so the v17 resources aren't destroyed/replaced just for a non-functional name change.

## Breaking Changes
No breaking changes. A `legacy_names` var should default to `false` so existing deployments would be unaffected.

## How Has This Been Tested?
Tested during the process of updating our own v17 cluster to v18. The variable defaulting `false` means it will be ignored by any implementation that doesn't actively set it to true in order to use the v17 matching names.
