### PR TITLE
Fixing errors while creating new EKS cluster Karpenter / Fargate profiles

### DIFF
--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -40,13 +40,15 @@ resource "aws_iam_role" "this" {
   tags = merge(var.tags, var.iam_role_tags)
 }
 
-resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSFargatePodExecutionRolePolicy",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_role }
+resource "aws_iam_role_policy_attachment" "cni_policy" {
+  count = var.create && var.create_iam_role && var.iam_role_attach_cni_policy ? 1 : 0
+  policy_arn = local.cni_policy
+  role       = aws_iam_role.this[0].name
+}
 
-  policy_arn = each.value
+resource "aws_iam_role_policy_attachment" "fargate_pod_execution_role_policy" {
+  count = var.create && var.create_iam_role ? 1 : 0
+  policy_arn = "${local.iam_role_policy_prefix}/AmazonEKSFargatePodExecutionRolePolicy"
   role       = aws_iam_role.this[0].name
 }
 

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -341,14 +341,25 @@ resource "aws_iam_role" "this" {
 }
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
-resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if local.create_iam_role }
 
-  policy_arn = each.value
+resource "aws_iam_role_policy_attachment" "AmazonEKSWorkerNodePolicy" {
+
+  count = local.create_iam_role ? 1 : 0
+  policy_arn = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.this[0].name
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryReadOnly" {
+
+  count = local.create_iam_role ? 1 : 0
+  policy_arn = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.this[0].name
+}
+
+resource "aws_iam_role_policy_attachment" "cni_policy" {
+
+  count = var.iam_role_attach_cni_policy && local.create_iam_role ? 1 : 0
+  policy_arn = var.iam_role_attach_cni_policy ? local.cni_policy : ""
   role       = aws_iam_role.this[0].name
 }
 


### PR DESCRIPTION
## Description
Create separate role policy attachments instead of using for_each in Karpenter and Fargate.

## Motivation and Context
While creating a new EKS cluster and using the modules of Karpenter / Fargate separately from the EKS cluster module, there is an error that the variable `local.iam_role_policy_prefix` is unknown and you should apply some resources first using `-target` to resolve the unknown dependency.

The error is because the for_each phase happens during plan and not during apply, while the resource will be resolved during apply.... therefore the removal of for_each for those 3 resources (which is also simplifying the code in my perspective) resolve the issue.

![Screenshot 2023-08-23 at 13 23 31](https://github.com/terraform-aws-modules/terraform-aws-eks/assets/14234032/9a27bc50-06ed-4382-b16e-271a29074f4a)


## Breaking Changes
No breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

