### PR TITLE
feat: Add support for managing `aws_eks_addon` versions using the new `aws_eks_addon_versions` data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ module "eks" {
     kube-proxy = {}
     vpc-cni = {
       resolve_conflicts = "OVERWRITE"
+      most_recent = true
     }
   }
 
@@ -249,6 +250,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [kubernetes_config_map.aws_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map_v1_data.aws_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
+| [aws_eks_addon_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data|
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -49,6 +49,7 @@ module "eks" {
     kube-proxy = {}
     vpc-cni = {
       resolve_conflicts = "OVERWRITE"
+      most_recent = true
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -305,9 +305,9 @@ resource "aws_iam_policy" "cluster_encryption" {
 data "aws_eks_addon_version" "this" {
   for_each = { for k, v in var.cluster_addons : k => v if local.create }
 
-  addon_name   = try(each.value.name, each.key)
+  addon_name         = try(each.value.name, each.key)
   kubernetes_version = var.cluster_version
-  most_recent = true
+  most_recent        = true
 }
 
 resource "aws_eks_addon" "this" {
@@ -316,7 +316,7 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = lookup(each.value, "addon_version", aws_eks_addon_version[try(each.value.name, each.key)].version)
+  addon_version            = lookup(each.value, "addon_version", data.aws_eks_addon_version.this[try(each.value.name, each.key)].version)
   resolve_conflicts        = lookup(each.value, "resolve_conflicts", null)
   service_account_role_arn = lookup(each.value, "service_account_role_arn", null)
 

--- a/main.tf
+++ b/main.tf
@@ -307,7 +307,7 @@ data "aws_eks_addon_version" "this" {
 
   addon_name         = try(each.value.name, each.key)
   kubernetes_version = var.cluster_version
-  most_recent        = true
+  most_recent        = lookup(each.value, "most_recent", false)
 }
 
 resource "aws_eks_addon" "this" {


### PR DESCRIPTION
## Description
uses the `aws_eks_addon_versions` data source to determine default vs latest version of a given addon

## Motivation and Context
EKS addon versions are deployed with their default versions, unless specified.  These aren't necessarily the latest versions, such as `vpc-cni` which gets deployed with `1.7` instead of the docs-recommended `1.10`.  Deploying with the latest available version also helps to keep teams updated, unless they decide to pin to a specific version.

fixes #1908 

## How Has This Been Tested?
- [] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
