### PR TITLE
Oscarmendoza123 patch 1

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -279,7 +279,9 @@ locals {
 resource "aws_cloudwatch_event_rule" "this" {
   for_each = { for k, v in local.events : k => v if local.enable_spot_termination }
 
-  name_prefix   = "${var.rule_name_prefix}${each.value.name}-"
+  name        = var.rule_use_name_prefix ? null : "${var.rule_name_prefix}${each.value.name}"
+  name_prefix = var.rule_use_name_prefix ? "${var.rule_name_prefix}${each.value.name}-" : null
+
   description   = each.value.description
   event_pattern = jsonencode(each.value.event_pattern)
 

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -246,6 +246,11 @@ variable "create_instance_profile" {
 ################################################################################
 # Event Bridge Rules
 ################################################################################
+variable "rule_use_name_prefix" {
+  description = "Determines whether the Cloud Watch Event name (`rule_name_prefix`) is used as a prefix"
+  type        = bool
+  default     = true
+}
 
 variable "rule_name_prefix" {
   description = "Prefix used for all event bridge rules"


### PR DESCRIPTION
## Description
Adding the same option as IAM roles to optionally use a name prefix. The will default to the same way the module is being used today but will give end users the option to not use the prefix.

## Motivation and Context
` Member must have length less than or equal to 64` error when trying to use this currently

## Breaking Changes
NA

## How Has This Been Tested?
- [x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x ] I have executed `pre-commit run -a` on my pull request

