### PR TITLE
docs: Add fix for `KUBELET_EXTRA_ARGS` overwrite to EKS managed node group example

### DIFF
--- a/examples/eks_managed_node_group/README.md
+++ b/examples/eks_managed_node_group/README.md
@@ -34,6 +34,7 @@ When using the default AMI provided by the EKS Managed Node Group service (i.e. 
     EOF
     # Source extra environment variables in bootstrap script
     sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
+    sed -i 's/KUBELET_EXTRA_ARGS=$2/KUBELET_EXTRA_ARGS="$2 $KUBELET_EXTRA_ARGS"/' /etc/eks/bootstrap.sh
     EOT
   }
   ...


### PR DESCRIPTION
## Description

Add additional `sed` command to example for `pre_bootstrap_user_data` when using official EKS AMI, which fixes `KUBELET_EXTRA_ARGS` environment variable getting overwritten by bootstrap script.

The `/etc/eks/bootstrap.sh` script accepts kubelet extra args as an argument, which overwrites the `KUBELET_EXTRA_ARGS` environment variable we define in our `pre_bootstrap_user_data`.

Using `sed` we are able to change the behavior of the bootstrap script such that it accepts the extra args as both an argument and from the environment.

Relevant links:

- https://github.com/awslabs/amazon-eks-ami/issues/844
  - [Problem identified](https://github.com/awslabs/amazon-eks-ami/issues/844#issuecomment-1047002193)
  - [Single line fix](https://github.com/awslabs/amazon-eks-ami/issues/844#issuecomment-1048578995)
  - [Complete example](https://github.com/awslabs/amazon-eks-ami/issues/844#issuecomment-1048592041)

## Motivation and Context

Want to provide a more up-to-date and fully functional example of how to achieve custom user data when using official EKS AMI.

## Breaking Changes

N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
  - Changes are to an example `README.md`
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - Confirmed working in my own EKS cluster, running Kubernetes 1.22 with official EKS AMI
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
