### PR TITLE
feat: Change http_put_response_hop_limit from 2 to 1

### DIFF
--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -240,7 +240,7 @@ variable "metadata_options" {
   default = {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    http_put_response_hop_limit = 2
+    http_put_response_hop_limit = 1
   }
 }
 


### PR DESCRIPTION
## Description
At the moment, parameter http_put_response_hop_limit is 2.
Following [these recommendations](https://securitylabs.datadoghq.com/articles/amazon-eks-attacking-securing-cloud-identities/#enforce-imdsv2-and-set-the-response-hop-limit-to-1) for security and [default parameters](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMetadataOptionsRequest.html), it should be changed to 1.

```
variable "metadata_options" {
  default = {
    http_put_response_hop_limit = 1
  }
}
```

## Motivation and Context
Closing a potential attack gap.

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
