### PR TITLE
feat: Add `autoscaling_group_tags` variable to self-managed-node-groups

### DIFF
--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -97,6 +97,12 @@ module "eks" {
 
   self_managed_node_group_defaults = {
     create_security_group = false
+
+    # enable discovery of autoscaling groups by cluster-autoscaler
+    autoscaling_group_tags = {
+      "k8s.io/cluster-autoscaler/enabled" : true,
+      "k8s.io/cluster-autoscaler/${local.name}" : true,
+    }
   }
 
   self_managed_node_groups = {

--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -101,7 +101,7 @@ module "eks" {
     # enable discovery of autoscaling groups by cluster-autoscaler
     autoscaling_group_tags = {
       "k8s.io/cluster-autoscaler/enabled" : true,
-      "k8s.io/cluster-autoscaler/${local.name}" : true,
+      "k8s.io/cluster-autoscaler/${local.name}" : "owned",
     }
   }
 

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -77,6 +77,7 @@ module "self_managed_node_group" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | The AMI from which to launch the instance | `string` | `""` | no |
+| <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | A map of additional tags to add to the auto\_scaling\_group created | `map(string)` | `{}` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `subnet_ids` argument. Conflicts with `subnet_ids` | `list(string)` | `null` | no |
 | <a name="input_block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instance besides the volumes specified by the AMI | `any` | `{}` | no |
 | <a name="input_bootstrap_extra_args"></a> [bootstrap\_extra\_args](#input\_bootstrap\_extra\_args) | Additional arguments passed to the bootstrap script. When `platform` = `bottlerocket`; these are additional [settings](https://github.com/bottlerocket-os/bottlerocket#settings) that are provided to the Bottlerocket user data | `string` | `""` | no |

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -77,7 +77,7 @@ module "self_managed_node_group" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | The AMI from which to launch the instance | `string` | `""` | no |
-| <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | A map of additional tags to add to the auto\_scaling\_group created | `map(string)` | `{}` | no |
+| <a name="input_autoscaling_group_tags"></a> [autoscaling\_group\_tags](#input\_autoscaling\_group\_tags) | A map of additional tags to add to the autoscaling group created. Tags are applied to the autoscaling group only and are NOT propagated to instances | `map(string)` | `{}` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of one or more availability zones for the group. Used for EC2-Classic and default subnets when not specified with `subnet_ids` argument. Conflicts with `subnet_ids` | `list(string)` | `null` | no |
 | <a name="input_block_device_mappings"></a> [block\_device\_mappings](#input\_block\_device\_mappings) | Specify volumes to attach to the instance besides the volumes specified by the AMI | `any` | `{}` | no |
 | <a name="input_bootstrap_extra_args"></a> [bootstrap\_extra\_args](#input\_bootstrap\_extra\_args) | Additional arguments passed to the bootstrap script. When `platform` = `bottlerocket`; these are additional [settings](https://github.com/bottlerocket-os/bottlerocket#settings) that are provided to the Bottlerocket user data | `string` | `""` | no |

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -390,13 +390,23 @@ resource "aws_autoscaling_group" "this" {
         "kubernetes.io/cluster/${var.cluster_name}" = "owned"
         "k8s.io/cluster/${var.cluster_name}"        = "owned"
       },
-      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.autoscaling_group_tags, var.tags) : merge(var.autoscaling_group_tags, var.tags)
+      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
     )
 
     content {
       key                 = tag.key
       value               = tag.value
       propagate_at_launch = true
+    }
+  }
+
+  dynamic "tag" {
+    for_each = var.autoscaling_group_tags
+
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = false
     }
   }
 

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -390,7 +390,7 @@ resource "aws_autoscaling_group" "this" {
         "kubernetes.io/cluster/${var.cluster_name}" = "owned"
         "k8s.io/cluster/${var.cluster_name}"        = "owned"
       },
-      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
+      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.autoscaling_group_tags, var.tags) : var.tags
     )
 
     content {

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -390,7 +390,7 @@ resource "aws_autoscaling_group" "this" {
         "kubernetes.io/cluster/${var.cluster_name}" = "owned"
         "k8s.io/cluster/${var.cluster_name}"        = "owned"
       },
-      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.autoscaling_group_tags, var.tags) : var.tags
+      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.autoscaling_group_tags, var.tags) : merge(var.autoscaling_group_tags, var.tags)
     )
 
     content {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -464,6 +464,12 @@ variable "use_default_tags" {
   default     = false
 }
 
+variable "autoscaling_group_tags" {
+  description = "A map of additional tags to add to the auto_scaling_group created"
+  type        = map(string)
+  default     = {}
+}
+
 ################################################################################
 # Autoscaling group schedule
 ################################################################################

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -465,7 +465,7 @@ variable "use_default_tags" {
 }
 
 variable "autoscaling_group_tags" {
-  description = "A map of additional tags to add to the auto_scaling_group created"
+  description = "A map of additional tags to add to the autoscaling group created. Tags are applied to the autoscaling group only and are NOT propagated to instances"
   type        = map(string)
   default     = {}
 }

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -387,8 +387,8 @@ module "self_managed_node_group" {
   create_schedule = try(each.value.create_schedule, var.self_managed_node_group_defaults.create_schedule, false)
   schedules       = try(each.value.schedules, var.self_managed_node_group_defaults.schedules, null)
 
-  delete_timeout   = try(each.value.delete_timeout, var.self_managed_node_group_defaults.delete_timeout, null)
-  use_default_tags = try(each.value.use_default_tags, var.self_managed_node_group_defaults.use_default_tags, false)
+  delete_timeout         = try(each.value.delete_timeout, var.self_managed_node_group_defaults.delete_timeout, null)
+  use_default_tags       = try(each.value.use_default_tags, var.self_managed_node_group_defaults.use_default_tags, false)
   autoscaling_group_tags = try(each.value.autoscaling_group_tags, var.self_managed_node_group_defaults.autoscaling_group_tags, {})
 
   # User data

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -389,6 +389,7 @@ module "self_managed_node_group" {
 
   delete_timeout   = try(each.value.delete_timeout, var.self_managed_node_group_defaults.delete_timeout, null)
   use_default_tags = try(each.value.use_default_tags, var.self_managed_node_group_defaults.use_default_tags, false)
+  autoscaling_group_tags = try(each.value.autoscaling_group_tags, var.self_managed_node_group_defaults.autoscaling_group_tags, {})
 
   # User data
   platform                 = try(each.value.platform, var.self_managed_node_group_defaults.platform, "linux")


### PR DESCRIPTION
## Description

`cluster-autoscaler` discovers ASGs using tags, which could currently only be set by setting tags on all resources. This helps setting tags like `k8s.io/cluster-autoscaler/enabled` on the `aws_autoscaling_group` resources only.

## Motivation and Context

Fixes #2072 

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request