### PR TITLE
Moving the conditional out of the for_each

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -431,11 +431,11 @@ resource "aws_iam_role" "this" {
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
+  for_each = var.create && var.create_iam_role ? { for k, v in toset(compact([
     "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
     "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
     var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_role }
+  ])) : k => v } : {}
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name


### PR DESCRIPTION

## Description
Currently by having the conditional check in the for_each terraform will fail to plan with the dreaded "Error: Invalid for_each argument" error.  This happens even if you are not trying to use the module provided role.  Moving the conditional check out allows terraform to plan successfully.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
I have added the following to the bottom of the examples/eks_managed_node_group/main.tf
```

module "foo_mng" {
  source  = "../../modules/eks-managed-node-group"

  name            = "foo"
  cluster_name    = "foo"
  cluster_version = "1.24"
  create_iam_role = false
  iam_role_arn    = "arn:aws:iam::123456789012:role/foo-eks-node-group"

 cluster_primary_security_group_id = module.eks.node_security_group_id

  subnet_ids             = module.vpc.private_subnets
  min_size               = 1
  desired_size           = 1
  max_size               = 1
  instance_types         = ["t3.large"]
}

```
With the above, the example continues to plan successfully.  In my env, the PR change allows me to successfully plan and create a cluster while the previous code caused a for_each plan failure.

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
