### PR TITLE
fix: Revert changes to ignore `role_last_used`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -318,12 +318,6 @@ resource "aws_iam_role" "this" {
   }
 
   tags = merge(var.tags, var.iam_role_tags)
-
-  lifecycle {
-    ignore_changes = [
-      role_last_used,
-    ]
-  }
 }
 
 # Policies attached ref https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -427,12 +427,6 @@ resource "aws_iam_role" "this" {
   force_detach_policies = true
 
   tags = merge(var.tags, var.iam_role_tags)
-
-  lifecycle {
-    ignore_changes = [
-      role_last_used,
-    ]
-  }
 }
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -61,12 +61,6 @@ resource "aws_iam_role" "irsa" {
   force_detach_policies = true
 
   tags = merge(var.tags, var.irsa_tags)
-
-  lifecycle {
-    ignore_changes = [
-      role_last_used,
-    ]
-  }
 }
 
 locals {


### PR DESCRIPTION
## Description
- Revert changes to ignore `role_last_used` in #2628

## Motivation and Context
- The changes in #2628 are not working as intended, therefore this needs to be resolve by the provider https://github.com/hashicorp/terraform-provider-aws/issues/30861#issuecomment-1561757274
- The changes in #2628 are reliant on an attribute that was introduced in v4.64.0 of the AWS provider. We should have bumped the provider min supported version for this, but as is it is currently throwing an error for users that are not at v4.64.0+ 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
