### PR TITLE
feat: Ignore changes to *.aws_iam_role.*.role_last_used

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -318,6 +318,12 @@ resource "aws_iam_role" "this" {
   }
 
   tags = merge(var.tags, var.iam_role_tags)
+
+  lifecycle {
+    ignore_changes = [
+      role_last_used,
+    ]
+  }
 }
 
 # Policies attached ref https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -427,6 +427,12 @@ resource "aws_iam_role" "this" {
   force_detach_policies = true
 
   tags = merge(var.tags, var.iam_role_tags)
+
+  lifecycle {
+    ignore_changes = [
+      role_last_used,
+    ]
+  }
 }
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -61,6 +61,12 @@ resource "aws_iam_role" "irsa" {
   force_detach_policies = true
 
   tags = merge(var.tags, var.irsa_tags)
+
+  lifecycle {
+    ignore_changes = [
+      role_last_used,
+    ]
+  }
 }
 
 locals {


### PR DESCRIPTION
## Description

Ignore changes to `role_last_used` for `aws_iam_role.this[0]`, `module.eks_managed_node_group[*].aws_iam_role.this[0]`, and `module.eks_managed_node_group[*].aws_iam_role.irsa[0]`.

## Motivation and Context

Without this commit, there is useless noise in drift detection in Terraform Enterprise, for example.

## Breaking Changes

I shouldn't think so.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
