### PR TITLE
feat: Ignore changes to labels and annotations on on `aws-auth` ConfigMap

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -520,7 +520,7 @@ resource "kubernetes_config_map" "aws_auth" {
   lifecycle {
     # We are ignoring the data here since we will manage it with the resource below
     # This is only intended to be used in scenarios where the configmap does not exist
-    ignore_changes = [data]
+    ignore_changes = [data, metadata[0].labels, metadata[0].annotations]
   }
 }
 


### PR DESCRIPTION
## Description
As per #2379, we manage the contents of the `aws-auth` ConfigMap with GitOps and ArgoCD.

The only issue we have is that ArgoCD automatically adds a label to every resource it updates and because `lifecycle_ignore` is only set on `data` we always have `terraform` wanting to remove the `metadata.label` added by ArgoCD (even though we have `manage_aws_auth_configmap=false` set, which semantically implies that this won't happen).

## Motivation and Context
Fixes: #2379

## Breaking Changes
This causes has no breaking changes.

## How Has This Been Tested?
- [x] I have tested and validated these changes using our testing environment.
- [x] I have executed `pre-commit run -a` on my pull request