### PR TITLE
fix: Call to lookup() closed too early, breaks sg rule creation in cluster sg if custom source sg is defined.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -84,6 +84,15 @@ module "eks" {
       type                       = "ingress"
       source_node_security_group = true
     }
+    # Test: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2319
+    ingress_source_security_group_id = {
+      description              = "Ingress from another computed security group"
+      protocol                 = "tcp"
+      from_port                = 22
+      to_port                  = 22
+      type                     = "ingress"
+      source_security_group_id = aws_security_group.additional.id
+    }
   }
 
   # Extend node-to-node security group rules
@@ -95,6 +104,15 @@ module "eks" {
       to_port     = 0
       type        = "ingress"
       self        = true
+    }
+    # Test: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2319
+    ingress_source_security_group_id = {
+      description              = "Ingress from another computed security group"
+      protocol                 = "tcp"
+      from_port                = 22
+      to_port                  = 22
+      type                     = "ingress"
+      source_security_group_id = aws_security_group.additional.id
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -191,13 +191,12 @@ resource "aws_security_group_rule" "cluster" {
   type              = each.value.type
 
   # Optional
-  description      = lookup(each.value, "description", null)
-  cidr_blocks      = lookup(each.value, "cidr_blocks", null)
-  ipv6_cidr_blocks = lookup(each.value, "ipv6_cidr_blocks", null)
-  prefix_list_ids  = lookup(each.value, "prefix_list_ids", [])
-  self             = lookup(each.value, "self", null)
-  source_security_group_id = lookup(each.value, "source_security_group_id",
-  lookup(each.value, "source_node_security_group", false) ? local.node_security_group_id : null)
+  description              = lookup(each.value, "description", null)
+  cidr_blocks              = lookup(each.value, "cidr_blocks", null)
+  ipv6_cidr_blocks         = lookup(each.value, "ipv6_cidr_blocks", null)
+  prefix_list_ids          = lookup(each.value, "prefix_list_ids", null)
+  self                     = lookup(each.value, "self", null)
+  source_security_group_id = try(each.value.source_node_security_group, false) ? local.node_security_group_id : lookup(each.value, "source_security_group_id", null)
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_security_group_rule" "cluster" {
   prefix_list_ids  = lookup(each.value, "prefix_list_ids", [])
   self             = lookup(each.value, "self", null)
   source_security_group_id = lookup(each.value, "source_security_group_id",
-  lookup(each.value, "source_node_security_group", false)) ? local.node_security_group_id : null
+  lookup(each.value, "source_node_security_group", false) ? local.node_security_group_id : null)
 }
 
 ################################################################################

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -180,13 +180,12 @@ resource "aws_security_group_rule" "node" {
   type              = each.value.type
 
   # Optional
-  description      = lookup(each.value, "description", null)
-  cidr_blocks      = lookup(each.value, "cidr_blocks", null)
-  ipv6_cidr_blocks = lookup(each.value, "ipv6_cidr_blocks", null)
-  prefix_list_ids  = lookup(each.value, "prefix_list_ids", [])
-  self             = lookup(each.value, "self", null)
-  source_security_group_id = lookup(each.value, "source_security_group_id",
-  lookup(each.value, "source_cluster_security_group", false)) ? local.cluster_security_group_id : null
+  description              = lookup(each.value, "description", null)
+  cidr_blocks              = lookup(each.value, "cidr_blocks", null)
+  ipv6_cidr_blocks         = lookup(each.value, "ipv6_cidr_blocks", null)
+  prefix_list_ids          = lookup(each.value, "prefix_list_ids", [])
+  self                     = lookup(each.value, "self", null)
+  source_security_group_id = try(each.value.source_cluster_security_group, false) ? local.cluster_security_group_id : lookup(each.value, "source_security_group_id", null)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fixed typo in nested lookup() calls in `aws_security_group_rule.cluster` resource

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a security group ID is supplied in the `source_security_group_id` parameter to `cluster_security_group_additional_rules`, the ternary operator will break, as the nested lookup() function will return a string rather than a bool.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Change was tested on production code within our organisation, which creates a SG rule with an external SG as its source. The same input worked under v18 and broke under v19.
