### PR TITLE
feat: Added node_group_autoscaling_group_arns output

### DIFF
--- a/examples/eks_managed_node_group/README.md
+++ b/examples/eks_managed_node_group/README.md
@@ -119,6 +119,7 @@ No inputs.
 | <a name="output_cluster_tls_certificate_sha1_fingerprint"></a> [cluster\_tls\_certificate\_sha1\_fingerprint](#output\_cluster\_tls\_certificate\_sha1\_fingerprint) | The SHA1 fingerprint of the public key of the cluster's certificate |
 | <a name="output_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#output\_eks\_managed\_node\_groups) | Map of attribute maps for all EKS managed node groups created |
 | <a name="output_eks_managed_node_groups_autoscaling_group_names"></a> [eks\_managed\_node\_groups\_autoscaling\_group\_names](#output\_eks\_managed\_node\_groups\_autoscaling\_group\_names) | List of the autoscaling group names created by EKS managed node groups |
+| <a name="output_eks_managed_node_groups_autoscaling_group_arns"></a> [eks\_managed\_node\_groups\_autoscaling\_group\_arns](#output\_eks\_managed\_node\_groups\_autoscaling\_group\_arns) | List of the autoscaling group arns created by self-managed node groups |
 | <a name="output_fargate_profiles"></a> [fargate\_profiles](#output\_fargate\_profiles) | Map of attribute maps for all EKS Fargate Profiles created |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | The Amazon Resource Name (ARN) of the key |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | The globally unique identifier for the key |

--- a/examples/eks_managed_node_group/outputs.tf
+++ b/examples/eks_managed_node_group/outputs.tf
@@ -187,6 +187,11 @@ output "eks_managed_node_groups_autoscaling_group_names" {
   value       = module.eks.eks_managed_node_groups_autoscaling_group_names
 }
 
+output "eks_managed_node_groups_autoscaling_group_arns" {
+  description = "List of the autoscaling group arns created by self-managed node groups"
+  value       = module.eks.eks_managed_node_groups_autoscaling_group_arns
+}
+
 ################################################################################
 # Self Managed Node Group
 ################################################################################

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -87,6 +87,7 @@ module "eks_managed_node_group" {
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_autoscaling_group.managed_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_group) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -183,6 +184,7 @@ module "eks_managed_node_group" {
 | <a name="output_launch_template_latest_version"></a> [launch\_template\_latest\_version](#output\_launch\_template\_latest\_version) | The latest version of the launch template |
 | <a name="output_launch_template_name"></a> [launch\_template\_name](#output\_launch\_template\_name) | The name of the launch template |
 | <a name="output_node_group_arn"></a> [node\_group\_arn](#output\_node\_group\_arn) | Amazon Resource Name (ARN) of the EKS Node Group |
+| <a name="output_node_group_autoscaling_group_arns"></a> [node\_group\_autoscaling\_group\_arns](#output\_node\_group\_autoscaling\_group\_arns) | n/a |
 | <a name="output_node_group_autoscaling_group_names"></a> [node\_group\_autoscaling\_group\_names](#output\_node\_group\_autoscaling\_group\_names) | List of the autoscaling group names |
 | <a name="output_node_group_id"></a> [node\_group\_id](#output\_node\_group\_id) | EKS Cluster name and EKS Node Group name separated by a colon (`:`) |
 | <a name="output_node_group_labels"></a> [node\_group\_labels](#output\_node\_group\_labels) | Map of labels applied to the node group |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -390,6 +390,11 @@ resource "aws_eks_node_group" "this" {
   )
 }
 
+data "aws_autoscaling_group" "managed_groups" {
+  count = var.create ? 1 : 0
+  name  = element(try(flatten(aws_eks_node_group.this[0].resources[*].autoscaling_groups[*].name), []), 0)
+}
+
 ################################################################################
 # IAM Role
 ################################################################################

--- a/modules/eks-managed-node-group/outputs.tf
+++ b/modules/eks-managed-node-group/outputs.tf
@@ -46,6 +46,10 @@ output "node_group_autoscaling_group_names" {
   value       = try(flatten(aws_eks_node_group.this[0].resources[*].autoscaling_groups[*].name), [])
 }
 
+output "node_group_autoscaling_group_arns" {
+  value = try(data.aws_autoscaling_group.managed_groups[0].arn, "")
+}
+
 output "node_group_status" {
   description = "Status of the EKS Node Group"
   value       = try(aws_eks_node_group.this[0].arn, null)

--- a/outputs.tf
+++ b/outputs.tf
@@ -192,6 +192,11 @@ output "eks_managed_node_groups_autoscaling_group_names" {
   value       = compact(flatten([for group in module.eks_managed_node_group : group.node_group_autoscaling_group_names]))
 }
 
+output "eks_managed_node_groups_autoscaling_group_arns" {
+  description = "List of the autoscaling group arns created by EKS managed node groups"
+  value       = compact(flatten([for group in module.eks_managed_node_group : group.node_group_autoscaling_group_arns]))
+}
+
 ################################################################################
 # Self Managed Node Group
 ################################################################################


### PR DESCRIPTION
## Description
Added node_group_autoscaling_group_arns output. 

## Motivation and Context
Resources is IAM policies should be scoped and not wildcarded. For instance, IRSA for cluster-autoscaler rather than looking like this:

```
  statement {
    sid       = ""
    effect    = "Allow"
    resources = [*]

    actions = [
      "autoscaling:SetDesiredCapacity",
      "autoscaling:TerminateInstanceInAutoScalingGroup",
      "autoscaling:DescribeAutoScalingInstances",
      "autoscaling:DescribeLaunchConfigurations",
    ]
  }
```

should look like:

```
  statement {
    sid       = ""
    effect    = "Allow"
    resources = module.eks_managed_node_group.node_group_autoscaling_group_arns

    actions = [
      "autoscaling:SetDesiredCapacity",
      "autoscaling:TerminateInstanceInAutoScalingGroup",
      "autoscaling:DescribeAutoScalingInstances",
      "autoscaling:DescribeLaunchConfigurations",
    ]
  }
```

## Breaking Changes
None

## How Has This Been Tested?
- [*] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [*] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
