### PR TITLE
fix(versions): Avoid deprecated resolve_conflicts warning by restricting AWS provider version to <5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.47"
+      version = ">= 4.47, < 5.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Description
Since we don't want to bump the AWS provider version we're using, let's add a constraint the other way to avoid the warning.

ref: #2680

## Motivation and Context
The latest version of this module does not set an upper bound to the AWS provider version it accepts, which means v5 of the provider can be used, causing the following warning to show up when using EKS addons:

```
╷
│ Warning: Argument is deprecated
│
│   with aws_eks_addon.this["vpc-cni"],
│   on main.tf line 392, in resource "aws_eks_addon" "this":
│  392:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│
│ The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial
│ resource creation. Use "resolve_conflicts_on_create" and/or
│ "resolve_conflicts_on_update" instead
│
│ (and 2 more similar warnings elsewhere)
╵
```

## Breaking Changes
None, this is a bugfix

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
