### PR TITLE
fix: Support path in roles for aws_auth

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -494,7 +494,7 @@ locals {
   aws_auth_configmap_data = {
     mapRoles = yamlencode(concat(
       [for role_arn in local.node_iam_role_arns_non_windows : {
-        rolearn  = role_arn
+        rolearn  = replace(role_arn, replace(coalesce(var.iam_role_path, "/"), "/^//", ""), "")
         username = "system:node:{{EC2PrivateDNSName}}"
         groups = [
           "system:bootstrappers",
@@ -503,7 +503,7 @@ locals {
         }
       ],
       [for role_arn in local.node_iam_role_arns_windows : {
-        rolearn  = role_arn
+        rolearn  = replace(role_arn, replace(coalesce(var.iam_role_path, "/"), "/^//", ""), "")
         username = "system:node:{{EC2PrivateDNSName}}"
         groups = [
           "eks:kube-proxy-windows",
@@ -514,7 +514,7 @@ locals {
       ],
       # Fargate profile
       [for role_arn in local.fargate_profile_pod_execution_role_arns : {
-        rolearn  = role_arn
+        rolearn  = replace(role_arn, replace(coalesce(var.iam_role_path, "/"), "/^//", ""), "")
         username = "system:node:{{SessionName}}"
         groups = [
           "system:bootstrappers",


### PR DESCRIPTION
## Description
This change strips the path from any rolearns for workers/fargate profiles when adding them to the aws_auth configmap. 

## Motivation and Context
This enables nodes to authenticate to the cluster when an iam_role_path is used since the authenticator [doesn't support paths in the role](https://github.com/aws/containers-roadmap/issues/573).

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
