### PR TITLE
feat: Allow to pass prefix for rule names

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -172,6 +172,7 @@ No modules.
 | <a name="input_queue_kms_master_key_id"></a> [queue\_kms\_master\_key\_id](#input\_queue\_kms\_master\_key\_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
 | <a name="input_queue_managed_sse_enabled"></a> [queue\_managed\_sse\_enabled](#input\_queue\_managed\_sse\_enabled) | Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys | `bool` | `true` | no |
 | <a name="input_queue_name"></a> [queue\_name](#input\_queue\_name) | Name of the SQS queue | `string` | `null` | no |
+| <a name="input_rule_name_prefix"></a> [rule\_name\_prefix](#input\_rule\_name\_prefix) | Prefix used for all event bridge rules | `string` | `"Karpenter"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -261,7 +261,7 @@ locals {
 resource "aws_cloudwatch_event_rule" "this" {
   for_each = { for k, v in local.events : k => v if local.enable_spot_termination }
 
-  name_prefix   = "Karpenter${each.value.name}-"
+  name_prefix   = "${var.rule_name_prefix}${each.value.name}-"
   description   = each.value.description
   event_pattern = jsonencode(each.value.event_pattern)
 

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -224,3 +224,13 @@ variable "create_instance_profile" {
   type        = bool
   default     = true
 }
+
+################################################################################
+# Event Bridge Rules
+################################################################################
+
+variable "rule_name_prefix" {
+  description = "Prefix used for all event bridge rules"
+  type        = string
+  default     = "Karpenter"
+}


### PR DESCRIPTION
## Description
Added variable to control the prefix used for event bridge rules.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We are trying to use ABAC to control permissions of our CI/CD, using `ResourceTag` IAM condition wherever possible. It seems that EventBridge IAM permissions does not allow that so I would like to limit permissions by resource ARN, and for that I would like to control the prefix used for all rules - so I could give our CI/CD tool permissions to control only rules matching this prefix.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
(Still testing, opened for feedback because it's my first PR)
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
