### PR TITLE
docs: Correct comment mis-spelling

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -93,13 +93,13 @@ module "eks" {
         resources = {
           limits = {
             cpu = "0.25"
-            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # We are targeting the smallest Task size of 512Mb, so we subtract 256Mb from the
             # request/limit to ensure we can fit within that task
             memory = "256M"
           }
           requests = {
             cpu = "0.25"
-            # We are targetting the smallest Task size of 512Mb, so we subtract 256Mb from the
+            # We are targeting the smallest Task size of 512Mb, so we subtract 256Mb from the
             # request/limit to ensure we can fit within that task
             memory = "256M"
           }


### PR DESCRIPTION


## Description
targetting -> targeting