### PR TITLE
feat: Move to IAM Policy vs Inline Policy for logs:CreateLogGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,12 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster) | resource |
 | [aws_eks_identity_provider_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_identity_provider_config) | resource |
 | [aws_iam_openid_connect_provider.oidc_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_policy.cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -286,6 +288,9 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_aws_auth_roles"></a> [aws\_auth\_roles](#input\_aws\_auth\_roles) | List of role maps to add to the aws-auth configmap | `list(any)` | `[]` | no |
 | <a name="input_aws_auth_users"></a> [aws\_auth\_users](#input\_aws\_auth\_users) | List of user maps to add to the aws-auth configmap | `list(any)` | `[]` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_policy_description"></a> [cloudwatch\_log\_group\_policy\_description](#input\_cloudwatch\_log\_group\_policy\_description) | Description of the cloudwatch log group policy created | `string` | `"Cloudwatch log group policy to allow logging during destroy process"` | no |
+| <a name="input_cloudwatch_log_group_policy_path"></a> [cloudwatch\_log\_group\_policy\_path](#input\_cloudwatch\_log\_group\_policy\_path) | Coudwatch log group policy path | `string` | `null` | no |
+| <a name="input_cloudwatch_log_group_policy_tags"></a> [cloudwatch\_log\_group\_policy\_tags](#input\_cloudwatch\_log\_group\_policy\_tags) | A map of additional tags to add to the cloudwatch log group policy created | `map(string)` | `{}` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events. Default retention - 90 days | `number` | `90` | no |
 | <a name="input_cluster_additional_security_group_ids"></a> [cluster\_additional\_security\_group\_ids](#input\_cluster\_additional\_security\_group\_ids) | List of additional, externally created security group IDs to attach to the cluster control plane | `list(string)` | `[]` | no |
 | <a name="input_cluster_addons"></a> [cluster\_addons](#input\_cluster\_addons) | Map of cluster addon configurations to enable for the cluster. Addon name can be the map keys or set with `name` | `any` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -460,6 +460,23 @@ variable "cluster_encryption_policy_tags" {
   default     = {}
 }
 
+variable "cloudwatch_log_group_policy_description" {
+  description = "Description of the cloudwatch log group policy created"
+  type        = string
+  default     = "Cloudwatch log group policy to allow logging during destroy process"
+}
+
+variable "cloudwatch_log_group_policy_path" {
+  description = "Coudwatch log group policy path"
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group_policy_tags" {
+  description = "A map of additional tags to add to the cloudwatch log group policy created"
+  type        = map(string)
+  default     = {}
+}
 ################################################################################
 # EKS Addons
 ################################################################################


### PR DESCRIPTION
## Description
Move to IAM Policy vs Inline Policy for logs:CreateLogGroup
Fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2439

## Motivation and Context
Running AWS Config, a finding that comes up is with the dynamic inline policy logs:CreateLogGroup. Ideally, we would move towards a IAM policy rather than inline policy [here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/main.tf#L298) so we can remediate this AWS Config finding.

## Breaking Changes
No Breaking Changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
