### PR TITLE
var.create && var.create_iam_role evaluated before the creation of the map not after

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -431,11 +431,11 @@ resource "aws_iam_role" "this" {
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
+  for_each = var.create && var.create_iam_role ? { for k, v in toset(compact([
     "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
     "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
     var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_role }
+  ])) : k => v } : {}
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name


### PR DESCRIPTION
Description
This PR fixes the issue with the for_each expression in the code, where var.create_iam_role was unable to overwrite a broken for_each expression. It changes the code to evaluate user variables first, and then if they are true, evaluates the list comprehension.

Motivation and Context
The issue with the for_each expression in the code has been reported in multiple issues (#2337, #1753, and #2411), and this PR aims to fix it for users creating their own iam role. This change evaluates user variables first, and then if they are true, evaluates the list comprehension, which solves an issue if some locals are only known after apply. See full comment https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2458#issuecomment-1459407299

Breaking Changes
There are no breaking changes with this PR.

How Has This Been Tested?
- I tested on a local terraform deployment
- I ran pre-commit as requested

I apologize as I have no reproducible minimum for you to evaluate on, hopefully someone else can provide it.