### PR TITLE
fix: Remove empty `""` from node group names output when node group creation is disabled

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -179,7 +179,7 @@ output "eks_managed_node_groups" {
 
 output "eks_managed_node_groups_autoscaling_group_names" {
   description = "List of the autoscaling group names created by EKS managed node groups"
-  value       = flatten([for group in module.eks_managed_node_group : group.node_group_autoscaling_group_names])
+  value       = compact(flatten([for group in module.eks_managed_node_group : group.node_group_autoscaling_group_names]))
 }
 
 ################################################################################
@@ -193,7 +193,7 @@ output "self_managed_node_groups" {
 
 output "self_managed_node_groups_autoscaling_group_names" {
   description = "List of the autoscaling group names created by self-managed node groups"
-  value       = [for group in module.self_managed_node_group : group.autoscaling_group_name]
+  value       = compact([for group in module.self_managed_node_group : group.autoscaling_group_name])
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Remove empty `""` from node group names output when node group creation is disabled

## Motivation and Context
- Closes #2193 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
