### PR TITLE
feat: Add support for allowed_instance_type

### DIFF
--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -43,13 +43,13 @@ module "self_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.47 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.57 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.47 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.57 |
 
 ## Modules
 

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -211,7 +211,8 @@ resource "aws_launch_template" "this" {
 
       burstable_performance   = try(instance_requirements.value.burstable_performance, null)
       cpu_manufacturers       = try(instance_requirements.value.cpu_manufacturers, [])
-      excluded_instance_types = try(instance_requirements.value.excluded_instance_types, [])
+      excluded_instance_types = try(instance_requirements.value.excluded_instance_types, null)
+      allowed_instance_types  = try(instance_requirements.value.allowed_instance_types, null) 
       instance_generations    = try(instance_requirements.value.instance_generations, [])
       local_storage           = try(instance_requirements.value.local_storage, null)
       local_storage_types     = try(instance_requirements.value.local_storage_types, [])

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -197,8 +197,9 @@ resource "aws_launch_template" "this" {
         }
       }
 
-      accelerator_types = try(instance_requirements.value.accelerator_types, [])
-      bare_metal        = try(instance_requirements.value.bare_metal, null)
+      accelerator_types      = try(instance_requirements.value.accelerator_types, [])
+      allowed_instance_types = try(instance_requirements.value.allowed_instance_types, null)
+      bare_metal             = try(instance_requirements.value.bare_metal, null)
 
       dynamic "baseline_ebs_bandwidth_mbps" {
         for_each = try([instance_requirements.value.baseline_ebs_bandwidth_mbps], [])
@@ -212,7 +213,6 @@ resource "aws_launch_template" "this" {
       burstable_performance   = try(instance_requirements.value.burstable_performance, null)
       cpu_manufacturers       = try(instance_requirements.value.cpu_manufacturers, [])
       excluded_instance_types = try(instance_requirements.value.excluded_instance_types, null)
-      allowed_instance_types  = try(instance_requirements.value.allowed_instance_types, null) 
       instance_generations    = try(instance_requirements.value.instance_generations, [])
       local_storage           = try(instance_requirements.value.local_storage, null)
       local_storage_types     = try(instance_requirements.value.local_storage_types, [])
@@ -232,6 +232,15 @@ resource "aws_launch_template" "this" {
         content {
           max = try(memory_mib.value.max, null)
           min = memory_mib.value.min
+        }
+      }
+
+      dynamic "network_bandwidth_gbps" {
+        for_each = try([instance_requirements.value.network_bandwidth_gbps], [])
+
+        content {
+          max = try(network_bandwidth_gbps.value.max, null)
+          min = try(network_bandwidth_gbps.value.min, null)
         }
       }
 

--- a/modules/self-managed-node-group/versions.tf
+++ b/modules/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 4.57"
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for the `allowed_instance_types` parameter in the `instance_requirements` block of the self managed nodegroups ASG. 

## Motivation and Context
This allowed additional flexibility when configuring the ASGs to use specific instance types. By defining the list of allowed instance types, we allow a more deterministic way of configuring our environment. Support for `allowed_instance_types` was added in `v4.57.0` of the aws provider, so have bumped up the version: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.57.0 

## Breaking Changes
No expected breaking changes
