### PR TITLE
fix: Ensure that custom KMS key is not created if encryption is not enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ module "kms" {
   source  = "terraform-aws-modules/kms/aws"
   version = "1.1.0" # Note - be mindful of Terraform/provider version compatibility between modules
 
-  create = local.create && var.create_kms_key && !local.create_outposts_local_cluster # not valid on Outposts
+  create = local.create && var.create_kms_key && local.enable_cluster_encryption_config # not valid on Outposts
 
   description             = coalesce(var.kms_key_description, "${var.cluster_name} cluster encryption key")
   key_usage               = "ENCRYPT_DECRYPT"


### PR DESCRIPTION
## Description
- Ensure that custom KMS key is not created if encryption is not enabled

## Motivation and Context
- Currently, you could end up with a custom KMS key that is not used by the cluster if encryption is disabled

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
