### PR TITLE
fix: Use `coalesce` when desired default value is not `null`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -386,7 +386,7 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version))
+  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
@@ -414,7 +414,7 @@ resource "aws_eks_addon" "before_compute" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version))
+  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")

--- a/main.tf
+++ b/main.tf
@@ -386,7 +386,7 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  addon_version            = coalesce(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
@@ -414,7 +414,7 @@ resource "aws_eks_addon" "before_compute" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  addon_version            = coalesce(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")

--- a/main.tf
+++ b/main.tf
@@ -414,7 +414,7 @@ resource "aws_eks_addon" "before_compute" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version))
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")

--- a/main.tf
+++ b/main.tf
@@ -386,7 +386,7 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)
+  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version))
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")


### PR DESCRIPTION
First of all, thanks for the work on this module. We've been using it for a couple of years now ❤️ 

## Description
Use `coalesce` when the desired default value of an expression is not `null`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We maintain an opinionated wrapper module around this one where we used to install the EKS add-ons using their separate Terraform resources but eventually switched to doing it through this module since it supports it.

On our module, we would like to support providing add-on versions while still keeping the default behavior from this module of retrieving the matching version from a data_source if no version is provided.

This would be a snippet from our module.

```
variable "coredns_version" {
  type    = string
  default = null
}

variable "kube_proxy_version" {
  type    = string
  default = null
}
```

```
...
  cluster_addons = {
    coredns = {
      addon_version = var.coredns_version
    }
    kube-proxy = {
      addon_version = var.kube_proxy_version
    }
...
```

But since `null` is a valid expression when using the `try` function; `try(each.value.addon_version, data.aws_eks_addon_version.this[each.key].version)` is returning `null` instead of defaulting to use the version from the data_source as we would like.

Using coalesce instead should fix this.
```
> try(null, "v1.26.2-eksbuild.1")
null
> coalesce(null, "v1.26.2-eksbuild.1")
"v1.26.2-eksbuild.1"
```

As a workaround, we could re-implement the same logic for retrieving add-on versions from data sources in our wrapper module or maybe use dynamic blocks, but if you don't see anything wrong with this change it would simplify our module a bit.

## Breaking Changes

This might be be considered a breaking change since it would change the behavior for end users that are explicitly passing `null` as input variable to the module, but it probably won't affect many users.

## How Has This Been Tested?

After an upgrade from EKS 1.25 to EKS 1.26 with this input:
```
  cluster_addons = {
    kube-proxy = {
      addon_version = var.kube_proxy_version <-- null
    }
}
```

plan with `try`:

```
No changes. Your infrastructure matches the configuration
```

plan with `coalesce`:
```
Terraform will perform the following actions:

  # module.cluster.module.eks.aws_eks_addon.this["kube-proxy"] will be updated in-place
  ~ resource "aws_eks_addon" "this" {
      ~ addon_version     = "v1.25.6-eksbuild.2" -> "v1.26.2-eksbuild.1"
        id                = "test:kube-proxy"
        tags              = {}
        # (7 unchanged attributes hidden)

      + timeouts {}
    }
```

I hope I've made myself clear 😛. Let me know your thoughts and if you are OK with this change. And if you wish I can extend it to all `try` occurrences where `null` is not the desired default value.