### PR TITLE
fix: Wrong STS audience in OIDC provider in China partition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -211,7 +211,7 @@ data "tls_certificate" "this" {
 resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count = local.create && var.enable_irsa ? 1 : 0
 
-  client_id_list  = distinct(compact(concat(["sts.${local.dns_suffix}"], var.openid_connect_audiences)))
+  client_id_list  = distinct(compact(concat(["sts.${data.aws_partition.current.dns_suffix}"], var.openid_connect_audiences)))
   thumbprint_list = concat([data.tls_certificate.this[0].certificates[0].sha1_fingerprint], var.custom_oidc_thumbprints)
   url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 


### PR DESCRIPTION
## Description
Change STS Audience service endpoint to point to the correct partition.

## Motivation and Context
When deploying EKS cluster in china partition you have to specify the following variable because the EKS have `amazonaws.com` not `amazonaws.cn`  dns_suffix:
```
cluster_iam_role_dns_suffix = "amazonaws.com"
```
Unfortunatelly, this variable is also used to determine STS Audience in OIDC provider when IRSA is enabled.
The correct STS endpoint in China partion is `sts.amazonaws.com.cn` not `sts.amazonaws.com` and should not depend on `cluster_iam_role_dns_suffix` variable.

## Breaking Changes
The OIDC provider will be forcfully replaced but because of the wrong STS audience it wasn't usable anyway. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
