### PR TITLE
fix: parameter schedule property name

### DIFF
--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -296,7 +296,20 @@ module "eks" {
       security_group_tags = {
         Purpose = "Protector of the kubelet"
       }
-
+      schedules = {
+        night = {
+          min_size         = 0
+          max_size         = 0
+          desired_capacity = 0
+          recurrence       = "00 00 * * 1-5"
+        },
+        morning = {
+          desired_size = 1
+          min_size     = 1
+          max_size     = 7
+          recurrence   = "00 06 * * 1-5"
+        }
+      }
       timeouts = {
         create = "80m"
         update = "80m"

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -434,7 +434,7 @@ resource "aws_autoscaling_schedule" "this" {
 
   min_size         = lookup(each.value, "min_size", null)
   max_size         = lookup(each.value, "max_size", null)
-  desired_capacity = lookup(each.value, "desired_size", null)
+  desired_capacity = try(coalesce(lookup(each.value, "desired_size", null), lookup(each.value, "desired_capacity", null)), null)
   start_time       = lookup(each.value, "start_time", null)
   end_time         = lookup(each.value, "end_time", null)
   time_zone        = lookup(each.value, "time_zone", null)


### PR DESCRIPTION
## Description
Added support for parameter `desired_capacity`

## Motivation and Context
Different parameter name lead users to mistakes and errors
close #2268

## Breaking Changes
It keep backwards compatibility

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
