### PR TITLE
docs: Correct `time_zone` argument on example autoscaling group schedule

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -271,7 +271,7 @@ module "eks" {
           desired_size = 2
           start_time   = "2023-03-05T00:00:00Z"
           end_time     = "2024-03-05T00:00:00Z"
-          time_zone     = "Etc/GMT+0"
+          time_zone    = "Etc/GMT+0"
           recurrence   = "0 0 * * *"
         },
         scale-down = {
@@ -280,7 +280,7 @@ module "eks" {
           desired_size = 0
           start_time   = "2023-03-05T12:00:00Z"
           end_time     = "2024-03-05T12:00:00Z"
-          time_zone     = "Etc/GMT+0"
+          time_zone    = "Etc/GMT+0"
           recurrence   = "0 12 * * *"
         }
       }


### PR DESCRIPTION
## Description
The sample usage of autoscaling group scheduled actions has a typo on time_zone definition

## Motivation and Context
When using the sample, the time_zone parameter is not set accordingly on AWS.

## Breaking Changes
Not applicable

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request