### PR TITLE
chore: Update FAQ for security group tagging

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,33 +24,15 @@ By default, EKS creates a cluster primary security group that is created outside
   attach_cluster_primary_security_group = true # default is false
 ```
 
-2. If you want to use the cluster primary security group, you can disable the tag passed to the node security group by overriding the tag expected value like:
-
-```hcl
-  attach_cluster_primary_security_group = true # default is false
-
-  node_security_group_tags = {
-    "kubernetes.io/cluster/<CLUSTER_NAME>" = null # or any other value other than "owned"
-  }
-```
-
-3. By overriding the tag expected value on the cluster primary security group like:
-
-```hcl
-  attach_cluster_primary_security_group = true # default is false
-
-  cluster_tags = {
-    "kubernetes.io/cluster/<CLUSTER_NAME>" = null # or any other value other than "owned"
-  }
-```
-
-4. By not attaching the cluster primary security group. The cluster primary security group has quite broad access and the module has instead provided a security group with the minimum amount of access to launch an empty EKS cluster successfully and users are encouraged to open up access when necessary to support their workload.
+2. By not attaching the cluster primary security group. The cluster primary security group has quite broad access and the module has instead provided a security group with the minimum amount of access to launch an empty EKS cluster successfully and users are encouraged to open up access when necessary to support their workload.
 
 ```hcl
   attach_cluster_primary_security_group = false # this is the default for the module
 ```
 
 In theory, if you are attaching the cluster primary security group, you shouldn't need to use the shared node security group created by the module. However, this is left up to users to decide for their requirements and use case.
+
+If you choose to use [Custom Networking](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html), make sure to only attach the security groups chosen used above in your ENIConfig resources to avoid redundant tags.
 
 ### Why are nodes not being registered?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ By default, EKS creates a cluster primary security group that is created outside
 
 In theory, if you are attaching the cluster primary security group, you shouldn't need to use the shared node security group created by the module. However, this is left up to users to decide for their requirements and use case.
 
-If you choose to use [Custom Networking](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html), make sure to only attach the security groups chosen used above in your ENIConfig resources to avoid redundant tags.
+If you choose to use [Custom Networking](https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html), make sure to only attach the security groups matching your choice above in your ENIConfig resources. This will ensure you avoid redundant tags.
 
 ### Why are nodes not being registered?
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -143,7 +143,7 @@ output "cluster_iam_role_unique_id" {
 
 output "cluster_addons" {
   description = "Map of attribute maps for all EKS cluster addons enabled"
-  value       = aws_eks_addon.this
+  value       = merge(aws_eks_addon.this, aws_eks_addon.before_compute)
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This is a documentation update as a result of:
- https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1692
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2687

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The FAQ notes setting a new value for the `kubernetes.io/cluster/<CLUSTER_NAME>` tags in AWS should fix the problem, but its the _existence_ of the tag itself that confuses things like the AWS Load Balancer Controller. Removing this from the FAQ to avoid confusion.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
I validated this as a part of https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1692
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
