### PR TITLE
fix: Prevent 'coalescelist' from failing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_eks_cluster" "this" {
 
   vpc_config {
     security_group_ids      = compact(distinct(concat(var.cluster_additional_security_group_ids, [local.cluster_security_group_id])))
-    subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
+    subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids, [""])
     endpoint_private_access = var.cluster_endpoint_private_access
     endpoint_public_access  = var.cluster_endpoint_public_access
     public_access_cidrs     = var.cluster_endpoint_public_access_cidrs


### PR DESCRIPTION
## Description

In some circumstances, `apply` may fail with the following error:

    Error: Error in function call

      on .terraform/modules/eks.main/main.tf line 21, in resource "aws_eks_cluster" "this":
      21:     subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
        ├────────────────
        │ var.control_plane_subnet_ids is empty list of string
        │ var.subnet_ids is empty list of string

    Call to function "coalescelist" failed: no non-null arguments.

This commit adds a list with an empty string to the arguments of
`coalescelist` in order to prevent Terraform from failing.

## Motivation and Context

See above.

## Breaking Changes

N/A

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have tested using a real project that depends on this module