### PR TITLE
fix: Use partition data source on VPC CNI IPv6 policy 

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cni_ipv6_policy" {
   statement {
     sid       = "CreateTags"
     actions   = ["ec2:CreateTags"]
-    resources = ["arn:${data.aws_partition.current.dns_suffix}:ec2:*:*:network-interface/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:network-interface/*"]
   }
 }
 

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "cni_ipv6_policy" {
   statement {
     sid       = "CreateTags"
     actions   = ["ec2:CreateTags"]
-    resources = ["arn:aws:ec2:*:*:network-interface/*"]
+    resources = ["arn:${data.aws_partition.current.dns_suffix}:ec2:*:*:network-interface/*"]
   }
 }
 


### PR DESCRIPTION
Description
Minor fix allowing partition changes [as per main.tf](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/5955d26589979abdad832e4e9a2dec9753ebc738/main.tf#L227).

Motivation and Context
Failed when using a different partition.

Breaking Changes
No.

How Has This Been Tested?
Unsure how to test it in example context. Require differing partitions.

Corrected to match suggestion from [previous PR](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2146). I've run the code against my scenario and it worked fine.