### PR TITLE
Fix/kms key creation

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -54,6 +54,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_eks"></a> [eks](#module\_eks) | ../.. | n/a |
 | <a name="module_eks_managed_node_group"></a> [eks\_managed\_node\_group](#module\_eks\_managed\_node\_group) | ../../modules/eks-managed-node-group | n/a |
 | <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | ../../modules/fargate-profile | n/a |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | 1.1.0 |
 | <a name="module_self_managed_node_group"></a> [self\_managed\_node\_group](#module\_self\_managed\_node\_group) | ../../modules/self-managed-node-group | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
@@ -64,6 +65,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_iam_policy.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_security_group.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,11 @@ module "kms" {
   override_policy_documents = var.kms_key_override_policy_documents
 
   # Aliases
-  aliases = concat(["eks/${var.cluster_name}"], var.kms_key_aliases)
+  aliases = var.kms_key_aliases
+  computed_aliases = {
+    # Computed since users can pass in computed values for cluster name such as random provider resources
+    cluster = { name = "eks/${var.cluster_name}" }
+  }
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ module "kms" {
   source  = "terraform-aws-modules/kms/aws"
   version = "1.1.0" # Note - be mindful of Terraform/provider version compatibility between modules
 
-  create = local.create && var.create_kms_key && !local.create_outposts_local_cluster # not valid on Outposts
+  create = local.create && var.create_kms_key && local.enable_cluster_encryption_config # not valid on Outposts
 
   description             = coalesce(var.kms_key_description, "${var.cluster_name} cluster encryption key")
   key_usage               = "ENCRYPT_DECRYPT"

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -300,7 +300,7 @@ resource "aws_launch_template" "this" {
 ################################################################################
 
 locals {
-  launch_template_id = var.create && var.create_launch_template ? aws_launch_template.this[0].id : var.launch_template_id
+  launch_template_id = var.create && var.create_launch_template && var.use_custom_launch_template ? aws_launch_template.this[0].id : var.launch_template_id
   # Change order to allow users to set version priority before using defaults
   launch_template_version = coalesce(var.launch_template_version, try(aws_launch_template.this[0].default_version, "$Default"))
 }

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -300,7 +300,7 @@ resource "aws_launch_template" "this" {
 ################################################################################
 
 locals {
-  launch_template_id = var.create && var.create_launch_template && var.use_custom_launch_template ? aws_launch_template.this[0].id : var.launch_template_id
+  launch_template_id = var.create && var.create_launch_template ? try(aws_launch_template.this[0].id, null) : var.launch_template_id
   # Change order to allow users to set version priority before using defaults
   launch_template_version = coalesce(var.launch_template_version, try(aws_launch_template.this[0].default_version, "$Default"))
 }


### PR DESCRIPTION
## Description
- Ensure that custom KMS key is not created if encryption is not enabled
- Avoid throwing an index error when users provide their own custom launch template instead of the module creating a custom launch template
- Support instances where a computed value is passed into the cluster name, such as using random provider resources

## Motivation and Context
- Currently, you could end up with a custom KMS key that is not used by the cluster if encryption is disabled
- Allow users to pass in computed values as the cluster name without error
- Resolves #2321 
- Resolved #2325 
- 
## Breaking Changes
- The default KMS key alias for the cluster name will be re-created but this is generally a safe process since its just an identifier. Otherwise, no breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
