### PR TITLE
Fix: Addresses typo introduced in #2125

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -92,7 +92,7 @@ module "eks" {
   }
 
   # Extend node-to-node security group rules
-  node_security_group_ntp_ipv4_cidr_block = ["fd00:ec2::123/128"]
+  node_security_group_ntp_ipv6_cidr_block = ["fd00:ec2::123/128"]
   node_security_group_additional_rules = {
     ingress_self_all = {
       description = "Node to node all ports/protocols"


### PR DESCRIPTION
Fixes typo introduced in https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2125
The example extends the Security Group NTP IPV4 CIDR block, however,
it's meant to update the IPV6 CIDR block

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
