### PR TITLE
chore: Fix typo for vpc-cni addon example

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -67,8 +67,8 @@ module "eks" {
       configuration_values = jsonencode({
         env = {
           # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
-          ENABLE_PREFIX_DELEGATION = true
-          WARM_PREFIX_TARGET       = 1
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
         }
       })
     }


### PR DESCRIPTION
All environment variables have to be strings

## Description
Fixes the VPC CNI examples due to invalid data types.

The previous version resulted in the following error:

```
│ Error: error creating EKS Add-On (xxxx-cni): InvalidParameterException: ConfigurationValue provided in request is not supported [$.env.ENABLE_PREFIX_DELEGATION: boolean found, string expected, $.env.WARM_PREFIX_TARGET: integer found, string expected]
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "xxxxx-7139-4755-9bee-xxxxx"
│   },
│   AddonName: "vpc-cni",
│   ClusterName: "xxxx",
│   Message_: "ConfigurationValue provided in request is not supported [$.env.ENABLE_PREFIX_DELEGATION: boolean found, string expected, $.env.WARM_PREFIX_TARGET: integer found, string expected]"
│ }
```

## Motivation and Context
- Resolves #2348


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Also: Thanks for this module, it's awesome :).


