### PR TITLE
feat: Root user master access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -528,7 +528,13 @@ locals {
       ],
       var.aws_auth_roles
     ))
-    mapUsers    = yamlencode(var.aws_auth_users)
+    mapUsers = yamlencode(concat([
+      { # Always give `root` user of current account `system:master` access
+        userarn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        username = "root"
+        groups   = ["system:masters"]
+      }
+    ], var.aws_auth_users))
     mapAccounts = yamlencode(var.aws_auth_accounts)
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Always give the `root` user of the current account `system:master` access.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We had an issue where we were using AWS SSO (IAM Identity Center) assumed roles to access our EKS cluster.
We inadvertently caused the Assumable Roles to be destroyed and recreated which caused their names to be updated (`AWSReservedSSO_XXXX_11111` -> `AWSReservedSSO_XXXX_22222`) which caused us to lose all auth with the EKS cluster and get locked out.

We tried recovering access by using the Root user of the account, but that didn't work because the Root user didn't have permissions according to the `aws-auth` configmap.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have run this in my own environment on our EKS clusters and validated that it works as expected. 
I set the following config using `19.13.1` of this Terraform module:
```hcl
locals {
  eks_auth_users = [{
    userarn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/robbie.blaine"
    username = "robbie.blaine"
    groups   = ["system:masters"]
  }]
}

module "eks" {
  source  = "terraform-aws-modules/eks/aws"
  version = "19.13.1"

  aws_auth_users = concat([{ # Always give `root` user master access
      userarn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
      username = "root"
      groups   = ["system:masters"]
    }], local.eks_auth_users)
}
```
And then validated the contents of the `aws-auth` configmap.
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

It may be better to use [`setunion()`](https://developer.hashicorp.com/terraform/language/functions/setunion) instead of `concat()`, but let me know what you think.