### PR TITLE
fix irsa lenght name

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -14,7 +14,7 @@ locals {
 
 locals {
   create_irsa = var.create && var.create_irsa
-  irsa_name   = coalesce(var.irsa_name, "KarpenterIRSA-${var.cluster_name}")
+  irsa_name   = substr(coalesce(var.irsa_name, "KarpenterIRSA-${var.cluster_name}"), 0, 37)
 
   irsa_oidc_provider_url = replace(var.irsa_oidc_provider_arn, "/^(.*provider/)/", "")
 }


### PR DESCRIPTION
## Description
This change limits the IRSA name to 38 characters.

## Motivation and Context
If your cluster name is too long, there is a problem with the prefix length.

```
╷                                                                                                                                                                                                                                                                                 
│ Error: expected length of name_prefix to be in the range (1 - 38), got KarpenterIRSA-dtrigo-cluster-sandbox-k8s-                                                                                                                                                                
│                                                                                                                                                                                                                                                                                 
│   with module.karpenter["workloads"].aws_iam_role.irsa[0],                                                                                                                                                                                                                      
│   on ../../../1-modules/AWS/terraform-aws-eks/modules/karpenter/main.tf line 53, in resource "aws_iam_role" "irsa":                                                                                                                                                             
│   53:   name_prefix = var.irsa_use_name_prefix ? "${local.irsa_name}-" : null                                                                                                                                                                                                   
│                                                                                                                                                                                                                                                                                 
╵                                                                                                                                                                                                                                                                                 
╷                                                                                                                                                                                                                                                                                 
│ Error: expected length of name_prefix to be in the range (1 - 38), got KarpenterIRSA-dtrigo-cluster-sandbox-k8s-                                                                                                                                                                
│                                                                                                                                                                                                                                                                                 
│   with module.karpenter["main_cloudos_services"].aws_iam_role.irsa[0],                                                                                                                                                                                                          
│   on ../../../1-modules/AWS/terraform-aws-eks/modules/karpenter/main.tf line 53, in resource "aws_iam_role" "irsa":                                                                                                                                                             
│   53:   name_prefix = var.irsa_use_name_prefix ? "${local.irsa_name}-" : null                                                                                                                                                                                                   
│                                                                                                                                                                                                                                                                                 
╵
```

## Breaking Changes
Is not a breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
