### PR TITLE
feat: Add ability to use IAM groups in the aws-auth configmap

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -445,6 +445,7 @@ locals {
       ],
       var.aws_auth_roles
     ))
+    mapGroups   = yamlencode(var.aws_auth_groups)
     mapUsers    = yamlencode(var.aws_auth_users)
     mapAccounts = yamlencode(var.aws_auth_accounts)
   }

--- a/variables.tf
+++ b/variables.tf
@@ -572,6 +572,7 @@ variable "aws_auth_groups" {
   description = "List of group maps to add to the aws-auth configmap"
   type        = list(any)
   default     = []
+}
 
 variable "aws_auth_users" {
   description = "List of user maps to add to the aws-auth configmap"

--- a/variables.tf
+++ b/variables.tf
@@ -568,6 +568,11 @@ variable "aws_auth_roles" {
   default     = []
 }
 
+variable "aws_auth_groups" {
+  description = "List of group maps to add to the aws-auth configmap"
+  type        = list(any)
+  default     = []
+
 variable "aws_auth_users" {
   description = "List of user maps to add to the aws-auth configmap"
   type        = list(any)


### PR DESCRIPTION
## Description
Updated variables.tf and and main.tf to add the variable and use it.

## Motivation and Context
This change allows the use of IAM groups for authentication with eks cluster

## Breaking Changes
Unsure; I would test this if I knew how

## How Has This Been Tested?
Ran a `terraform init` and a `terraform validate` locally after editing.
