### PR TITLE
feat: Add `aws_auth_configmap_prevent_destroy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_security_group_rule.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [kubernetes_config_map.aws_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_config_map.aws_auth_prevent_destroy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map_v1_data.aws_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
+| [kubernetes_config_map_v1_data.aws_auth_prevent_destroy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -262,6 +264,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 |------|-------------|------|---------|:--------:|
 | <a name="input_attach_cluster_encryption_policy"></a> [attach\_cluster\_encryption\_policy](#input\_attach\_cluster\_encryption\_policy) | Indicates whether or not to attach an additional policy for the cluster IAM role to utilize the encryption key provided | `bool` | `true` | no |
 | <a name="input_aws_auth_accounts"></a> [aws\_auth\_accounts](#input\_aws\_auth\_accounts) | List of account maps to add to the aws-auth configmap | `list(any)` | `[]` | no |
+| <a name="input_aws_auth_configmap_prevent_destroy"></a> [aws\_auth\_configmap\_prevent\_destroy](#input\_aws\_auth\_configmap\_prevent\_destroy) | Whether or not to set prevent\_destroy = true on the kubernetes\_config\_map resource | `bool` | `false` | no |
 | <a name="input_aws_auth_fargate_profile_pod_execution_role_arns"></a> [aws\_auth\_fargate\_profile\_pod\_execution\_role\_arns](#input\_aws\_auth\_fargate\_profile\_pod\_execution\_role\_arns) | List of Fargate profile pod execution role ARNs to add to the aws-auth configmap | `list(string)` | `[]` | no |
 | <a name="input_aws_auth_node_iam_role_arns_non_windows"></a> [aws\_auth\_node\_iam\_role\_arns\_non\_windows](#input\_aws\_auth\_node\_iam\_role\_arns\_non\_windows) | List of non-Windows based node IAM role ARNs to add to the aws-auth configmap | `list(string)` | `[]` | no |
 | <a name="input_aws_auth_node_iam_role_arns_windows"></a> [aws\_auth\_node\_iam\_role\_arns\_windows](#input\_aws\_auth\_node\_iam\_role\_arns\_windows) | List of Windows based node IAM role ARNs to add to the aws-auth configmap | `list(string)` | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -544,6 +544,12 @@ variable "create_aws_auth_configmap" {
   default     = false
 }
 
+variable "aws_auth_configmap_prevent_destroy" {
+  description = "Whether or not to set prevent_destroy = true on the kubernetes_config_map resource"
+  type        = bool
+  default     = false
+}
+
 variable "aws_auth_node_iam_role_arns_non_windows" {
   description = "List of non-Windows based node IAM role ARNs to add to the aws-auth configmap"
   type        = list(string)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add `aws_auth_configmap_prevent_destroy`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want to avoid destroying the config map by mistake by toggling an input

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- ~I have updated at least one of the `examples/*` to demonstrate and validate my change(s)~
    - I purposely did not as this would break the test since the test wants to apply and destroy the resources, the `kubernetes_config_map` would fail to be destroyed.
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## references

- https://www.terraform.io/language/meta-arguments/lifecycle
- https://aws.amazon.com/premiumsupport/knowledge-center/amazon-eks-cluster-access/

## commands

Using the defaults with `manage_aws_auth_configmap = true`, we see the existing `kubernetes_config_map_v1_data` without the lifecycle hook.

```hcl
  # module.eks.kubernetes_config_map_v1_data.aws_auth[0] will be created
  + resource "kubernetes_config_map_v1_data" "aws_auth" {
      + data  = (known after apply)
      + force = true
      + id    = (known after apply)

      + metadata {
          + name      = "aws-auth"
          + namespace = "kube-system"
        }
    }
```

With the following

```hcl
manage_aws_auth_configmap = true

aws_auth_configmap_prevent_destroy = true
```

We see the new one created. Note that the lifecycle is hidden but it is there as seen by the name of the resource.

```hcl
  # module.eks.kubernetes_config_map_v1_data.aws_auth_prevent_destroy[0] will be created
  + resource "kubernetes_config_map_v1_data" "aws_auth_prevent_destroy" {
      + data  = (known after apply)
      + force = true
      + id    = (known after apply)

      + metadata {
          + name      = "aws-auth"
          + namespace = "kube-system"
        }
    }
```

With the following

```hcl
create_aws_auth_configmap = true

aws_auth_configmap_prevent_destroy = true

manage_aws_auth_configmap = false
```

We see the new one created. Note that the lifecycle is hidden but it is there as seen by the name of the resource.

```hcl
  # module.eks.kubernetes_config_map.aws_auth_prevent_destroy[0] will be created
  + resource "kubernetes_config_map" "aws_auth_prevent_destroy" {
      + data = (known after apply)
      + id   = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "aws-auth"
          + namespace        = "kube-system"
          + resource_version = (known after apply)
          + uid              = (known after apply)
        }
    }
```
