### PR TITLE
feat: Add `node_iam_role_arns` local variable to check for Windows platform on EKS managed nodegroups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -443,7 +443,7 @@ locals {
   node_iam_role_arns_non_windows = distinct(
     compact(
       concat(
-        [for group in module.eks_managed_node_group : group.iam_role_arn],
+        [for group in module.eks_managed_node_group : group.iam_role_arn if group.platform != "windows"],
         [for group in module.self_managed_node_group : group.iam_role_arn if group.platform != "windows"],
         var.aws_auth_node_iam_role_arns_non_windows,
       )
@@ -453,6 +453,7 @@ locals {
   node_iam_role_arns_windows = distinct(
     compact(
       concat(
+        [for group in module.eks_managed_node_group : group.iam_role_arn if group.platform == "windows"],
         [for group in module.self_managed_node_group : group.iam_role_arn if group.platform == "windows"],
         var.aws_auth_node_iam_role_arns_windows,
       )

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -189,4 +189,5 @@ module "eks_managed_node_group" {
 | <a name="output_node_group_resources"></a> [node\_group\_resources](#output\_node\_group\_resources) | List of objects containing information about underlying resources |
 | <a name="output_node_group_status"></a> [node\_group\_status](#output\_node\_group\_status) | Status of the EKS Node Group |
 | <a name="output_node_group_taints"></a> [node\_group\_taints](#output\_node\_group\_taints) | List of objects containing information about taints applied to the node group |
+| <a name="output_platform"></a> [platform](#output\_platform) | Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/eks-managed-node-group/outputs.tf
+++ b/modules/eks-managed-node-group/outputs.tf
@@ -79,3 +79,12 @@ output "iam_role_unique_id" {
   description = "Stable and unique string identifying the IAM role"
   value       = try(aws_iam_role.this[0].unique_id, null)
 }
+
+################################################################################
+# Additional
+################################################################################
+
+output "platform" {
+  description = "Identifies if the OS platform is `bottlerocket`, `linux`, or `windows` based"
+  value       = var.platform
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change adds additional checks for `platform == "windows"` on both `local.node_iam_role_arns_non_windows` and `local.node_iam_role_arns_windows`.

The additional validation in `local.node_iam_role_arns_windows` ensures that the correct configurations are added to `aws-auth`.

The additiional validation in `local.node_iam_role_arns_non_windows` ensures that terraform does not also create an extra incorrect entry in `aws-auth` for the node group.

To support this change, the eks_managed_node_group module has a new output (`platform`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves the issue described in this [comment](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2350#issuecomment-1428624704) from #2350 
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes found during my testing.

## How Has This Been Tested?
- [] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
