### PR TITLE
fix: Update main.tf, fix for aws_security_group_rule.cluster, prefix_list_…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ resource "aws_security_group_rule" "cluster" {
   description              = lookup(each.value, "description", null)
   cidr_blocks              = lookup(each.value, "cidr_blocks", null)
   ipv6_cidr_blocks         = lookup(each.value, "ipv6_cidr_blocks", null)
-  prefix_list_ids          = lookup(each.value, "prefix_list_ids", null)
+  prefix_list_ids          = lookup(each.value, "prefix_list_ids", [])
   self                     = lookup(each.value, "self", null)
   source_security_group_id = try(each.value.source_node_security_group, false) ? local.node_security_group_id : lookup(each.value, "source_security_group_id", null)
 }


### PR DESCRIPTION
…ids null to empty list

fix for aws_security_group_rule.cluster, prefix_list_ids null to empty list

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
bug fix, `prefix_list_ids` parameter in `aws_security_group_rule` cannot take null.

REF: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule#prefix_list_ids
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
