### PR TITLE
Fix: self_managed_node_group_defaults tag_specification

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -423,7 +423,7 @@ module "self_managed_node_group" {
   update_launch_template_default_version = try(each.value.update_launch_template_default_version, var.self_managed_node_group_defaults.update_launch_template_default_version, true)
   launch_template_description            = try(each.value.launch_template_description, var.self_managed_node_group_defaults.launch_template_description, "Custom launch template for ${try(each.value.name, each.key)} self managed node group")
   launch_template_tags                   = try(each.value.launch_template_tags, var.self_managed_node_group_defaults.launch_template_tags, {})
-  tag_specifications                     = try(each.value.tag_specifications, var.eks_managed_node_group_defaults.tag_specifications, ["instance", "volume", "network-interface", "spot-instances-request"])
+  tag_specifications                     = try(each.value.tag_specifications, var.self_managed_node_group_defaults.tag_specifications, ["instance", "volume", "network-interface", "spot-instances-request"])
 
   ebs_optimized   = try(each.value.ebs_optimized, var.self_managed_node_group_defaults.ebs_optimized, null)
   ami_id          = try(each.value.ami_id, var.self_managed_node_group_defaults.ami_id, "")


### PR DESCRIPTION
## Description
Fix reference for self_manage_node_groups to pull tag_specification from the correct defaults

## Motivation and Context
Module was not allowing self managed node group defines to respect tag_specification from self managed node group defaults definition
