### PR TITLE
fix: Use MIME format for user data

### DIFF
--- a/examples/user_data/main.tf
+++ b/examples/user_data/main.tf
@@ -26,6 +26,9 @@ module "eks_mng_linux_additional" {
 module "eks_mng_linux_custom_ami" {
   source = "../../modules/_user_data"
 
+  # pre_/post_ bootstrap_user_data will be defined in MIME format
+  platform = "linux"
+
   cluster_name              = local.name
   cluster_endpoint          = local.cluster_endpoint
   cluster_auth_base64       = local.cluster_auth_base64

--- a/templates/linux_user_data.tpl
+++ b/templates/linux_user_data.tpl
@@ -1,8 +1,14 @@
 %{ if enable_bootstrap_user_data ~}
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="//"
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+
 #!/bin/bash
 set -e
-%{ endif ~}
 ${pre_bootstrap_user_data ~}
+%{ endif ~}
 %{ if length(cluster_service_ipv4_cidr) > 0 ~}
 export SERVICE_IPV4_CIDR=${cluster_service_ipv4_cidr}
 %{ endif ~}
@@ -11,4 +17,6 @@ B64_CLUSTER_CA=${cluster_auth_base64}
 API_SERVER_URL=${cluster_endpoint}
 /etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL
 ${post_bootstrap_user_data ~}
+
+--//--
 %{ endif ~}


### PR DESCRIPTION
## Description
When ``enable_bootstrap_user_data: true``, and custom AMI types (platform linux), Amazon EC2 user data in launch templates that are used with managed node groups must be in the MIME multi-part archive format. This is because user data is merged with Amazon EKS user data required for nodes to join the cluster. It looks like AWS API accepts user data not in MIME multi-part format when creating an EKS node group, but checks on update and errors out: ``Ec2LaunchTemplateInvalidConfiguration: User data was not in the MIME multipart format``.

With that change, ``pre_/post_ bootstrap_user_data`` will be wrapped with MIME tags as required, if using enable_bootstrap_user_data, or will be skipped otherwise. This also provides a fix for the case when
``pre_bootstrap_user_data`` is still injected into user data, when the ``enable_bootstrap_user_data flag`` is unset.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1875
Related https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2059
Related https://github.com/hashicorp/terraform-provider-aws/issues/15007

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects (more or less, see below my used tEKS config and the resulted node group user data)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have deployed a private EKS cluster with node groups using custom AMI types, by my fork of [tEKS](https://github.com/particuleio/teks). It worked as expected for my testing setup, the resulted node group has been updated and wrapped with MIME tags, and terraform didn't error out this time:
```
MIME-Version: 1.0
Content-Type: multipart/mixed; boundary="//"

--//
Content-Type: text/x-shellscript; charset="us-ascii"

#!/bin/bash
set -e
cat <<-EOF > /etc/profile.d/bootstrap.sh
export CONTAINER_RUNTIME="containerd"
export USE_MAX_PODS=false
export KUBELET_EXTRA_ARGS="--max-pods=110"
EOF
# Source extra environment variables in bootstrap script
sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
cd /tmp
sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
sudo systemctl enable amazon-ssm-agent
sudo systemctl start amazon-ssm-agent
B64_CLUSTER_CA=<snip>
API_SERVER_URL=https://<snip>.eu-west-1.eks.amazonaws.com
/etc/eks/bootstrap.sh teks-test-dev-demo  --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL

--//--
```
My tEKS configuration snippet is:
```
...
eks_managed_node_groups = merge({
    for az, v in local.ec2 :
    "${az}" => {
      ami_type       = lookup(v, "type", can(regex("arm", az)) ? local.eks_ec2_ami_type_arm : local.eks_ec2_ami_type)
      platform       = lookup(v, "platform", can(regex("arm", az)) ? local.eks_ec2_platform_arm : local.eks_ec2_platform)
      instance_types = [lookup(v, "flavor", can(regex("arm", az)) ? local.eks_ec2_flavor_arm : local.eks_ec2_flavor)]
      capacity_type  = lookup(v, "capacity_type", "ON_DEMAND")
      desired_size   = lookup(v, "desired_size", local.eks_ec2_desired_size)
      min_size       = lookup(v, "min_size", local.eks_ec2_min_size)
      max_size       = lookup(v, "max_size", local.eks_ec2_max_size)

      enable_bootstrap_user_data = include.root.locals.merged.eks_ec2_enable_bootstrap_user_data  # I set it to true
      pre_bootstrap_user_data = !can(
        regex(
          "AL2",
          lookup(v, "type", can(regex("arm", az)) ? local.eks_ec2_ami_type_arm : local.eks_ec2_ami_type)
        )
      ) ? "" : <<-EOT
          cat <<-EOF > /etc/profile.d/bootstrap.sh
          export CONTAINER_RUNTIME="containerd"
          export USE_MAX_PODS=false
          export KUBELET_EXTRA_ARGS="--max-pods=${run_cmd("/bin/sh", "-c", "../../../../../../../tools/max-pods-calculator.sh --instance-type ${lookup(v, "flavor", can(regex("arm", az)) ? local.eks_ec2_flavor_arm : local.eks_ec2_flavor)} --cni-version ${include.root.locals.merged.eks_cluster_addon_versions.cni} --cni-prefix-delegation-enabled")}"
          EOF
          # Source extra environment variables in bootstrap script
          sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
          cd /tmp
          sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
          sudo systemctl enable amazon-ssm-agent
          sudo systemctl start amazon-ssm-agent
          EOT
...
```
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
