### PR TITLE
docs: Mention that security groups must be manually referenced on externally attached EKS managed groups

### DIFF
--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -15,6 +15,11 @@ module "eks_managed_node_group" {
   vpc_id     = "vpc-1234556abcdef"
   subnet_ids = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
 
+  // The following variables are necessary if you decide to use the module outside of the parent EKS module context.
+  // Without it, the security groups of the nodes are empty and thus won't join the cluster.
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  cluster_security_group_id = module.eks.node_security_group_id
+
   min_size     = 1
   max_size     = 10
   desired_size = 1


### PR DESCRIPTION
## Description
Improving the docs a little bit, I was bitten hard by the lack of guidance on those two variables.

## Motivation and Context
Gives the information to anyone that tries to decouple the main `eks` module to different managed or self-managed groups.

## Breaking Changes
None. Docs only.
