### PR TITLE
fix: Clarify space for additional security sgs on nodes

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -500,7 +500,7 @@ module "self_managed_node_group" {
   iam_role_additional_policies = lookup(each.value, "iam_role_additional_policies", lookup(var.self_managed_node_group_defaults, "iam_role_additional_policies", {}))
 
   # Security group
-  vpc_security_group_ids            = compact(concat([local.node_security_group_id], try(each.value.vpc_security_group_ids, var.self_managed_node_group_defaults.vpc_security_group_ids, [])))
+  vpc_security_group_ids            = compact(concat([local.node_security_group_id], try(each.value.vpc_security_group_ids, var.node_additional_security_group_ids, [])))
   cluster_primary_security_group_id = try(each.value.attach_cluster_primary_security_group, var.self_managed_node_group_defaults.attach_cluster_primary_security_group, false) ? aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id : null
 
   tags = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))

--- a/variables.tf
+++ b/variables.tf
@@ -330,6 +330,12 @@ variable "node_security_group_additional_rules" {
   default     = {}
 }
 
+variable "node_additional_security_group_ids" {
+  description = "List of additional security group rules to add to nodes"
+  type = list(string)
+  default = []
+}
+
 variable "node_security_group_enable_recommended_rules" {
   description = "Determines whether to enable recommended security group rules for the node security group created. This includes node-to-node TCP ingress on ephemeral ports and allows all egress traffic"
   type        = bool


### PR DESCRIPTION
## Description
making a map for managed nodes to add additional sgs is confusing

just want it to be a clear place where the additional sg ids go.

## Motivation and Context
Its confusing why a map is needed for managed node sg ids when the cluster has a top level variable for the same reason.

## Breaking Changes
The only place i found that uses this map field `var.eks_managed_node_group_defaults.vpc_security_group_ids`

is the concat operation to add the ids to the final security group list.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
