### PR TITLE
Change the way creating well known policy attachment

### DIFF
--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -40,13 +40,15 @@ resource "aws_iam_role" "this" {
   tags = merge(var.tags, var.iam_role_tags)
 }
 
-resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSFargatePodExecutionRolePolicy",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_role }
+resource "aws_iam_role_policy_attachment" "cni_policy" {
+  count = var.create && var.create_iam_role && var.iam_role_attach_cni_policy ? 1 : 0
+  policy_arn = local.cni_policy
+  role       = aws_iam_role.this[0].name
+}
 
-  policy_arn = each.value
+resource "aws_iam_role_policy_attachment" "fargate_pod_execution_role_policy" {
+  count = var.create && var.create_iam_role ? 1 : 0
+  policy_arn = "${local.iam_role_policy_prefix}/AmazonEKSFargatePodExecutionRolePolicy"
   role       = aws_iam_role.this[0].name
 }
 


### PR DESCRIPTION
## Description
Change the way creating well known policy attachment. Instead of creating them with for_each which cannot
be executed before some resources are created, we will use explicit policy creation. It fix the issue when running terraform plan before EKS cluster is created.

## Motivation and Context
When running terraform plan, before the EKS cluster is created there is an error that the values are determined in runtime, so the for_each fail the terraform plan. 

## Breaking Changes
It will replace the policy attachments, but shouldn't break anything

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
