### PR TITLE
feat: Add auto discovery permission of cluster endpoint to Karpenter role

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -133,7 +133,7 @@ data "aws_iam_policy_document" "irsa" {
 
   statement {
     actions   = ["eks:DescribeCluster"]
-    resources = "arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"
+    resources = "arn:${local.partition}:eks:*:${local.account_id}:cluster/${var.cluster_name}"
   }
 
   statement {

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -132,6 +132,11 @@ data "aws_iam_policy_document" "irsa" {
   }
 
   statement {
+    actions   = ["eks:DescribeCluster"]
+    resources = "arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"
+  }
+
+  statement {
     actions   = ["iam:PassRole"]
     resources = [var.create_iam_role ? aws_iam_role.this[0].arn : var.iam_role_arn]
   }

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -133,7 +133,7 @@ data "aws_iam_policy_document" "irsa" {
 
   statement {
     actions   = ["eks:DescribeCluster"]
-    resources = "arn:${local.partition}:eks:*:${local.account_id}:cluster/${var.cluster_name}"
+    resources = ["arn:${local.partition}:eks:*:${local.account_id}:cluster/${var.cluster_name}"]
   }
 
   statement {


### PR DESCRIPTION
## Description
Adds the necessary policy for https://github.com/aws/karpenter/pull/3363

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
