### PR TITLE
fix: Ensure aws_eks_addons with before_compute flag get destoyed after compute resources

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -36,6 +36,10 @@ resource "time_sleep" "this" {
 
     cluster_certificate_authority_data = aws_eks_cluster.this[0].certificate_authority[0].data
   }
+
+  depends_on = [
+    aws_eks_addon.before_compute
+  ]
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
With the added dependency, the `aws_eks_addon.before_compute` resources get destroyed after the node groups. 

## Motivation and Context
Destroying the `vpc-cni` EKS addon before destroying the node groups may result in leaked EC2 network interfaces.

Current behavior:
```
module.eks.aws_eks_addon.before_compute["vpc-cni"]: Destruction complete after 2s
module.eks.module.eks_managed_node_group["test"].aws_eks_node_group.this[0]: Destroying...
```

Expected behavior:
```
module.eks.module.eks_managed_node_group["default_b"].aws_eks_node_group.this[0]: Destruction complete after 2m37s
module.eks.module.eks_managed_node_group["test"].aws_launch_template.this[0]: Destroying... 
module.eks.module.eks_managed_node_group["test"].aws_launch_template.this[0]: Destruction complete after 0s
module.eks.module.eks_managed_node_group["test"].aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"]: Destroying... 
module.eks.module.eks_managed_node_group["test"].aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]: Destroying...
module.eks.module.eks_managed_node_group["test"].aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]: Destroying... 
module.eks.time_sleep.this[0]: Destroying... 
module.eks.time_sleep.this[0]: Destruction complete after 0s
module.eks.aws_eks_addon.before_compute["vpc-cni"]: Destroying... 
```

## Breaking Changes
NA

## How Has This Been Tested?

I have manually tested the change by provisioning and then destroying a Terraform module with AWS VPC and AWS EKS cluster with multiple node groups and the `vpc-cni` configured as a "before_compute" addon.
