### PR TITLE
fix: Ignore load_balancers, since module doesn't manage it

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -417,7 +417,8 @@ resource "aws_autoscaling_group" "this" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
-      desired_capacity
+      desired_capacity,
+      load_balancers
     ]
   }
 }


### PR DESCRIPTION
## Description
See #2217

Since the new module version v18.x doesn't support attaching classic load balancers to ASGs. We have to separately attach load balancers using the aws_autoscaling_attachment terraform resource.

However, for terraform-aws-eks managed ASGs, every time we run a terraform apply, the module removes this association leading to the load balancers being removed from ASGs, causing an outage.


## Motivation and Context
See #2217


## How Has This Been Tested?
Change can be tested by using the following resource in modules configured with self-managed-eks-node-groups:

```hcl
resource "aws_autoscaling_attachment" "test" {
  count                                  = length(module.eks.self_managed_node_groups_autoscaling_group_names)
  autoscaling_group_name                 = module.eks.self_managed_node_groups_autoscaling_group_names[count.index]
  elb                                    = "elb-arn"
}
```
