### PR TITLE
feat: Trigger specific event for karpenter 

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -235,6 +235,9 @@ locals {
       event_pattern = {
         source      = ["aws.health"]
         detail-type = ["AWS Health Event"]
+        detail = {
+          service = ["EC2"] # Specific Health Event EC2 Service
+        }
       }
     }
     spot_interupt = {
@@ -259,6 +262,9 @@ locals {
       event_pattern = {
         source      = ["aws.ec2"]
         detail-type = ["EC2 Instance State-change Notification"]
+        detail = {
+          state = ["stopping", "stopped", "shutting-down", "terminated"] # Ignore "pending" and "running"
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added specific EC2 events from AWS health and EC2 State Changes 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is already used in AWS EKS Blueprints Karpenter AddOns. These changes will trigger only specific health events for EC2 and its state.

## Breaking Changes
<!-- Does this break backward compatibility with the current major version? -->
<!-- If so, please provide an explanation of why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
