### PR TITLE
fix: Adding line within node_iam_role_arns_windows to ensure full support …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -453,6 +453,7 @@ locals {
   node_iam_role_arns_windows = distinct(
     compact(
       concat(
+        [for group in module.eks_managed_node_group : group.iam_role_arn],
         [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"],
         var.aws_auth_node_iam_role_arns_windows,
       )


### PR DESCRIPTION
adding line for aws auth configmap that allows `eks:kube-proxy-windows` to be included in the list of groups.  Without this, aws console shows `Access Denied`  

## Description
I added the line `[for group in module.eks_managed_node_group : group.iam_role_arn],` to   `node_iam_role_arns_windows` within `main.tf`. This ensures that the aws_auth cm is able to provide sufficient permissions to the nodes to remove the access issues that are reported within the console


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->   This change is required to ensure that windows MNGs are able to successfully join the cluster with no issues reported
<!--- If it fixes an open issue, please link to the issue here. -->. I do not currently see an open issue

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->. No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
