### PR TITLE
fix: Correct map name for security group rule 4443/tcp

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -116,7 +116,7 @@ locals {
       self        = true
     }
     # metrics-server
-    ingress_cluster_8443_webhook = {
+    ingress_cluster_4443_webhook = {
       description                   = "Cluster API to node 4443/tcp webhook"
       protocol                      = "tcp"
       from_port                     = 4443


### PR DESCRIPTION
## Description
- Correct map name for security group rule 4443/tcp

## Motivation and Context
- Copy+paste error - https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2353#discussion_r1051644557

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
