### PR TITLE
fix: Set `image_id` to come from the launch template instead of data source for self-managed node groups

### DIFF
--- a/modules/self-managed-node-group/outputs.tf
+++ b/modules/self-managed-node-group/outputs.tf
@@ -153,7 +153,7 @@ output "platform" {
 
 output "image_id" {
   description = "ID of the image"
-  value       = try(data.aws_ami.eks_default[0].image_id, "")
+  value       = try(aws_launch_template.this[0].image_id, "")
 }
 
 output "user_data" {


### PR DESCRIPTION
## Description

Fixes issue #2235 ; configure the output of image id to be the real output of the launch_template

## Motivation and Context
#2235 

## Breaking Changes

If a user provided a custom ami_id and relied on the broken information this submodule was returning, they could see a change in behavior as the output corrects itself.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - `examples/self_managed_node_group`
  - Run: `terraform output -json | jq .self_managed_node_groups.value.bottlerocket.image_id`
    - Value before change: `ami-0f2b7c6874eb8414f` (The default AMI, despite being overridden in the config)
    - Value after change: `ami-04958b57e72e69fb0` (The actual bottlerocket ami id)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
