### PR TITLE
Ease kubernetes provider configuration

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -5,17 +5,14 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
+  token                  = data.aws_eks_cluster_auth.this.token
 }
 
 data "aws_availability_zones" "available" {}
 data "aws_caller_identity" "current" {}
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
 
 locals {
   name   = "ex-${replace(basename(path.cwd), "_", "-")}"

--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -5,17 +5,14 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
+  token                  = data.aws_eks_cluster_auth.this.token
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
 
 locals {
   name            = "ex-${replace(basename(path.cwd), "_", "-")}"

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -10,26 +10,14 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
+  token                  = data.aws_eks_cluster_auth.this.token
 }
 
 provider "helm" {
   kubernetes {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-    exec {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "aws"
-      # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-    }
+    token                  = data.aws_eks_cluster_auth.this.token
   }
 }
 
@@ -38,18 +26,15 @@ provider "kubectl" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   load_config_file       = false
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
+  token                  = data.aws_eks_cluster_auth.this.token
 }
 
 data "aws_availability_zones" "available" {}
 data "aws_ecrpublic_authorization_token" "token" {
   provider = aws.virginia
+}
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
 }
 
 locals {

--- a/examples/outposts/main.tf
+++ b/examples/outposts/main.tf
@@ -5,13 +5,7 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    #                           Note: `cluster_id` is used with Outposts for auth
-    args = ["eks", "get-token", "--cluster-id", module.eks.cluster_id, "--region", var.region]
-  }
+  token                  = data.aws_eks_cluster_auth.this.token
 }
 
 locals {
@@ -141,4 +135,8 @@ data "aws_subnets" "this" {
 
 data "aws_vpc" "this" {
   id = data.aws_subnet.this.vpc_id
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
 }

--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -5,17 +5,14 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
+  token                  = data.aws_eks_cluster_auth.this.token
 }
 
 data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
 
 locals {
   name            = "ex-${replace(basename(path.cwd), "_", "-")}"


### PR DESCRIPTION
## Description
Improve the way to pass token to the kubernetes provider.

## Motivation and Context
It solves the issue of the initial `aws` configuration that is called externally. In most cases the AWS provider configuration used in terraform would  differ from the config of `aws` command.

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

P.S. It might need more testing, as i was just started and torn down the EKS cluster.