### PR TITLE
fix: Evaluate aws_iam_role_policy_attachment.this conditional before items

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -737,11 +737,11 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
+  for_each = var.create && var.create_iam_instance_profile ? toset(compact([
     "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
     "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
     var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_instance_profile }
+  ])) : []
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Currently the `for_each` in `aws_iam_role_policy_attachment.this` will cause Terraform to resolve each item in the set *before* evaluating whether it would use that set; this change postpones the resolution until *after* evaluating `var.create` and `var.create_iam_instance_profile`. This means that the items are allowed to be unresolvable, given that they are discarded immediately by the conditionals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For example:

- I want to use `depends_on` when calling this module to delay nodegroup creation until after deploying a CNI config dependency
- This causes a an issue with the items not being known until apply time (error: `The "for_each" value depends on resource attributes that cannot be determined until apply...`)
- Therefore, I have split my use of the module into two distinct blocks:
  - One module usage is responsible for creating the IAM role (which depends on the `aws_partition` data source, and does not need `depends_on`)
  - The second module usage is for the launch templates etc (this does need `depends_on` to delay creation)
- Currently setting `create_iam_instance_profile = false` still relies on the `aws_partition` data source due to the evaluation order (this PR fixes that).

<details>
<summary>Example code</summary>

```terraform
module "self_managed_node_group_iam_role" {
  source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
  version = ">= 19.5.1"

  # Only create the IAM Role
  create_autoscaling_group = false
  create_launch_template   = false
  create_schedule          = false
}

module "self_managed_node_group" {
  source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
  version = ">= 19.5.1"

  create_iam_instance_profile = false
  iam_instance_profile_arn    = module.self_managed_node_group_iam_role.iam_instance_profile_arn

  depends_on = [helm_release.aws_vpc_cni] # Must wait until VPC CNI config is deployed, otherwise we have to restart nodes
}

resource "helm_release" "aws_vpc_cni" {
  # Configure VPC CNI with ENIConfig that manipulates which subnets pods are created in
  # Only respected by nodes that are created after this configuration is deployed
  ...
}
```

</details>

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Testing has been done using the code snippet in the example above (prior to cluster creation; the intention is that this can be used to create a brand new cluster from scratch, fully automated)

<details>
<summary>Prior to fix</summary>

```terraform
module "self_managed_node_group_iam_role" {
  source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
  version = ">= 19.5.1"

  ...
}

module "self_managed_node_group" {
  source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
  version = ">= 19.5.1"

  ...
}
```

Output:
```
╷
│ Error: Invalid for_each argument
│ 
│   on .terraform/modules/self_managed_node_group/modules/self-managed-node-group/main.tf line 740, in resource "aws_iam_role_policy_attachment" "this":
│  740:   for_each = { for k, v in toset(compact([
│  741:     "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
│  742:     "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
│  743:     var.iam_role_attach_cni_policy ? local.cni_policy : "",
│  744:   ])) : k => v if var.create && var.create_iam_instance_profile }
│     ├────────────────
│     │ local.cni_policy is a string, known only after apply
│     │ local.iam_role_policy_prefix is a string, known only after apply
│     │ var.create is true
│     │ var.create_iam_instance_profile is false
│     │ var.iam_role_attach_cni_policy is true
│ 
│ The "for_each" map includes keys derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.
│ 
│ When working with unknown values in for_each, it's better to define the map
│ keys statically in your configuration and place apply-time results only in
│ the map values.
│ 
│ Alternatively, you could use the -target planning option to first apply
│ only the resources that the for_each value depends on, and then apply a
│ second time to fully converge.
```

</details>

<details>
<summary>After fix</summary>

```terraform
module "self_managed_node_group_iam_role" {
  source  = "github.com/demolitionmode/terraform-aws-eks//modules/self-managed-node-group"

  ...
}

module "self_managed_node_group" {
  source  = "github.com/demolitionmode/terraform-aws-eks//modules/self-managed-node-group"

  ...
}
```

Plan is successful

</details>

