### PR TITLE
feat: Define instance types on launch template to avoid node group creation and deletion when changing instance_types value

### DIFF
--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -64,13 +64,13 @@ module "eks_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.57 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.57 |
 
 ## Modules
 

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -170,8 +170,20 @@ resource "aws_launch_template" "this" {
     }
   }
 
-  # # Set on node group instead
-  # instance_type = var.launch_template_instance_type
+  dynamic "instance_requirements" {
+    for_each = length(var.instance_types) > 0 ? [var.instance_types] : []
+
+    content {
+      allowed_instance_types = var.instance_types
+      memory_mib {
+        min = 1
+      }
+      vcpu_count {
+        min = 1
+      }
+    }
+  }
+
   kernel_id = var.kernel_id
   key_name  = var.key_name
 
@@ -331,7 +343,7 @@ resource "aws_eks_node_group" "this" {
   capacity_type        = var.capacity_type
   disk_size            = var.use_custom_launch_template ? null : var.disk_size # if using a custom LT, set disk size on custom LT or else it will error here
   force_update_version = var.force_update_version
-  instance_types       = var.instance_types
+  instance_types       = var.use_custom_launch_template ? null : var.instance_types
   labels               = var.labels
 
   dynamic "launch_template" {

--- a/modules/eks-managed-node-group/versions.tf
+++ b/modules/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 4.57"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace aws_eks_node_group.instance_types by aws_launch_template.instance_requirements.allowed_instance_types.

If possible i'll need your help to test it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will replace a node group creation, then old nodegroup deletion by a simple update of the launch template on the nodegroup

This is very useful because of this [issue](https://github.com/aws/containers-roadmap/issues/1636) and will prevent downtime for instance_types change use case.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking change it allow the same as before, but it will also allow specifying more than before like : 
```
instance_types = ["c5*", "c6*"]
```

aws [documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceRequirements.html) see AllowedInstanceTypes part

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
