### PR TITLE
feat: Apply `distinct()` on role arns to ensure no duplicated roles in aws-auth configmap

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -356,21 +356,33 @@ resource "aws_eks_identity_provider_config" "this" {
 ################################################################################
 
 locals {
-  node_iam_role_arns_non_windows = compact(concat(
-    [for group in module.eks_managed_node_group : group.iam_role_arn],
-    [for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"],
-    var.aws_auth_node_iam_role_arns_non_windows,
-  ))
+  node_iam_role_arns_non_windows = distinct(
+    compact(
+      concat(
+        [for group in module.eks_managed_node_group : group.iam_role_arn],
+        [for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"],
+        var.aws_auth_node_iam_role_arns_non_windows,
+      )
+    )
+  )
 
-  node_iam_role_arns_windows = compact(concat(
-    [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"],
-    var.aws_auth_node_iam_role_arns_windows,
-  ))
+  node_iam_role_arns_windows = distinct(
+    compact(
+      concat(
+        [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"],
+        var.aws_auth_node_iam_role_arns_windows,
+      )
+    )
+  )
 
-  fargate_profile_pod_execution_role_arns = compact(concat(
-    [for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn],
-    var.aws_auth_fargate_profile_pod_execution_role_arns,
-  ))
+  fargate_profile_pod_execution_role_arns = distinct(
+    compact(
+      concat(
+        [for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn],
+        var.aws_auth_fargate_profile_pod_execution_role_arns,
+      )
+    )
+  )
 
   aws_auth_configmap_data = {
     mapRoles = yamlencode(concat(

--- a/outputs.tf
+++ b/outputs.tf
@@ -185,10 +185,10 @@ output "aws_auth_configmap_yaml" {
   description = "[DEPRECATED - use `var.manage_aws_auth_configmap`] Formatted yaml output for base aws-auth configmap containing roles used in cluster node groups/fargate profiles"
   value = templatefile("${path.module}/templates/aws_auth_cm.tpl",
     {
-      eks_managed_role_arns                   = compact([for group in module.eks_managed_node_group : group.iam_role_arn])
-      self_managed_role_arns                  = compact([for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"])
-      win32_self_managed_role_arns            = compact([for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"])
-      fargate_profile_pod_execution_role_arns = compact([for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn])
+      eks_managed_role_arns                   = distinct(compact([for group in module.eks_managed_node_group : group.iam_role_arn]))
+      self_managed_role_arns                  = distinct(compact([for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"]))
+      win32_self_managed_role_arns            = distinct(compact([for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"]))
+      fargate_profile_pod_execution_role_arns = distinct(compact([for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn]))
     }
   )
 }


### PR DESCRIPTION
## Description
Apply distinct() on role arns to ensure no duplicated roles in aws auth configmap

## Motivation and Context
1. Created a cluster with a couple of eks managed node groups which shared the same iam role names
```hcl
module "eks" {
  source  = "terraform-aws-modules/eks/aws"
  version = "~> 18.21"

  # other fields...

  eks_managed_node_groups = {
    "dummy_cpu" = {
      "ami_type" = "AL2_x86_64"
      "desired_size" = 1
      "instance_types" = [
        "t3.small",
      ]
      "max_size" = 1
      "min_size" = 0
      # other fields...
    }
    "dummy_gpu" = {
      "ami_type" = "AL2_x86_64_GPU"
      "desired_size" = 0
      "instance_types" = [
        "g4dn.xlarge",
      ]
      "max_size" = 1
      "min_size" = 0
      "taints" = [
        {
          "effect" = "NO_SCHEDULE"
          "key" = "nvidia.com/gpu"
          "value" = "true"
        },
      ]
      # other fields...
    }
    "dummy_testapp_cpu" = {
      "ami_type" = "AL2_x86_64"
      "desired_size" = 1
      "instance_types" = [
        "t3.small",
      ]
      "max_size" = 1
      "min_size" = 0
      # other fields...
    }
    "platform" = {
      "desired_size" = 1
      "instance_types" = [
        "t3.medium",
      ]
      "max_size" = 6
      "min_size" = 0
      # other fields...
    }
  }

  eks_managed_node_group_defaults = {
    "ami_type" = "AL2_x86_64"
    "capacity_type" = "SPOT"
    "create_iam_role" = false
    "iam_role_arn" = "arn:aws:iam::01234567890:role/eks-dummy-worker"
    # other fields...
  }

  manage_aws_auth_configmap = true
  aws_auth_roles            = var.map_roles
  aws_auth_users            = var.map_users
}
```
2. When the module creates the aws auth configmap, there will be duplicates:
```bash
# module.eks.kubernetes_config_map_v1_data.aws_auth[0] will be created
  + resource "kubernetes_config_map_v1_data" "aws_auth" {
      + data  = {
          + "mapAccounts" = jsonencode([])
          + "mapRoles"    = <<-EOT
                - "groups":
                  - "system:bootstrappers"
                  - "system:nodes"
                  "rolearn": "arn:aws:iam::01234567890:role/eks-dummy-worker"
                  "username": "system:node:{{EC2PrivateDNSName}}"
                - "groups":
                  - "system:bootstrappers"
                  - "system:nodes"
                  "rolearn": "arn:aws:iam::01234567890:role/eks-dummy-worker"
                  "username": "system:node:{{EC2PrivateDNSName}}"
                - "groups":
                  - "system:bootstrappers"
                  - "system:nodes"
                  "rolearn": "arn:aws:iam::01234567890:role/eks-dummy-worker"
                  "username": "system:node:{{EC2PrivateDNSName}}"
                - "groups":
                  - "system:bootstrappers"
                  - "system:nodes"
                  "rolearn": "arn:aws:iam::01234567890:role/eks-dummy-worker"
                  "username": "system:node:{{EC2PrivateDNSName}}"
                - "groups":
                  - "dummy"
                  "rolearn": "arn:aws:iam::01234567890:role/dummy"
                ...
            EOT
          + "mapUsers"    = <<-EOT
                - ...
            EOT
        }
      + force = true
      + id    = (known after apply)

      + metadata {
          + name      = "aws-auth"
          + namespace = "kube-system"
        }
    }
```
3. Although there may not be any effect, but it is probably undesirable to have duplicate role configuration. So this PR addresses this.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes as it is a minor fix.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
