### PR TITLE
fix: SQS queue encryption types selection

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -197,7 +197,7 @@ resource "aws_sqs_queue" "this" {
 
   name                              = local.queue_name
   message_retention_seconds         = 300
-  sqs_managed_sse_enabled           = var.queue_managed_sse_enabled
+  sqs_managed_sse_enabled           = var.queue_managed_sse_enabled ? var.queue_managed_sse_enabled : null
   kms_master_key_id                 = var.queue_kms_master_key_id
   kms_data_key_reuse_period_seconds = var.queue_kms_data_key_reuse_period_seconds
 


### PR DESCRIPTION
## Description
`sqs_managed_sse_enabled` and `kms_master_key_id` cannot coexist. prior to this fix, if `queue_managed_sse_enabled` was set to `false`, then `sqs_managed_sse_enabled` would be set to false as well, instead `null`, as it should be in this case.

## Motivation and Context
I have tried to change an SQS queue's encryption from "SSE-SQS" to "SSE-KMS", using the karpenter submodule and failed with an error saying **"sqs_managed_sse_enabled": conflicts with "kms_master_key_id"**.
This fixes the issue.

## Breaking Changes
None known.

## How Has This Been Tested?
I have successfully deployed with this change in my environment, where SQS queues are managed by the karpenter submodule for about 2 months now.
I have executed `pre-commit run -a` on my pull request
