### PR TITLE
docs: Update Documentation README ToC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@
 - Upgrade Guides
   - [Upgrade to v17.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-17.0.md)
   - [Upgrade to v18.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-18.0.md)
+  - [Upgrade to v19.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md)


### PR DESCRIPTION
## Description
Add an entry to the documentation Table of content to reference the upgrade to v19.x guide.

## Motivation and Context
The README of the documentation lists links to the different Markdown files in the doc directory, but the recent [UPGRADE-19.0.md](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md) is not listed.

## Breaking Changes
No breaking changes


## How Has This Been Tested?
Only documentation. The rendering on the pull request is enough
