### PR TITLE
fix: Add Name tag for EKS cloudwatch log group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,8 +111,8 @@ resource "aws_cloudwatch_log_group" "this" {
   kms_key_id        = var.cloudwatch_log_group_kms_key_id
 
   tags = merge(
-    { Name = "/aws/eks/${var.cluster_name}/cluster" },
-    var.tags
+    var.tags,
+    { Name = "/aws/eks/${var.cluster_name}/cluster" }
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,10 @@ resource "aws_cloudwatch_log_group" "this" {
   retention_in_days = var.cloudwatch_log_group_retention_in_days
   kms_key_id        = var.cloudwatch_log_group_kms_key_id
 
-  tags = var.tags
+  tags = merge(
+    { Name = "/aws/eks/${var.cluster_name}/cluster" },
+    var.tags
+  )
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
Add additional `Name` tag to the cloudwatch log group resource.

## Motivation and Context
In addition to the name of the log group itself, we wanted to add the log group name _tag_ as well for our own cost reporting.

## How Has This Been Tested?
- [X] I have executed `pre-commit run -a` on my pull request

Ran this change locally against my existing EKS cluster. Here's an example of the plan below:
```
  # module.eks.aws_cloudwatch_log_group.this[0] will be updated in-place
  ~ resource "aws_cloudwatch_log_group" "this" {
        id                = "/aws/eks/awesome_cluster/cluster"
        name              = "/aws/eks/awesome_cluster/cluster"
      ~ tags              = {
          + "Name" = "/aws/eks/awesome_cluster/cluster"
        }
      ~ tags_all          = {
          + "Name"             = "/aws/eks/awesome_cluster/cluster"
            # (5 unchanged elements hidden)
        }
        # (3 unchanged attributes hidden)
    }
```