### PR TITLE
feat: Add `create_autoscaling_group` option and extra outputs

### DIFF
--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -91,6 +91,7 @@ module "self_managed_node_group" {
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes cluster version - used to lookup default AMI ID if one is not provided | `string` | `null` | no |
 | <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | The CPU options for the instance | `map(string)` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether to create self managed node group or not | `bool` | `true` | no |
+| <a name="input_create_autoscaling_group"></a> [create\_autoscaling\_group](#input\_create\_autoscaling\_group) | Determines whether to create self managed autoscaling group or not | `bool` | `true` | no |
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `true` | no |
 | <a name="input_create_launch_template"></a> [create\_launch\_template](#input\_create\_launch\_template) | Determines whether to create launch template or not | `bool` | `true` | no |
 | <a name="input_create_schedule"></a> [create\_schedule](#input\_create\_schedule) | Determines whether to create autoscaling group schedule or not | `bool` | `true` | no |

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -91,7 +91,7 @@ module "self_managed_node_group" {
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes cluster version - used to lookup default AMI ID if one is not provided | `string` | `null` | no |
 | <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | The CPU options for the instance | `map(string)` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether to create self managed node group or not | `bool` | `true` | no |
-| <a name="input_create_autoscaling_group"></a> [create\_autoscaling\_group](#input\_create\_autoscaling\_group) | Determines whether to create self managed autoscaling group or not | `bool` | `true` | no |
+| <a name="input_create_autoscaling_group"></a> [create\_autoscaling\_group](#input\_create\_autoscaling\_group) | Determines whether to create autoscaling group or not | `bool` | `true` | no |
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `true` | no |
 | <a name="input_create_launch_template"></a> [create\_launch\_template](#input\_create\_launch\_template) | Determines whether to create launch template or not | `bool` | `true` | no |
 | <a name="input_create_schedule"></a> [create\_schedule](#input\_create\_schedule) | Determines whether to create autoscaling group schedule or not | `bool` | `true` | no |
@@ -195,10 +195,12 @@ module "self_managed_node_group" {
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | The Amazon Resource Name (ARN) specifying the IAM role |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The name of the IAM role |
 | <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Stable and unique string identifying the IAM role |
+| <a name="output_image_id"></a> [image\_id](#output\_image\_id) | ID of the image |
 | <a name="output_launch_template_arn"></a> [launch\_template\_arn](#output\_launch\_template\_arn) | The ARN of the launch template |
 | <a name="output_launch_template_id"></a> [launch\_template\_id](#output\_launch\_template\_id) | The ID of the launch template |
 | <a name="output_launch_template_latest_version"></a> [launch\_template\_latest\_version](#output\_launch\_template\_latest\_version) | The latest version of the launch template |
 | <a name="output_platform"></a> [platform](#output\_platform) | Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
+| <a name="output_user_data"></a> [user\_data](#output\_user\_data) | Base64 encoded user data |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -263,7 +263,7 @@ locals {
 }
 
 resource "aws_autoscaling_group" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.create_autoscaling_group ? 1 : 0
 
   name        = var.use_name_prefix ? null : var.name
   name_prefix = var.use_name_prefix ? "${var.name}-" : null

--- a/modules/self-managed-node-group/outputs.tf
+++ b/modules/self-managed-node-group/outputs.tf
@@ -145,3 +145,13 @@ output "platform" {
   description = "Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based"
   value       = var.platform
 }
+
+output "image_id" {
+  description = "ID of the image"
+  value       = try(data.aws_ami.eks_default[0].image_id, "")
+}
+
+output "user_data" {
+  description = "Base64 encoded user data"
+  value       = try(module.user_data.user_data, "")
+}

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -266,6 +266,12 @@ variable "launch_template_tags" {
 # Autoscaling group
 ################################################################################
 
+variable "create_autoscaling_group" {
+  description = "Determines whether to create autoscaling group or not"
+  type        = bool
+  default     = true
+}
+
 variable "name" {
   description = "Name of the Self managed Node Group"
   type        = string

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -346,6 +346,8 @@ module "self_managed_node_group" {
   cluster_ip_family = var.cluster_ip_family
 
   # Autoscaling Group
+  create_autoscaling_group = try(each.value.create_autoscaling_group, var.self_managed_node_group_defaults.create_autoscaling_group, true)
+
   name            = try(each.value.name, each.key)
   use_name_prefix = try(each.value.use_name_prefix, var.self_managed_node_group_defaults.use_name_prefix, true)
 


### PR DESCRIPTION
## Description
adds  `create_autoscaling_group` to `self-managed-node-groups` and adds `image_id` and `user_data` outputs. 

## Motivation and Context

Currently to use this module with something like karpenter or spotinst you need to create a nodegroup and scale it down in order to have the iam role, userdata, etc. created for you.

You can then do something like this to get all the data you need:

```
data "aws_autoscaling_group" "spotinst" {
  name = module.eks.self_managed_node_groups["spotinst"].autoscaling_group_name
}

data "aws_launch_configuration" "spotinst" {
  name = data.aws_autoscaling_group.spotinst.launch_configuration
}

iam_instance_profile  = data.aws_launch_configuration.spotinst.iam_instance_profile
security_groups       = data.aws_launch_configuration.spotinst.security_groups
image_id              = data.aws_launch_configuration.spotinst.image_id
user_data             = data.aws_launch_configuration.spotinst.user_data
```
This PR eliminates the extra hoops by adding the `create_autoscaling_group` option and exporting the `image_id` and `user_data`.
