### PR TITLE
fix: Update CloudWatch log group creation deny policy to use wildcard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.75.0
+    rev: v1.76.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -279,7 +279,7 @@ resource "aws_iam_role" "this" {
           {
             Action   = ["logs:CreateLogGroup"]
             Effect   = "Deny"
-            Resource = aws_cloudwatch_log_group.this[0].arn
+            Resource = "*"
           },
         ]
       })


### PR DESCRIPTION
## Description
- Replace CloudWatch log group ARN in cluster IAM role policy to use a `"*"` instead

## Motivation and Context

- The current solution scoped to the CloudWatch log group ARN does not work as intended but the wildcard `"*"` version does. See thread at end of this prior issue where the issue still persists on latest version of module https://github.com/terraform-aws-modules/terraform-aws-eks/issues/920

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->