### PR TITLE
fix: Avoid re-naming the primary security group through a `Name` tag and leave to the EKS service to manage

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -67,6 +67,13 @@ module "eks" {
     resources        = ["secrets"]
   }]
 
+  cluster_tags = {
+    # This should not affect the name of the cluster primary security group
+    # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
+    # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
+    Name = local.name
+  }
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,10 @@ resource "aws_eks_cluster" "this" {
 }
 
 resource "aws_ec2_tag" "cluster_primary_security_group" {
-  for_each = { for k, v in merge(var.tags, var.cluster_tags) : k => v if local.create }
+  # This should not affect the name of the cluster primary security group
+  # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
+  # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
+  for_each = { for k, v in merge(var.tags, var.cluster_tags) : k => v if local.create && k != "Name" }
 
   resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
   key         = each.key


### PR DESCRIPTION
## Description
- Avoid re-naming the primary security group through a `Name` tag and leave to the EKS service to manage

## Motivation and Context
- Closes #2006
- Closes #2008

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
