### PR TITLE
fix: Revert PR 2307 - Get only the root CA fingerprint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count = local.create && var.enable_irsa && !local.create_outposts_local_cluster ? 1 : 0
 
   client_id_list  = distinct(compact(concat(["sts.${local.dns_suffix}"], var.openid_connect_audiences)))
-  thumbprint_list = concat(data.tls_certificate.this[0].certificates[*].sha1_fingerprint, var.custom_oidc_thumbprints)
+  thumbprint_list = concat(data.tls_certificate.this[0].certificates[0].sha1_fingerprint, var.custom_oidc_thumbprints)
   url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 
   tags = merge(


### PR DESCRIPTION

## Description
With this [PR 2307](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2307) the module is getting all certificate fingerprints in the OIDC provider thumbprint list, but as it's recommended by AWS it's recommended only to get the Root CA fingerprint. The documentation can be found [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change, we are trying to follow the AWS recommendations for getting only the fingerprint of the `top intermediate CA in the certificate authority chain` as it's mentioned in the point 5 of the [official documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html)
```
5. In your command window, scroll up until you see a certificate similar to the following example. If you see more than one certificate, find the last certificate displayed (at the end of the command output). This contains the certificate of the top intermediate CA in the certificate authority chain.
```
<!--- If it fixes an open issue, please link to the issue here. -->
It reverts this PR https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2307
## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I only have access to my work environment. I have tested this change against our different environments without issues
