### PR TITLE
fix: Pin TLS provider version to 3.x versions only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.73.0
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
 
 ## Providers
 
@@ -218,7 +218,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
 
 ## Modules
 

--- a/examples/eks_managed_node_group/README.md
+++ b/examples/eks_managed_node_group/README.md
@@ -60,14 +60,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 2.2 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
 
 ## Modules
 

--- a/examples/eks_managed_node_group/versions.tf
+++ b/examples/eks_managed_node_group/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 2.2"
+      version = "~> 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/examples/self_managed_node_group/README.md
+++ b/examples/self_managed_node_group/README.md
@@ -28,14 +28,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 2.2 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 2.2 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 3.0 |
 
 ## Modules
 

--- a/examples/self_managed_node_group/versions.tf
+++ b/examples/self_managed_node_group/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 2.2"
+      version = "~> 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ module "kms" {
   source  = "terraform-aws-modules/kms/aws"
   version = "1.0.2" # Note - be mindful of Terraform/provider version compatibility between modules
 
-  create = var.create_kms_key
+  create = local.create && var.create_kms_key
 
   description             = coalesce(var.kms_key_description, "${var.cluster_name} cluster encryption key")
   key_usage               = "ENCRYPT_DECRYPT"

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.0"
+      version = "~> 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Description
- Pin TLS provider version to 3.x versions only
- Correct KMS key creation boolean logic

## Motivation and Context
- Ref https://github.com/hashicorp/terraform-provider-tls/issues/244
- Closes #2170 
- Closes #2171
- Closes #2172
- Closes #2173 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
