### PR TITLE
fix: Split deprecated resolve_conflicts to resolve_conflicts_on_create/update

### DIFF
--- a/docs/UPGRADE-19.0.md
+++ b/docs/UPGRADE-19.0.md
@@ -36,7 +36,8 @@ Please consult the `examples` directory for reference example configurations. If
   - `cluster_encryption_config` previously defaulted to `[]` and now defaults to `{resources = ["secrets"]}` to encrypt secrets by default
 - `cluster_endpoint_public_access` previously defaulted to `true` and now defaults to `false`. Clusters created with this module now default to private-only access to the cluster endpoint
   - `cluster_endpoint_private_access` previously defaulted to `false` and now defaults to `true`
-- The addon configuration now sets `"OVERWRITE"` as the default value for `resolve_conflicts` to ease add-on upgrade management. Users can opt out of this by instead setting `"NONE"` as the value for `resolve_conflicts`
+- The addon configuration now sets `"OVERWRITE"` as the default value for `resolve_conflicts_on_create` to ease add-on upgrade management. Users can opt out of this by instead setting `"NONE"` as the value for `resolve_conflicts_on_create`
+- The addon configuration now sets `"OVERWRITE"` as the default value for `resolve_conflicts_on_update` to ease add-on upgrade management. Users can opt out of this by instead setting `"NONE"` as the value for `resolve_conflicts_on_update`
 - The `kms` module used has been updated from `v1.0.2` to `v1.1.0` - no material changes other than updated to latest
 - The default value for EKS managed node group `update_config` has been updated to the recommended `{ max_unavailable_percentage = 33 }`
 - The default value for the self-managed node group `instance_refresh` has been updated to the recommended:
@@ -190,7 +191,8 @@ EKS managed node groups on `v18.x` by default create a security group that does 
     }
     kube-proxy = {}
     vpc-cni = {
--     resolve_conflicts = "OVERWRITE" # now the default
+-     resolve_conflicts_on_create = "OVERWRITE" # now the default
+-     resolve_conflicts_on_update = "OVERWRITE" # now the default
     }
   }
 

--- a/docs/irsa_integration.md
+++ b/docs/irsa_integration.md
@@ -12,8 +12,9 @@ module "eks" {
 
   cluster_addons = {
     vpc-cni = {
-      resolve_conflicts        = "OVERWRITE"
-      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+      service_account_role_arn    = module.vpc_cni_irsa.iam_role_arn
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -386,10 +386,12 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
-  configuration_values     = try(each.value.configuration_values, null)
-  preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
+  addon_version               = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  configuration_values        = try(each.value.configuration_values, null)
+  preserve                    = try(each.value.preserve, null)
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts_on_create, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts_on_update, "OVERWRITE")
+
   service_account_role_arn = try(each.value.service_account_role_arn, null)
 
   timeouts {
@@ -414,11 +416,12 @@ resource "aws_eks_addon" "before_compute" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
-  configuration_values     = try(each.value.configuration_values, null)
-  preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
-  service_account_role_arn = try(each.value.service_account_role_arn, null)
+  addon_version               = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  configuration_values        = try(each.value.configuration_values, null)
+  preserve                    = try(each.value.preserve, null)
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts_on_create, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts_on_update, "OVERWRITE")
+  service_account_role_arn    = try(each.value.service_account_role_arn, null)
 
   timeouts {
     create = try(each.value.timeouts.create, var.cluster_addons_timeouts.create, null)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 5.0.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Description
Deprecation warnings around resolve_conflicts, change to resolve_conflicts_on_create and resolve_conflicts_on_update

## Motivation and Context
â Warning: Argument is deprecated
â 
â   with module.eks_cluster.module.eks.aws_eks_addon.this["kube-proxy"],
â   on .terraform/modules/eks_cluster.eks/main.tf line 392, in resource "aws_eks_addon" "this":
â  392:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
â 
â The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial resource creation. Use "resolve_conflicts_on_create" and/or "resolve_conflicts_on_update" instead

## Breaking Changes
Unknown!

## How Has This Been Tested?
I have tested these changes in my current environment and deprecation warnings no longer present.
