### PR TITLE
fix: Invalid value for "replace" parameter: argument must not be null.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -105,7 +105,7 @@ output "node_security_group_id" {
 
 output "oidc_provider" {
   description = "The OpenID Connect identity provider (issuer URL without leading `https://`)"
-  value       = try(replace(aws_eks_cluster.this[0].identity[0].oidc[0].issuer, "https://", null), null)
+  value       = try(replace(aws_eks_cluster.this[0].identity[0].oidc[0].issuer, "https://", ""), null)
 }
 
 output "oidc_provider_arn" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
replace function doesn't accept null as replacement value
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

cause an issue when you try to use `module.eks.oidc_provider` it always be null

```shell
$ tf console
Acquiring state lock. This may take a few moments...
> replace("https://test.com.ar", "https://", null)
│
│ Error: Invalid function argument
│
│   on <console-input> line 1:
│   (source code not available)
│
│ Invalid value for "replace" parameter: argument must not be null.
╵

# wrapped inside `try` function it always be null
> try(replace("https://test.com.ar", "https://", null), null)
null
> try(replace("https://test.com.ar", "https://", ""), null)
"test.com.ar"
```

<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
