### PR TITLE
Add optional list of policy ARNs for attachment to Karpenter IRSA

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -124,6 +124,7 @@ No modules.
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.irsa_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
@@ -155,6 +156,7 @@ No modules.
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_irsa_additional_policy_arns"></a> [irsa\_additional\_policy\_arns](#input\_irsa\_additional\_policy\_arns) | List of additional policy ARNs to be attached to the IAM role for service account | `list(string)` | `[]` | no |
 | <a name="input_irsa_assume_role_condition_test"></a> [irsa\_assume\_role\_condition\_test](#input\_irsa\_assume\_role\_condition\_test) | Name of the [IAM condition operator](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to evaluate when assuming the role | `string` | `"StringEquals"` | no |
 | <a name="input_irsa_description"></a> [irsa\_description](#input\_irsa\_description) | IAM role for service accounts description | `string` | `"Karpenter IAM role for service account"` | no |
 | <a name="input_irsa_max_session_duration"></a> [irsa\_max\_session\_duration](#input\_irsa\_max\_session\_duration) | Maximum API session duration in seconds between 3600 and 43200 | `number` | `null` | no |

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -175,6 +175,13 @@ resource "aws_iam_role_policy_attachment" "irsa" {
   policy_arn = aws_iam_policy.irsa[0].arn
 }
 
+resource "aws_iam_role_policy_attachment" "irsa_additional" {
+  for_each = { for k, v in var.irsa_additional_policy_arns : k => v if local.create_irsa }
+
+  role       = aws_iam_role.irsa[0].name
+  policy_arn = each.value
+}
+
 ################################################################################
 # Node Termination Queue
 ################################################################################

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -74,6 +74,12 @@ variable "irsa_tags" {
   default     = {}
 }
 
+variable "irsa_additional_policy_arns" {
+  description = "List of additional policy ARNs to be attached to the IAM role for service account"
+  type        = list(string)
+  default     = []
+}
+
 variable "irsa_tag_key" {
   description = "Tag key (`{key = value}`) applied to resources launched by Karpenter through the Karpenter provisioner"
   type        = string


### PR DESCRIPTION
## Description
This PR addresses the issue (feature request) reported in #2535

## Motivation and Context
It adds possibility to attach a custom IAM policy ARN (with access to CMK KMS) to Karpenter IRSA.
At the moment this is not possible. The only way is to add a KMS usage policy to the KMS resource which is inconvenient in our case because it's managed by other team.
We would like to attach a custom IAM policy to the principal, i.e. Karpenter IRSA.


## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
