### PR TITLE
chore: Update examples to better demonstrate questions raised through issues

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,11 +1,5 @@
 provider "aws" {
   region = local.region
-
-  default_tags {
-    tags = {
-      ExampleDefaultTag = "ExampleDefaultValue"
-    }
-  }
 }
 
 provider "kubernetes" {
@@ -196,12 +190,14 @@ module "eks" {
     }
   }
 
-  # OIDC Identity provider
-  cluster_identity_providers = {
-    sts = {
-      client_id = "sts.amazonaws.com"
-    }
-  }
+  # Create a new cluster where both an identity provider and Fargate profile is created
+  # will result in conflicts since only one can take place at a time
+  # # OIDC Identity provider
+  # cluster_identity_providers = {
+  #   sts = {
+  #     client_id = "sts.amazonaws.com"
+  #   }
+  # }
 
   # aws-auth configmap
   manage_aws_auth_configmap = true
@@ -216,10 +212,30 @@ module "eks" {
 
   aws_auth_roles = [
     {
-      rolearn  = "arn:aws:iam::66666666666:role/role1"
-      username = "role1"
-      groups   = ["system:masters"]
+      rolearn  = module.eks_managed_node_group.iam_role_arn
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups = [
+        "system:bootstrappers",
+        "system:nodes",
+      ]
     },
+    {
+      rolearn  = module.self_managed_node_group.iam_role_arn
+      username = "system:node:{{EC2PrivateDNSName}}"
+      groups = [
+        "system:bootstrappers",
+        "system:nodes",
+      ]
+    },
+    {
+      rolearn  = module.fargate_profile.fargate_profile_pod_execution_role_arn
+      username = "system:node:{{SessionName}}"
+      groups = [
+        "system:bootstrappers",
+        "system:nodes",
+        "system:node-proxier",
+      ]
+    }
   ]
 
   aws_auth_users = [
@@ -261,6 +277,20 @@ module "eks_managed_node_group" {
     module.eks.cluster_security_group_id,
   ]
 
+  ami_type = "BOTTLEROCKET_x86_64"
+  platform = "bottlerocket"
+
+  # this will get added to what AWS provides
+  bootstrap_extra_args = <<-EOT
+    # extra args added
+    [settings.kernel]
+    lockdown = "integrity"
+
+    [settings.kubernetes.node-labels]
+    "label1" = "foo"
+    "label2" = "bar"
+  EOT
+
   tags = merge(local.tags, { Separate = "eks-managed-node-group" })
 }
 
@@ -281,8 +311,6 @@ module "self_managed_node_group" {
     module.eks.cluster_primary_security_group_id,
     module.eks.cluster_security_group_id,
   ]
-
-  use_default_tags = true
 
   tags = merge(local.tags, { Separate = "self-managed-node-group" })
 }


### PR DESCRIPTION
## Description
- Remove usage of default tags in `complete` example since support will be removed in v19 due to a number of issues
- Comment out `cluster_identity_providers` in `complete` example - deploying the example as is results in an issue where both Fargate profiles are trying to be created at the same time as the additional cluster identity provider. These operations need to be made independently
- Update `complete` example to show that the IAM role created by node groups/profiles need to be added back into the core module in order to be added to the aws-auth configmap
- Add example of additional Bottlerocket user data via `bootstrap_extra_args` for standalone EKS managed node group

## Motivation and Context
- Resolves #2289
- Resolves #2290

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
