### PR TITLE
fix: Invalid for_each argument with var.create_cluster_primary_security_group_tags = false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,9 +68,9 @@ resource "aws_ec2_tag" "cluster_primary_security_group" {
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
   # `aws_default_tags` is merged in to "dedupe" tags and stabilize tag updates
-  for_each = { for k, v in merge(var.tags, var.cluster_tags, data.aws_default_tags.current.tags) :
-    k => v if local.create && k != "Name" && var.create_cluster_primary_security_group_tags
-  }
+  for_each = var.create_cluster_primary_security_group_tags ? { for k, v in merge(var.tags, var.cluster_tags, data.aws_default_tags.current.tags) :
+    k => v if local.create && k != "Name"
+  } : {}
 
   resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
   key         = each.key


### PR DESCRIPTION
I've got today:

```
╷          
│ Error: Invalid for_each argument
│ 
│   on .terraform/modules/app_cluster.eks/main.tf line 70, in resource "aws_ec2_tag" "cluster_primary_security_group":
│   70:   for_each = { for k, v in merge(var.tags, var.cluster_tags, data.aws_default_tags.current.tags) :
│   71:     k => v if local.create && k != "Name" && var.create_cluster_primary_security_group_tags
│   72:   }
│     ├────────────────
│     │ data.aws_default_tags.current.tags is a map of string, known only after apply
│     │ local.create is true
│     │ var.cluster_tags is empty map of string
│     │ var.create_cluster_primary_security_group_tags is false
│     │ var.tags is map of string with 4 elements
│ 
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot
│ determine the full set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place
│ apply-time results only in the map values.
│ 
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and
│ then apply a second time to fully converge.
╵
```

but I have `var.create_cluster_primary_security_group_tags = false`

It worked with this patch.
