### PR TITLE
fix: Correct DNS suffix for OIDC provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ data "tls_certificate" "this" {
 resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count = local.create && var.enable_irsa ? 1 : 0
 
-  client_id_list  = distinct(compact(concat(["sts.${data.aws_partition.current.dns_suffix}"], var.openid_connect_audiences)))
+  client_id_list  = distinct(compact(concat(["sts.${local.dns_suffix}"], var.openid_connect_audiences)))
   thumbprint_list = concat([data.tls_certificate.this[0].certificates[0].sha1_fingerprint], var.custom_oidc_thumbprints)
   url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 


### PR DESCRIPTION
## Description

This is a supplement fix for
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1904

## Motivation and Context

This MR is a combined fix for succefully launching Karpenter 0.8.2 on AWS EKS on China Region (cn-northwest-1)

## Breaking Changes

N/A

## How Has This Been Tested?
- [*] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

AWS EKS version 1.22 + Karpenter 0.8.2 launched succefully with this fix with node scaling test done.