### PR TITLE
fix: Remove the kubernetes.io/cluster/cluster_id tag from node group SG

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -156,8 +156,7 @@ resource "aws_security_group" "node" {
   tags = merge(
     var.tags,
     {
-      "Name"                                      = local.node_sg_name
-      "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+      "Name" = local.node_sg_name
     },
     var.node_security_group_tags
   )


### PR DESCRIPTION
## Description
Fixes the issue described in the [Issue #2223](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2223) by removing the tag `"kubernetes.io/cluster/${var.cluster_name}"` from the Node Group SG created by the module.

## Motivation and Context
EKS clusters created with this module have issues running ALB Ingress Controller due to the presence of the tag ` "kubernetes.io/cluster/${var.cluster_name}" = "owned"` on the node_security_group. The ingress controller keeps spamming following error: 

```JSON
{
  "level": "error",
  "ts": 1662575681.565169,
  "logger": "controller-runtime.manager.controller.targetGroupBinding",
  "msg": "Reconciler error",
  "reconciler group": "elbv2.k8s.aws",
  "reconciler kind": "TargetGroupBinding",
  "name": "k8s-argocd-argocdse-ace231793c",
  "namespace": "argocd",
  "error": "expect exactly one securityGroup tagged with kubernetes.io/cluster/int-cluster for eni eni-085f19bc4667e3c34, got: [sg-065d86cd7ae244685 sg-0667d0816d900666c] (clusterName: int-cluster)"
}
```

## Breaking Changes
Simple tag removal, not a breaking change.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
