### PR TITLE
fix: Soft-replacement of `resolve_conflicts` arg in aws_eks_addon

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -386,11 +386,12 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
-  configuration_values     = try(each.value.configuration_values, null)
-  preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
-  service_account_role_arn = try(each.value.service_account_role_arn, null)
+  addon_version               = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  configuration_values        = try(each.value.configuration_values, null)
+  preserve                    = try(each.value.preserve, null)
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts, each.value.resolve_conflicts_on_create, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts, each.value.resolve_conflicts_on_update, "OVERWRITE")
+  service_account_role_arn    = try(each.value.service_account_role_arn, null)
 
   timeouts {
     create = try(each.value.timeouts.create, var.cluster_addons_timeouts.create, null)


### PR DESCRIPTION
## Description
Replaces the `resolve_conflicts` argument of `aws_eks_addon` resource with the new `resolve_conflicts_on_create` and `resolve_conflicts_on_update`. By doing so, the warning is removed.

## Motivation and Context
The `resolve_conflicts` argument is [actually deprecated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon#resolve_conflicts).

## Breaking Changes
No breaking changes introduced with this PR as old configurations (since hashicorp/aws>=4.47 as specified in [versions.tf](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/versions.tf#L7)) are still compatible as `resolve_conflicts` it still used in a first attempt.
This could be considered as a first step that removes the warning and, in a future fix, will eventually remove the compatibility with the old parameter.
With this change in place, a subsequent plan after the modules upgrade, will only trigger an "update in-place", nothing else is required and no resource replacement is needed.

## How Has This Been Tested?
- [x] ~~I have updated at least one of the `examples/*` to demonstrate and validate my change(s)~~ (none of the examples provided is actually using such parameter, anyway the change is transparent)
- [x] ~~I have tested and validated these changes using one or more of the provided `examples/*` projects~~ (same as above)
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
