### PR TITLE
chore: Update Karpenter example to use partition data source

### DIFF
--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -69,7 +69,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | ../.. | n/a |
-| <a name="module_karpenter_irsa"></a> [karpenter\_irsa](#module\_karpenter\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.15 |
+| <a name="module_karpenter_irsa"></a> [karpenter\_irsa](#module\_karpenter\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.21.1 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
@@ -80,6 +80,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [helm_release.karpenter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.karpenter_example_deployment](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.karpenter_provisioner](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 


### PR DESCRIPTION
## Description
This example change comes along with https://github.com/terraform-aws-modules/terraform-aws-iam/pull/235

## Motivation and Context
Offered an example file that works for partition such as aws-gov and aws-cn

## Breaking Changes
N/A

## How Has This Been Tested?
- [*] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)

With combined MRs, an eks cluster with kapenter 0.8.2 is successfully launched on cn-northwest-1 region.
