### PR TITLE
fix: Unable to change desired_size on managed node groups

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -339,9 +339,6 @@ resource "aws_eks_node_group" "this" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes = [
-      scaling_config[0].desired_size,
-    ]
   }
 
   tags = merge(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove ignoring changes to `scaling_config` `desired_size` for managed node groups.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On managed nodes you are unable to change the `desired_size` of the node group as the value is ignored. To change this you have to resort to changing it the CLI or Console.

This causes an issue if for example you have a `desired_size` of 3 and you wish to increase the `min_size` above 3.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
