### PR TITLE
feat: Add option to set instance_type on the launch template

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -182,6 +182,12 @@ module "eks" {
       instance_types = ["t4g.medium"]
     }
 
+    # Set the instance type in the launch template
+    lt_instance_type = {
+      instance_type  = "t3.medium"
+      instance_types = null # Reset the value from eks_managed_node_group_defaults to prevent conflict.
+    }
+
     # Complete
     complete = {
       name            = "complete-eks-mng"
@@ -269,8 +275,8 @@ module "eks" {
           min_size     = 2
           max_size     = "-1" # Retains current max size
           desired_size = 2
-          start_time   = "2023-03-05T00:00:00Z"
-          end_time     = "2024-03-05T00:00:00Z"
+          start_time   = "2024-03-05T00:00:00Z"
+          end_time     = "2025-03-05T00:00:00Z"
           timezone     = "Etc/GMT+0"
           recurrence   = "0 0 * * *"
         },
@@ -278,8 +284,8 @@ module "eks" {
           min_size     = 0
           max_size     = "-1" # Retains current max size
           desired_size = 0
-          start_time   = "2023-03-05T12:00:00Z"
-          end_time     = "2024-03-05T12:00:00Z"
+          start_time   = "2024-03-05T12:00:00Z"
+          end_time     = "2025-03-05T12:00:00Z"
           timezone     = "Etc/GMT+0"
           recurrence   = "0 12 * * *"
         }

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -136,7 +136,8 @@ module "eks_managed_node_group" {
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_instance_market_options"></a> [instance\_market\_options](#input\_instance\_market\_options) | The market (purchasing) option for the instance | `any` | `{}` | no |
-| <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]` | `list(string)` | `null` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Set of instance type associated with the Launch Template. Conflicts with `instance_types` | `string` | `null` | no |
+| <a name="input_instance_types"></a> [instance\_types](#input\_instance\_types) | Set of instance types associated with the EKS Node Group. Defaults to `["t3.medium"]`. Conflicts with `instance_types` | `list(string)` | `null` | no |
 | <a name="input_kernel_id"></a> [kernel\_id](#input\_kernel\_id) | The kernel ID | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The key name that should be used for the instance(s) | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value map of Kubernetes labels. Only labels that are applied with the EKS API are managed by this argument. Other Kubernetes labels applied to the EKS Node Group will not be managed | `map(string)` | `null` | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -170,6 +170,8 @@ resource "aws_launch_template" "this" {
     }
   }
 
+  instance_type = var.instance_type
+
   # # Set on node group instead
   # instance_type = var.launch_template_instance_type
   kernel_id = var.kernel_id

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -222,6 +222,12 @@ variable "instance_market_options" {
   default     = {}
 }
 
+variable "instance_type" {
+  description = "Set of instance type associated with the Launch Template. Conflicts with `instance_types`"
+  type        = string
+  default     = null
+}
+
 variable "maintenance_options" {
   description = "The maintenance options for the instance"
   type        = any
@@ -351,7 +357,7 @@ variable "force_update_version" {
 }
 
 variable "instance_types" {
-  description = "Set of instance types associated with the EKS Node Group. Defaults to `[\"t3.medium\"]`"
+  description = "Set of instance types associated with the EKS Node Group. Defaults to `[\"t3.medium\"]`. Conflicts with `instance_types`"
   type        = list(string)
   default     = null
 }

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -341,6 +341,7 @@ module "eks_managed_node_group" {
   elastic_inference_accelerator      = try(each.value.elastic_inference_accelerator, var.eks_managed_node_group_defaults.elastic_inference_accelerator, {})
   enclave_options                    = try(each.value.enclave_options, var.eks_managed_node_group_defaults.enclave_options, {})
   instance_market_options            = try(each.value.instance_market_options, var.eks_managed_node_group_defaults.instance_market_options, {})
+  instance_type                      = try(each.value.instance_type, var.eks_managed_node_group_defaults.instance_type, null)
   license_specifications             = try(each.value.license_specifications, var.eks_managed_node_group_defaults.license_specifications, {})
   metadata_options                   = try(each.value.metadata_options, var.eks_managed_node_group_defaults.metadata_options, local.metadata_options)
   enable_monitoring                  = try(each.value.enable_monitoring, var.eks_managed_node_group_defaults.enable_monitoring, true)


### PR DESCRIPTION
## Description
This adds an extra `instance_type` input variable as an alternative to the existing `instance_types`, so users can decide between setting this on the `eks_managed_node_group` or in the `aws_launch_template`. I do feel that it might be bad to have two parameters with so similar name, and considered naming it something like `launch_template_instance_type`, but that also seems to go against the naming style of the other inputs..

## Motivation and Context
This allows setting the instance type on the launch template rather than the EKS Managed node group. This is useful because it allows using manage node groups rolling update process to change the instance type of a node group. If the instance type is set on the manage node group directly it is not possible to change it without re-creating the node groups. Setting the instance type on in the launch template seems to be the suggested solution for that: https://github.com/aws/containers-roadmap/issues/746#issuecomment-675099508

Solves: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2503

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - Tested with the `complete` example
  - Tested with the `eks_managed_node_group` example, adding node group setting the instance type in the launch template.
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

