### PR TITLE
feat: Allow AWS EKS addon timeouts to be configured

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -45,6 +45,7 @@ module "eks" {
   cluster_addons = {
     coredns = {
       resolve_conflicts = "OVERWRITE"
+      create_timeout = "30m"
     }
     kube-proxy = {}
     vpc-cni = {

--- a/main.tf
+++ b/main.tf
@@ -355,6 +355,12 @@ resource "aws_eks_addon" "this" {
     module.self_managed_node_group,
   ]
 
+  timeouts {
+    create = lookup(each.value, "create_timeout", "20m")
+    update = lookup(each.value, "update_timeout", "20m")
+    delete = lookup(each.value, "delete_timeout", "40m")
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## Description

This PR allows `aws_eks_addon` timeouts to be configured. If not provided, the default timeouts per documentation are chosen.

## Motivation and Context

The coredns addon can often take longer than 20 minutes to provision. Because the create timeout is not configured, this leads to terraform apply errors; just being able to extend the create timeout solves the issue.

## Breaking Changes
No breaking changes, and default values are what are used anyways if not provided.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
