### PR TITLE
fix: Update KMS module version which aligns on module version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 |------|--------|---------|
 | <a name="module_eks_managed_node_group"></a> [eks\_managed\_node\_group](#module\_eks\_managed\_node\_group) | ./modules/eks-managed-node-group | n/a |
 | <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | ./modules/fargate-profile | n/a |
-| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | 1.0.0 |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | 1.0.1 |
 | <a name="module_self_managed_node_group"></a> [self\_managed\_node\_group](#module\_self\_managed\_node\_group) | ./modules/self-managed-node-group | n/a |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_log_group" "this" {
 
 module "kms" {
   source  = "terraform-aws-modules/kms/aws"
-  version = "1.0.0"
+  version = "1.0.1" # Note - be mindful of Terraform/provider version compatibility between modules
 
   create = var.create_kms_key
 


### PR DESCRIPTION
## Description
- Update KMS module version which aligns on module version requirements. Version v1.0.1 of the KMS module supports the version of Terraform and AWS provider in this module; in v1.0.0 the versions were Terraform >= 1.0 and AWS provider >= 4.0 which forced users into later version requirements

## Motivation and Context
- Closes #2126
- Closes #2130 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
