### PR TITLE
fix: Include all certificate fingerprints in the OIDC provider thumbprint list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -213,7 +213,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count = local.create && var.enable_irsa ? 1 : 0
 
   client_id_list  = distinct(compact(concat(["sts.${local.dns_suffix}"], var.openid_connect_audiences)))
-  thumbprint_list = concat([data.tls_certificate.this[0].certificates[0].sha1_fingerprint], var.custom_oidc_thumbprints)
+  thumbprint_list = concat(data.tls_certificate.this[0].certificates[*].sha1_fingerprint, var.custom_oidc_thumbprints)
   url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 
   tags = merge(


### PR DESCRIPTION
## Description
Include all certificate fingerprints in the thumbprint list, rather than just the first one

## Motivation and Context
I'm following the Terraform documentation for enabling IRSA https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#enabling-iam-roles-for-service-accounts. This suggests that all the certificates thumbprints should be listed. This module currently only selects the first one, which should be the highest root certificate in the chain pulled back by the `tls_certificate` data lookup. I can't see anything to suggest that this is intentional.

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I only have access to my work environment. I have tested this change against our development and staging environments without issues.

