### PR TITLE
feat: Support default_tags in tag_specifications

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -43,6 +43,8 @@ module "user_data" {
 ################################################################################
 
 locals {
+  tags = var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
+
   launch_template_name_int = coalesce(var.launch_template_name, "${var.name}-node-group")
 
   security_group_ids = compact(concat([try(aws_security_group.this[0].id, ""), var.cluster_primary_security_group_id], var.vpc_security_group_ids))
@@ -257,7 +259,6 @@ resource "aws_launch_template" "this" {
 ################################################################################
 
 locals {
-  tags                 = var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
   launch_template_name = try(aws_launch_template.this[0].name, var.launch_template_name)
   # Change order to allow users to set version priority before using defaults
   launch_template_version = coalesce(var.launch_template_version, try(aws_launch_template.this[0].default_version, "$Default"))

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -234,7 +234,7 @@ resource "aws_launch_template" "this" {
     for_each = toset(["instance", "volume", "network-interface"])
     content {
       resource_type = tag_specifications.key
-      tags          = merge(var.tags, { Name = var.name }, var.launch_template_tags)
+      tags          = merge(local.tags, { Name = var.name }, var.launch_template_tags)
     }
   }
 
@@ -257,6 +257,7 @@ resource "aws_launch_template" "this" {
 ################################################################################
 
 locals {
+  tags                 = var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
   launch_template_name = try(aws_launch_template.this[0].name, var.launch_template_name)
   # Change order to allow users to set version priority before using defaults
   launch_template_version = coalesce(var.launch_template_version, try(aws_launch_template.this[0].default_version, "$Default"))
@@ -390,7 +391,7 @@ resource "aws_autoscaling_group" "this" {
         "kubernetes.io/cluster/${var.cluster_name}" = "owned"
         "k8s.io/cluster/${var.cluster_name}"        = "owned"
       },
-      var.use_default_tags ? merge(data.aws_default_tags.current.tags, var.tags) : var.tags
+      local.tags
     )
 
     content {


### PR DESCRIPTION
## Description
Default tags not applied to resources like `volume,instance and network-interface` for self-managed node groups in `aws_launch_template`

As it looks, there is currently no plans to propagate default tags to `tag_specifications` in   `aws` [provider](https://github.com/hashicorp/terraform-provider-aws/issues/19387)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

[it fixes similar closed issue](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1916)

## Breaking changes

No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
- [x] tested in one of the custome cluster as well
