### PR TITLE
feat: Create support an external addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_cluster_autoscaler"></a> [cluster\_autoscaler](#module\_cluster\_autoscaler) | ./modules/addons/cluster-autoscaler | n/a |
 | <a name="module_eks_managed_node_group"></a> [eks\_managed\_node\_group](#module\_eks\_managed\_node\_group) | ./modules/eks-managed-node-group | n/a |
 | <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | ./modules/fargate-profile | n/a |
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | 1.1.0 |
@@ -291,6 +292,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_aws_auth_users"></a> [aws\_auth\_users](#input\_aws\_auth\_users) | List of user maps to add to the aws-auth configmap | `list(any)` | `[]` | no |
 | <a name="input_cloudwatch_log_group_kms_key_id"></a> [cloudwatch\_log\_group\_kms\_key\_id](#input\_cloudwatch\_log\_group\_kms\_key\_id) | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html) | `string` | `null` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Number of days to retain log events. Default retention - 90 days | `number` | `90` | no |
+| <a name="input_cluster_additional_addons"></a> [cluster\_additional\_addons](#input\_cluster\_additional\_addons) | Map of addtional external addons configurations to enable for the cluster. Addon name can be the map keys or set with `name` | `any` | `{}` | no |
 | <a name="input_cluster_additional_security_group_ids"></a> [cluster\_additional\_security\_group\_ids](#input\_cluster\_additional\_security\_group\_ids) | List of additional, externally created security group IDs to attach to the cluster control plane | `list(string)` | `[]` | no |
 | <a name="input_cluster_addons"></a> [cluster\_addons](#input\_cluster\_addons) | Map of cluster addon configurations to enable for the cluster. Addon name can be the map keys or set with `name` | `any` | `{}` | no |
 | <a name="input_cluster_addons_timeouts"></a> [cluster\_addons\_timeouts](#input\_cluster\_addons\_timeouts) | Create, update, and delete timeout configurations for the cluster addons | `map(string)` | `{}` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -59,6 +59,12 @@ module "eks" {
     }
   }
 
+  cluster_additional_addons = {
+    cluster-autoscaler = {
+      install = true
+    }
+  }
+
   # External encryption key
   create_kms_key = false
   cluster_encryption_config = {

--- a/main.tf
+++ b/main.tf
@@ -438,6 +438,33 @@ data "aws_eks_addon_version" "this" {
 }
 
 ################################################################################
+# EKS Additional Addons
+################################################################################
+
+module "cluster_autoscaler" {
+  source = "./modules/addons/cluster-autoscaler"
+
+  for_each = { for k, v in var.cluster_additional_addons : k => v if k == "cluster-autoscaler" && local.create && var.enable_irsa && !local.create_outposts_local_cluster }
+
+  install   = try(each.value.install, false)
+  time_wait = try(each.value.time_wait, "30s")
+
+  image_tag            = try(each.value.image_tag, "")
+  namespace            = try(each.value.namespace, "kube-system")
+  helm_release_version = try(each.value.helm_release_version, "")
+  helm_release_values  = try(each.value.helm_release_values, "")
+
+  irsa_role_name = try(each.value.rirsa_role_name, "")
+
+  cluster_name              = aws_eks_cluster.this[0].name
+  cluster_version           = aws_eks_cluster.this[0].version
+  cluster_oidc_provider_arn = aws_iam_openid_connect_provider.oidc_provider[0].arn
+
+  tags = var.tags
+
+}
+
+################################################################################
 # EKS Identity Provider
 # Note - this is different from IRSA
 ################################################################################

--- a/modules/addons/cluster-autoscaler/README.md
+++ b/modules/addons/cluster-autoscaler/README.md
@@ -1,0 +1,54 @@
+# cluster-autoscaler
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.47 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.5 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.47 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.5 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.9 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_irsa_role"></a> [irsa\_role](#module\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.3 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of associated EKS cluster | `string` | `null` | no |
+| <a name="input_cluster_oidc_provider_arn"></a> [cluster\_oidc\_provider\_arn](#input\_cluster\_oidc\_provider\_arn) | Cluster OIDC provider ARN. | `string` | `null` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.25`). | `string` | `null` | no |
+| <a name="input_helm_release_values"></a> [helm\_release\_values](#input\_helm\_release\_values) | List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple -f options. | `string` | `null` | no |
+| <a name="input_helm_release_version"></a> [helm\_release\_version](#input\_helm\_release\_version) | Specify the exact chart version to install. If this is not specified, the latest version is installed. | `string` | `null` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Image tag used on Cluster Autoscaler helm deploy. | `string` | `null` | no |
+| <a name="input_install"></a> [install](#input\_install) | Enable (if true) or disable (if false) the installation of the Cluster Autoscaler. | `bool` | `true` | no |
+| <a name="input_irsa_role_name"></a> [irsa\_role\_name](#input\_irsa\_role\_name) | Name of IAM role to Cluster Autoscaler IRSA. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to install the Cluster Autoscaler release into. | `string` | `"kube-system"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_time_wait"></a> [time\_wait](#input\_time\_wait) | Time wait after cluster creation for access API Server for resource deploy. | `string` | `"30s"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/addons/cluster-autoscaler/main.tf
+++ b/modules/addons/cluster-autoscaler/main.tf
@@ -1,0 +1,118 @@
+################################################################################
+# Cluster Autoscaler
+################################################################################
+locals {
+  image_tag = coalesce(
+    var.image_tag,
+    var.cluster_version == "1.24" ? "v1.24.2" : "",
+    var.cluster_version == "1.25" ? "v1.25.2" : "",
+    var.cluster_version == "1.26" ? "v1.26.3" : "",
+    var.cluster_version == "1.27" ? "v1.27.2" : "",
+  )
+
+  helm_release_version = coalesce(
+    var.helm_release_version,
+    var.cluster_version == "1.24" ? "9.29.1" : "",
+    var.cluster_version == "1.25" ? "9.29.1" : "",
+    var.cluster_version == "1.26" ? "9.29.1" : "",
+    var.cluster_version == "1.27" ? "9.29.1" : "",
+  )
+  helm_chart_full_name = "aws-cluster-autoscaler"
+}
+
+data "aws_region" "current" {}
+
+resource "time_sleep" "this" {
+  count = var.install ? 1 : 0
+
+  create_duration = var.time_wait
+}
+
+module "irsa_role" {
+  count = var.install ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.3"
+
+  role_name                        = var.irsa_role_name != "" ? var.irsa_role_name : "cluster-autoscaler-${var.cluster_name}"
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_ids   = [var.cluster_name]
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = var.cluster_oidc_provider_arn
+      namespace_service_accounts = ["${var.namespace}:${local.helm_chart_full_name}"]
+    }
+  }
+
+  tags = var.tags
+}
+
+# Reference: https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler
+resource "helm_release" "this" {
+  count = var.install ? 1 : 0
+
+  depends_on = [
+    time_sleep.this,
+  ]
+
+  namespace        = var.namespace
+  create_namespace = false
+
+  name              = "cluster-autoscaler"
+  repository        = "https://kubernetes.github.io/autoscaler"
+  chart             = "cluster-autoscaler"
+  version           = local.helm_release_version
+  dependency_update = true
+
+  set {
+    name  = "image.tag"
+    value = local.image_tag
+  }
+  set {
+    name  = "autoDiscovery.clusterName"
+    value = var.cluster_name
+  }
+  set {
+    name  = "awsRegion"
+    value = data.aws_region.current.name
+  }
+  set {
+    name  = "cloudProvider"
+    value = "aws"
+  }
+  set {
+    name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = module.irsa_role[0].iam_role_arn
+  }
+
+  values = [
+    yamlencode({
+      replicaCount = "2"
+      updateStrategy = {
+        type = "RollingUpdate"
+        rollingUpdate = {
+          maxUnavailable = "1"
+        }
+      }
+      extraArgs = {
+        expander = "least-waste"
+      }
+      affinity = {
+        podAntiAffinity = {
+          requiredDuringSchedulingIgnoredDuringExecution = [
+            {
+              labelSelector = {
+                matchLabels = {
+                  "app.kubernetes.io/name" = local.helm_chart_full_name
+                }
+              }
+              namespaces  = [var.namespace]
+              topologyKey = "kubernetes.io/hostname"
+            }
+          ]
+        }
+      }
+    }), var.helm_release_values
+  ]
+}

--- a/modules/addons/cluster-autoscaler/variables.tf
+++ b/modules/addons/cluster-autoscaler/variables.tf
@@ -1,0 +1,65 @@
+variable "install" {
+  description = "Enable (if true) or disable (if false) the installation of the Cluster Autoscaler."
+  type        = bool
+  default     = true
+}
+
+variable "time_wait" {
+  description = "Time wait after cluster creation for access API Server for resource deploy."
+  type        = string
+  default     = "30s"
+}
+
+variable "irsa_role_name" {
+  description = "Name of IAM role to Cluster Autoscaler IRSA."
+  type        = string
+  default     = null
+}
+
+variable "cluster_name" {
+  description = "Name of associated EKS cluster"
+  type        = string
+  default     = null
+}
+
+variable "cluster_version" {
+  description = "Kubernetes `<major>.<minor>` version to use for the EKS cluster (i.e.: `1.25`)."
+  type        = string
+  default     = null
+}
+
+variable "cluster_oidc_provider_arn" {
+  description = "Cluster OIDC provider ARN."
+  type        = string
+  default     = null
+}
+
+variable "namespace" {
+  description = "Namespace to install the Cluster Autoscaler release into."
+  type        = string
+  default     = "kube-system"
+}
+
+variable "image_tag" {
+  description = "Image tag used on Cluster Autoscaler helm deploy."
+  type        = string
+  default     = null
+}
+
+variable "helm_release_values" {
+  description = "List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple -f options."
+  type        = string
+  default     = null
+}
+
+variable "helm_release_version" {
+  description = "Specify the exact chart version to install. If this is not specified, the latest version is installed."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/addons/cluster-autoscaler/versions.tf
+++ b/modules/addons/cluster-autoscaler/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.47"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.5"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -483,6 +483,16 @@ variable "cluster_addons_timeouts" {
 }
 
 ################################################################################
+# EKS Additional Addons
+################################################################################
+
+variable "cluster_additional_addons" {
+  description = "Map of addtional external addons configurations to enable for the cluster. Addon name can be the map keys or set with `name`"
+  type        = any
+  default     = {}
+}
+
+################################################################################
 # EKS Identity Provider
 ################################################################################
 


### PR DESCRIPTION
## Description
In this new functionality the idea is
we have the possibility to install external/additional addons, that is, the addons that are not installable by the `aws_eks_addon` resource.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently there are components/addons that are ideal for a functional installation of an EKS Cluster, at least to have a good functioning and that it is possible to implement applications without great complexities.
We have examples of addons that fulfill this role: Cluster Autoscaler, Metric Server, AWS Load Balancer Controller, etc.
In this way, the creation of additional/external addons opens the possibility of implementing several others (currently we contemplate only Cluster Autoscaler).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
NDA

## How Has This Been Tested?
- [ x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

## Mentions
@snifbr - Great technical support and amazing conversartion <3
