### PR TITLE
fix: Updated the examples based on change-doc for v19

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -230,8 +230,8 @@ module "eks" {
       disable_api_termination = false
       enable_monitoring       = true
 
-      block_device_mappings = {
-        xvda = {
+      block_device_mappings = [
+        {
           device_name = "/dev/xvda"
           ebs = {
             volume_size           = 75
@@ -243,7 +243,7 @@ module "eks" {
             delete_on_termination = true
           }
         }
-      }
+      ]
 
       metadata_options = {
         http_endpoint               = "enabled"

--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -201,8 +201,8 @@ module "eks" {
       ebs_optimized     = true
       enable_monitoring = true
 
-      block_device_mappings = {
-        xvda = {
+      block_device_mappings = [
+        {
           device_name = "/dev/xvda"
           ebs = {
             volume_size           = 75
@@ -214,7 +214,7 @@ module "eks" {
             delete_on_termination = true
           }
         }
-      }
+      ]
 
       metadata_options = {
         http_endpoint               = "enabled"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As per the Updating to v19.x document [here](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md), the `block_device_mappings` object has been changed from map of map to array of maps but the examples were not updated to reflect the change.
>block_device_mappings previously required a map of maps but has since changed to an array of maps. Users can remove the outer key for each block device mapping and replace the outermost map {} with an array []. There are no state changes required for this change.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change helps correct the example implementation for Update version 19.x. Currently, the example `block_device_mapping` is misleading and needs to be fixed.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
This is not a breaking change
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
