### PR TITLE
Set ami_type to CUSTOM when providing ami_id

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -288,7 +288,7 @@ resource "aws_eks_node_group" "this" {
   node_group_name_prefix = var.use_name_prefix ? "${var.name}-" : null
 
   # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-custom-ami
-  ami_type        = var.ami_id != "" ? null : var.ami_type
+  ami_type        = var.ami_id != "" ? "CUSTOM" : var.ami_type
   release_version = var.ami_id != "" ? null : var.ami_release_version
   version         = var.ami_id != "" ? null : var.cluster_version
 


### PR DESCRIPTION
## Description

This fix lets you change the `ami_type` of a node-group from managed to `CUSTOM`.

## Motivation and Context

Even though this is an immutable parameter, the provider will destroy and recreate the node-group which is the desired behavior.

## How Has This Been Tested?
- [x] Tested on existing cluster, by switching a node-group from `AL2_x86-64` to `CUSTOM`