### PR TITLE
feat(kms): Remove default kms key adminstrators if the default policy is enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ module "kms" {
   # Policy
   enable_default_policy     = var.kms_key_enable_default_policy
   key_owners                = var.kms_key_owners
-  key_administrators        = coalescelist(var.kms_key_administrators, [data.aws_iam_session_context.current.issuer_arn])
+  key_administrators        = var.kms_key_enable_default_policy ? var.kms_key_administrators : coalescelist(var.kms_key_administrators, [data.aws_iam_session_context.current.issuer_arn])
   key_users                 = concat([local.cluster_role], var.kms_key_users)
   key_service_users         = var.kms_key_service_users
   source_policy_documents   = var.kms_key_source_policy_documents


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
If I enable the default policy I do not want the currently running user to be saved in the KMS admin policy. Since the default policy is permissive I think we can remove the default admin if it's enabled.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Simplifies with Terraform diff per user running the command.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Manually applied and tested