### PR TITLE
feat: Allow setting custom IRSA policy name for karpenter

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -163,6 +163,7 @@ No modules.
 | <a name="input_irsa_oidc_provider_arn"></a> [irsa\_oidc\_provider\_arn](#input\_irsa\_oidc\_provider\_arn) | OIDC provider arn used in trust policy for IAM role for service accounts | `string` | `""` | no |
 | <a name="input_irsa_path"></a> [irsa\_path](#input\_irsa\_path) | Path of IAM role for service accounts | `string` | `"/"` | no |
 | <a name="input_irsa_permissions_boundary_arn"></a> [irsa\_permissions\_boundary\_arn](#input\_irsa\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role for service accounts | `string` | `null` | no |
+| <a name="input_irsa_policy_name"></a> [irsa\_policy\_name](#input\_irsa\_policy\_name) | Name of IAM policy for service accounts | `string` | `null` | no |
 | <a name="input_irsa_ssm_parameter_arns"></a> [irsa\_ssm\_parameter\_arns](#input\_irsa\_ssm\_parameter\_arns) | List of SSM Parameter ARNs that contain AMI IDs launched by Karpenter | `list(string)` | <pre>[<br>  "arn:aws:ssm:*:*:parameter/aws/service/*"<br>]</pre> | no |
 | <a name="input_irsa_subnet_account_id"></a> [irsa\_subnet\_account\_id](#input\_irsa\_subnet\_account\_id) | Account ID of where the subnets Karpenter will utilize resides. Used when subnets are shared from another account | `string` | `""` | no |
 | <a name="input_irsa_tag_key"></a> [irsa\_tag\_key](#input\_irsa\_tag\_key) | Tag key (`{key = value}`) applied to resources launched by Karpenter through the Karpenter provisioner | `string` | `"karpenter.sh/discovery"` | no |

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -13,8 +13,9 @@ locals {
 ################################################################################
 
 locals {
-  create_irsa = var.create && var.create_irsa
-  irsa_name   = coalesce(var.irsa_name, "KarpenterIRSA-${var.cluster_name}")
+  create_irsa      = var.create && var.create_irsa
+  irsa_name        = coalesce(var.irsa_name, "KarpenterIRSA-${var.cluster_name}")
+  irsa_policy_name = coalesce(var.irsa_policy_name, local.irsa_name)
 
   irsa_oidc_provider_url = replace(var.irsa_oidc_provider_arn, "/^(.*provider/)/", "")
 }
@@ -159,7 +160,7 @@ data "aws_iam_policy_document" "irsa" {
 resource "aws_iam_policy" "irsa" {
   count = local.create_irsa ? 1 : 0
 
-  name_prefix = "${local.irsa_name}-"
+  name_prefix = "${local.irsa_policy_name}-"
   path        = var.irsa_path
   description = var.irsa_description
   policy      = data.aws_iam_policy_document.irsa[0].json

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -32,6 +32,12 @@ variable "irsa_name" {
   default     = null
 }
 
+variable "irsa_policy_name" {
+  description = "Name of IAM policy for service accounts"
+  type        = string
+  default     = null
+}
+
 variable "irsa_use_name_prefix" {
   description = "Determines whether the IAM role for service accounts name (`irsa_name`) is used as a prefix"
   type        = bool


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

allow setting custom IRSA policy name separately from custom role name.

You can use `irsa_name` currently to set them both to the same thing, but there is no way to give them each custom names.

Closes #2465 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

My organization has requirements around role and policy names. The module only lets you set a role name currently, and uses that as the policy name. I need to be able to set a policy name, and a role name, and not to the same thing.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No. Made it backwards compatible.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I ran it locally on a project with all combinations of providing names or not.
