### PR TITLE
fix: Fix for_each limitation on the iam role resources at node groups instances

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -398,6 +398,13 @@ locals {
   iam_role_name          = coalesce(var.iam_role_name, "${var.name}-eks-node-group")
   iam_role_policy_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   cni_policy             = var.cluster_ip_family == "ipv6" ? "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/AmazonEKS_CNI_IPv6_Policy" : "${local.iam_role_policy_prefix}/AmazonEKS_CNI_Policy"
+
+  iam_role_policy_map = merge({
+    AmazonEKSWorkerNodePolicy          = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
+    AmazonEC2ContainerRegistryReadOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
+  }, var.iam_role_attach_cni_policy ? {
+    AmazonEKSCNIPolicy = local.cni_policy,
+  } : {})
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
@@ -431,11 +438,7 @@ resource "aws_iam_role" "this" {
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_role }
+  for_each = { for k, v in local.iam_role_policy_map : k => v if var.create && var.create_iam_role }
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -402,7 +402,7 @@ locals {
   iam_role_policy_map = merge({
     AmazonEKSWorkerNodePolicy          = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
     AmazonEC2ContainerRegistryReadOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-  }, var.iam_role_attach_cni_policy ? {
+    }, var.iam_role_attach_cni_policy ? {
     AmazonEKSCNIPolicy = local.cni_policy,
   } : {})
 }

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -705,11 +705,11 @@ locals {
   iam_role_name          = coalesce(var.iam_role_name, "${var.name}-node-group")
   iam_role_policy_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   cni_policy             = var.cluster_ip_family == "ipv6" ? "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/AmazonEKS_CNI_IPv6_Policy" : "${local.iam_role_policy_prefix}/AmazonEKS_CNI_Policy"
-  
+
   iam_role_policy_map = merge({
     AmazonEKSWorkerNodePolicy          = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
     AmazonEC2ContainerRegistryReadOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-  }, var.iam_role_attach_cni_policy ? {
+    }, var.iam_role_attach_cni_policy ? {
     AmazonEKSCNIPolicy = local.cni_policy,
   } : {})
 }

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -705,6 +705,13 @@ locals {
   iam_role_name          = coalesce(var.iam_role_name, "${var.name}-node-group")
   iam_role_policy_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
   cni_policy             = var.cluster_ip_family == "ipv6" ? "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/AmazonEKS_CNI_IPv6_Policy" : "${local.iam_role_policy_prefix}/AmazonEKS_CNI_Policy"
+  
+  iam_role_policy_map = merge({
+    AmazonEKSWorkerNodePolicy          = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
+    AmazonEC2ContainerRegistryReadOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
+  }, var.iam_role_attach_cni_policy ? {
+    AmazonEKSCNIPolicy = local.cni_policy,
+  } : {})
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {
@@ -737,11 +744,7 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_instance_profile }
+  for_each = { for k, v in local.iam_role_policy_map : k => v if var.create && var.create_iam_instance_profile }
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name


### PR DESCRIPTION
## Description
This PR changes the object that interacts with the `for_each` statement to avoid the limitation on it, described on the `Limitations on values used in for_each` section at for_each [docs](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each#limitations-on-values-used-in-for_each) on Terraform.

For that, instead of using a previous `set` type, a `map` type was used with hardcoded values for the keys on that map, avoiding this limitation and allowing one single `terraform apply` to perform all changes on the resources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is related to issue #2458. 

Currently, we have a limitation in the `for_each` statement on Terraform, which is the keys of the map (or all sets of strings) must be known values, or you will get an error message that `for_each` has dependencies that cannot be determined before apply, and a `-target` may be needed.

On this specific issue, this behavior is only noticed using Self-Managed Node Groups, but that can be noticed using EKS Managed Node Groups because of the way the IAM roles are managed in them, so this PR solves both situations.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This will trigger a recreation of the IAM roles attached to the EKS Managed Node Groups and Self-Managed Node Groups because this PR changes the way these resources are named. To avoid that we can use the `terraform state mv` command to rename the resources and fix the problem.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
I have tested using a use case that I discussed in issue #2458. This is a use case in the company that I work for. I can't put the entire code here (NDA purposes), however, I'll be glad to tweak some of the current examples and post them as a new test case. What do you think?
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
