### PR TITLE
feat: Add additional port for `metrics-server` to recommended rules

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -115,6 +115,16 @@ locals {
       type        = "ingress"
       self        = true
     }
+    # metrics-server
+    ingress_cluster_8443_webhook = {
+      description                   = "Cluster API to node 4443/tcp webhook"
+      protocol                      = "tcp"
+      from_port                     = 4443
+      to_port                       = 4443
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+    # Karpenter
     ingress_cluster_8443_webhook = {
       description                   = "Cluster API to node 8443/tcp webhook"
       protocol                      = "tcp"
@@ -123,6 +133,7 @@ locals {
       type                          = "ingress"
       source_cluster_security_group = true
     }
+    # ALB controller, NGINX
     ingress_cluster_9443_webhook = {
       description                   = "Cluster API to node 9443/tcp webhook"
       protocol                      = "tcp"


### PR DESCRIPTION
## Description
- Add additional port for `metrics-server` to recommended rules

## Motivation and Context
- `metrics-server` is a common utility in EKS clusters

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
