### PR TITLE
Make AMI lookup conditional on creation of launch template

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -2,7 +2,7 @@ data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
 data "aws_ami" "eks_default" {
-  count = var.create ? 1 : 0
+  count = var.create && var.create_launch_template ? 1 : 0
 
   filter {
     name   = "name"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Given that `data.aws_ami.eks_default` is only used in the `aws_launch_template.this` resource, which has a conditional `var.create_launch_template`, the data block has been updated to have the same conditional. This means that `var.cluster_version` is no longer needed to be passed when `var.create_launch_template` is set to false (ie. when the available EKS AMIs make no difference to the resources actually being created).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2385

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Tested with change made against latest on master branch, and the variables shown in related issue.

Prior to change, omission of `cluster_version` results in:

```bash
│ Error: Invalid template interpolation value
│
│   on .terraform/modules/self_managed_node_group_iam_role/modules/self-managed-node-group/main.tf line 9, in data "aws_ami" "eks_default":
│    9:     values = ["amazon-eks-node-${var.cluster_version}-v*"]
│     ├────────────────
│     │ var.cluster_version is null
│
│ The expression result is null. Cannot include a null value in a string
│ template.
```

After change, omission of `cluster_version` is valid