### PR TITLE
docs: Add info about new variable to incompatible changes

### DIFF
--- a/docs/UPGRADE-19.0.md
+++ b/docs/UPGRADE-19.0.md
@@ -12,6 +12,7 @@ Please consult the `examples` directory for reference example configurations. If
   1. `var.iam_role_additional_policies` was changed from type `list(string)` to type `map(string)` -> this is a breaking change. More information on managing this change can be found below, under `Terraform State Moves`
   2. The logic used in the root module for this variable was changed to replace the use of `try()` with `lookup()`. More details on why can be found [here](https://github.com/clowdhaus/terraform-for-each-unknown)
 - The cluster name has been removed from the Karpenter module event rule names. Due to the use of long cluster names appending to the provided naming scheme, the cluster name has moved to a `ClusterName` tag and the event rule name is now a prefix. This guarantees that users can have multiple instances of Karpenter with their respective event rules/SQS queue without name collisions, while also still being able to identify which queues and event rules belong to which cluster.
+- The new variable `node_security_group_enable_recommended_rules` is set to true by default and may conflict with any custom ingress/egress rules. Please ensure that any duplicates from the `node_security_group_additional_rules` are removed before upgrading, or set `node_security_group_enable_recommended_rules` to false. [Reference](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md#added)
 
 ## Additional changes
 


### PR DESCRIPTION
## Description
The new variable `node_security_group_enable_recommended_rules` is set to true by default and might cause incompatibilities with previous, additional rules.

## Motivation and Context
While upgrading from version 18 to 19 I experienced issues with some custom `node_security_group_additional_rules` because I missed to remove all duplicates that are now part of `node_security_group_enable_recommended_rules`.

I think this should be listed in the incompatible changes, as it breaks the apply run if you miss to remove the duplicate rules.
The error you might receive will look like the following:
```
Error: [WARN] A duplicate Security Group rule was found on (sg-xxx). This may be a side effect of a now-fixed Terraform issue causing two security groups with identical attributes but different source_security_group_ids to overwrite each other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: sg-xxx, TCP, from port: 8443, to port: 8443, ALLOW" already exists status code: 400, request id: xxx
with module.eks.aws_security_group_rule.node["ingress_cluster_8443_webhook"]
on eks/node_groups.tf line 207, in resource "aws_security_group_rule" "node":
```

## Breaking Changes
no breaking change

## How Has This Been Tested?
only changes the docs
