### PR TITLE
docs: Correct indentation for the bullet list on upgrade guide

### DIFF
--- a/docs/UPGRADE-19.0.md
+++ b/docs/UPGRADE-19.0.md
@@ -57,10 +57,9 @@ Please consult the `examples` directory for reference example configurations. If
 ### Variable and output changes
 
 1. Removed variables:
-
-  - `node_security_group_ntp_ipv4_cidr_block` - default security group settings have an egress rule for ALL to `0.0.0.0/0`/`::/0`
-  - `node_security_group_ntp_ipv6_cidr_block` - default security group settings have an egress rule for ALL to `0.0.0.0/0`/`::/0`
-
+ 
+   - `node_security_group_ntp_ipv4_cidr_block` - default security group settings have an egress rule for ALL to `0.0.0.0/0`/`::/0`
+   - `node_security_group_ntp_ipv6_cidr_block` - default security group settings have an egress rule for ALL to `0.0.0.0/0`/`::/0`
    - Self-managed node groups:
      - `create_security_group`
      - `security_group_name`


### PR DESCRIPTION
## Description
Hi, 

thanks for your work ! 

Here a fix for a bullet list incorrectly indented in order to be displayed as a sub-element of `Removed variables:`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The migration guide was not rendered properly

## Breaking Changes
-

## How Has This Been Tested?
-