### PR TITLE
chore: Update examples for Fargate high availability

### DIFF
--- a/examples/outposts/main.tf
+++ b/examples/outposts/main.tf
@@ -64,14 +64,6 @@ module "eks" {
     }
   }
 
-  self_managed_node_group_defaults = {
-    attach_cluster_primary_security_group = true
-
-    iam_role_additional_policies = {
-      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-    }
-  }
-
   self_managed_node_groups = {
     outpost = {
       name = local.name


### PR DESCRIPTION
## Description
- Update examples to show Fargate profiles configured for high availability

## Motivation and Context
- Fargate profiles are not automatically distributed across AZs; its recommended to create multiple profiles across multiple AZs for a highly available setup

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request