### PR TITLE
feat: Add AmazonEKSServicePolicy to clusters for compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -256,6 +256,7 @@ resource "aws_iam_role" "this" {
 resource "aws_iam_role_policy_attachment" "this" {
   for_each = local.create_iam_role ? toset(compact(distinct(concat([
     "${local.policy_arn_prefix}/AmazonEKSClusterPolicy",
+    "${local.policy_arn_prefix}/AmazonEKSServicePolicy",
     "${local.policy_arn_prefix}/AmazonEKSVPCResourceController",
   ], var.iam_role_additional_policies)))) : toset([])
 


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/userguide/security-iam-awsmanpol.html

You can attach AmazonEKSServicePolicy to your IAM entities. Clusters that
were created before April 16, 2020, required you to create an IAM role
and attach this policy to it. Clusters that were created on or after
April 16, 2020, don't require you to create a role and don't require
you to assign this policy.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Provide backwards compatibility for EKS clusters created prior to April 16, 2020

Without this change, older clusters will not be able to stream logs to Cloudwatch
among other lost functionality.

## Breaking Changes
N/A

## How Has This Been Tested?
Tested on our EKS cluster