### PR TITLE
docs: Added note explaining requirement for kubernetes provider.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,6 +8,8 @@ provider "aws" {
   }
 }
 
+# The Kubernetes provider is included in this file so the EKS module can complete successfully. Otherwise, it throws an error when 
+# creating `kubernetes_config_map.aws_auth`.
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)


### PR DESCRIPTION
## Description
Document the need for kubernetes provider in this example.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The inclusion of the aws_auth_users resource in this example requires this and manual addition of this 
resource can lead to confusing errors tracking down the root cause.

Related to issue #852.

## Breaking Changes
None

## How Has This Been Tested?
Documentation only.
