### PR TITLE
feat: Wrap linux user data with MIME

### DIFF
--- a/templates/linux_user_data.tpl
+++ b/templates/linux_user_data.tpl
@@ -1,4 +1,10 @@
 %{ if enable_bootstrap_user_data ~}
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="//"
+
+--//
+Content-Type: text/x-shellscript
+
 #!/bin/bash
 set -e
 %{ endif ~}
@@ -11,4 +17,6 @@ B64_CLUSTER_CA=${cluster_auth_base64}
 API_SERVER_URL=${cluster_endpoint}
 /etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL
 ${post_bootstrap_user_data ~}
+
+--//--
 %{ endif ~}


### PR DESCRIPTION
## Description
Wraps the linux user data template in mime formatting

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Recently tried to push some user data items and got an error:
```
Ec2LaunchTemplateInvalidConfiguration: User data was not in the MIME multipart format.
```
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
Run a Terraform plan
<img width="1690" alt="image" src="https://github.com/terraform-aws-modules/terraform-aws-eks/assets/1124760/8215ae61-30de-4213-b66e-06b7901301ad">

