### PR TITLE
feat: Add prometheus-adapter port 6443 to recommended sec groups

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -124,6 +124,15 @@ locals {
       type                          = "ingress"
       source_cluster_security_group = true
     }
+    # prometheus-adapter
+    ingress_cluster_6443_webhook = {
+      description                   = "Cluster API to node 6443/tcp webhook"
+      protocol                      = "tcp"
+      from_port                     = 6443
+      to_port                       = 6443
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
     # Karpenter
     ingress_cluster_8443_webhook = {
       description                   = "Cluster API to node 8443/tcp webhook"


### PR DESCRIPTION
## Description
I wonder if [kubernetes-sigs/prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter) can be added to the default recommended security groups.

When deployed with kube-prometheus/kube-prometheus-stack/helm/manifests it uses port 6443.

Thinking if metrics-server could be added by default so can prometheus-adapter.

## Motivation and Context
To have the Kubernetes aggregated API [v1beta1.metrics.k8s.io/default](http://v1beta1.metrics.k8s.io/default) available by default if using the prom-adapter.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [] I have tested and validated these changes using one or more of the provided `examples/*` projects
