### PR TITLE
fix: Allow all traffic on node to node

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -108,10 +108,10 @@ locals {
 
   node_secuirty_group_recommended_rules = { for k, v in {
     ingress_nodes_ephemeral = {
-      description = "Node to node ingress on ephemeral ports"
-      protocol    = "tcp"
-      from_port   = 1025
-      to_port     = 65535
+      description = "Node to node ingress on all traffic"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
       type        = "ingress"
       self        = true
     }


### PR DESCRIPTION
## Description
Allow all on node to node traffic

## Motivation and Context
We noticed random timeout issues when accessing Services after removing this rule when upgrading to `19.0.0` version of this module. When the allow all traffic rule was added back, our timeout issues stopped.

The [Amazon EKS security group considerations](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) suggests the use of all traffic allowed from self on nodes.

## Breaking Changes
None

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
