### PR TITLE
fix: Snapshot permissions issue for Karpenter submodule

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "irsa" {
     actions = ["ec2:RunInstances"]
     resources = [
       "arn:${local.partition}:ec2:*::image/*",
+      "arn:${local.partition}:ec2:*::snapshot/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:instance/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:spot-instances-request/*",
       "arn:${local.partition}:ec2:*:${local.account_id}:security-group/*",


### PR DESCRIPTION
## Description
This commit [2648](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2648)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With current permissions we are unable to use SnapshotID with Karpenter provisioner
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2648
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
Manually, by using local module with fixed permissions