### PR TITLE
feat: Add cluster_additional_security_group_ids_exclude_cluster_sg_id…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_eks_cluster" "this" {
   enabled_cluster_log_types = var.cluster_enabled_log_types
 
   vpc_config {
-    security_group_ids      = compact(distinct(concat(var.cluster_additional_security_group_ids, [local.cluster_security_group_id])))
+    security_group_ids      = var.cluster_additional_security_group_ids_exclude_cluster_sg_id ?  var.cluster_additional_security_group_ids : compact(distinct(concat(var.cluster_additional_security_group_ids, [local.cluster_security_group_id])))
     subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
     endpoint_private_access = var.cluster_endpoint_private_access
     endpoint_public_access  = var.cluster_endpoint_public_access

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "cluster_additional_security_group_ids" {
   default     = []
 }
 
+variable "cluster_additional_security_group_ids_include_cluster_sg_id" {
+  description = "If true the cluster security group ID is excluded from the list of additionl security groups"
+  type        = bool
+  default     = false
+}
+
 variable "control_plane_subnet_ids" {
   description = "A list of subnet IDs where the EKS cluster control plane (ENIs) will be provisioned. Used for expanding the pool of subnets used by nodes/node groups without replacing the EKS control plane"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "cluster_additional_security_group_ids" {
   default     = []
 }
 
-variable "cluster_additional_security_group_ids_include_cluster_sg_id" {
+variable "cluster_additional_security_group_ids_exclude_cluster_sg_id" {
   description = "If true the cluster security group ID is excluded from the list of additionl security groups"
   type        = bool
   default     = false


### PR DESCRIPTION
… for excluding the cluster security group id from the list of additional security groups.

## Description
Adds a variable cluster_additional_security_group_ids_exclude_cluster_sg_id that defaults to false. When set to true, the list of additional security groups added to the eks cluster will not include the cluster security group. By default, the cluster security group is included.

## Motivation and Context
This is useful in the scenario where an existing cluster is being imported with `terraform import` and the cluster security group was not included in additional security groups. Without this option, the cluster has to be recreated because the module tries to change the list of additional security groups, which forces a replacement

Fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2751

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
