### PR TITLE
fix: Remove `modified_at` from ignored changes on EKS addons

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -312,12 +312,6 @@ resource "aws_eks_addon" "this" {
   resolve_conflicts        = lookup(each.value, "resolve_conflicts", null)
   service_account_role_arn = lookup(each.value, "service_account_role_arn", null)
 
-  lifecycle {
-    ignore_changes = [
-      modified_at
-    ]
-  }
-
   depends_on = [
     module.fargate_profile,
     module.eks_managed_node_group,


### PR DESCRIPTION
## Description
- Remove `modified_at` from ignored changes on EKS addons

## Motivation and Context
- Closes #2081 
- Deploying the `complete` example using version 1.1.5 I am not seeing the changes in the plans as before. However, while forcing a minimum required version of 1.2.0 would be a breaking change, simply removing the ignored changes is not a breaking change. Either route (keep the ignored changes or remove) has the potential to show something in the plans/applies so why not remove it in favor of using the later versions of Terraform which doesn't incur a breaking change penalty 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
