### PR TITLE
fix: Ensure that `var.create` is tied to all resources correctly

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -152,7 +152,7 @@ data "aws_iam_policy_document" "irsa" {
 }
 
 resource "aws_iam_policy" "irsa" {
-  count = var.create_irsa ? 1 : 0
+  count = local.create_irsa ? 1 : 0
 
   name_prefix = "${local.irsa_name}-"
   path        = var.irsa_path


### PR DESCRIPTION
## Description
- Ensure that `var.create` is tied to all resources correctly

## Motivation and Context
- Resolves #2306 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
