### PR TITLE
bump kms module to 1.0.2 to fix malformed policy document when not specifying key_owners

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "aws_cloudwatch_log_group" "this" {
 
 module "kms" {
   source  = "terraform-aws-modules/kms/aws"
-  version = "1.0.1" # Note - be mindful of Terraform/provider version compatibility between modules
+  version = "1.0.2" # Note - be mindful of Terraform/provider version compatibility between modules
 
   create = var.create_kms_key
 


### PR DESCRIPTION
## Description
when enabling the default policy without key_owners it will lead to a malformed document

│ Error: error creating KMS Key: MalformedPolicyDocumentException: Policy contains a statement with no principal.


## Motivation and Context
Downstream the fix from https://github.com/terraform-aws-modules/terraform-aws-kms/pull/2

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
