### PR TITLE
fix: Add `compact()` to `aws_auth_configmap_yaml` for when node groups are set to `create = false`

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -185,10 +185,10 @@ output "aws_auth_configmap_yaml" {
   description = "[DEPRECATED - use `var.manage_aws_auth_configmap`] Formatted yaml output for base aws-auth configmap containing roles used in cluster node groups/fargate profiles"
   value = templatefile("${path.module}/templates/aws_auth_cm.tpl",
     {
-      eks_managed_role_arns                   = [for group in module.eks_managed_node_group : group.iam_role_arn]
-      self_managed_role_arns                  = [for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"]
-      win32_self_managed_role_arns            = [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"]
-      fargate_profile_pod_execution_role_arns = [for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn]
+      eks_managed_role_arns                   = compact([for group in module.eks_managed_node_group : group.iam_role_arn])
+      self_managed_role_arns                  = compact([for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"])
+      win32_self_managed_role_arns            = compact([for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"])
+      fargate_profile_pod_execution_role_arns = compact([for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn])
     }
   )
 }


### PR DESCRIPTION
## Description
- Add `compact()` to `aws_auth_configmap_yaml` for when node groups are set to `create = false`

## Motivation and Context
- Closes #1970 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
