### PR TITLE
quiet "redundant ignore_changes" warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -312,12 +312,6 @@ resource "aws_eks_addon" "this" {
   resolve_conflicts        = lookup(each.value, "resolve_conflicts", null)
   service_account_role_arn = lookup(each.value, "service_account_role_arn", null)
 
-  lifecycle {
-    ignore_changes = [
-      modified_at
-    ]
-  }
-
   depends_on = [
     module.fargate_profile,
     module.eks_managed_node_group,


### PR DESCRIPTION
## Motivation and Context

Terraform emits the warning

```
╷
│ Warning: Redundant ignore_changes element
│
│   on .terraform/modules/k8s.eks/main.tf line 305, in resource "aws_eks_addon" "this":
│  305: resource "aws_eks_addon" "this" {
│
│ Adding an attribute name to ignore_changes tells Terraform to ignore future changes to the
│ argument in configuration after the object has been created, retaining the value originally
│ configured.
│
│ The attribute modified_at is decided by the provider alone and therefore there can be no
│ configured value to compare with. Including this attribute in ignore_changes has no effect.
│ Remove the attribute from ignore_changes to quiet this warning.
```

Which I would like to go away. I trust it is correct that this is in fact determined by the provider.

## How Has This Been Tested?
~- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)~ N/A
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
