### PR TITLE
fix: skip public_access_cidrs if var.cluster_endpoint_public_access = false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_eks_cluster" "this" {
     subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
     endpoint_private_access = var.cluster_endpoint_private_access
     endpoint_public_access  = var.cluster_endpoint_public_access
-    public_access_cidrs     = var.cluster_endpoint_public_access ? var.cluster_endpoint_public_access_cidrs : []
+    public_access_cidrs     = var.cluster_endpoint_public_access ? var.cluster_endpoint_public_access_cidrs : null
   }
 
   dynamic "kubernetes_network_config" {


### PR DESCRIPTION
## Description
Do not set public_access_cidr when public access is disabled.

## Motivation and Context

When upgrading from v18 -> v19 with an existing private-only cluster we were shown the following plan:
```
  # module.eks.aws_eks_cluster.this[0] will be updated in-place
  ~ resource "aws_eks_cluster" "this" {
        id                        = "xx"
        name                      = "xx"
        tags                      = {}
        # (11 unchanged attributes hidden)

      ~ vpc_config {
          ~ public_access_cidrs       = [
              - "0.0.0.0/0",
            ]
            # (6 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }
```
When applying we got:
```
│ Error: updating EKS Cluster (xx) VPC config: InvalidParameterException: Cluster is already at the desired configuration with endpointPrivateAccess: true , endpointPublicAccess: false, and Public Endpoint Restrictions: [0.0.0.0/0]
```

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
