### PR TITLE
fix: Update logic for create_cluster_primary_security_groups to short-circuit sooner

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,8 +95,8 @@ resource "aws_ec2_tag" "cluster_primary_security_group" {
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2760
-  for_each = var.create_cluster_primary_security_group_tags ? { for k, v in merge(var.tags, var.cluster_tags) :
-    k => v if local.create && k != "Name" && v != null
+  for_each = local.create && var.create_cluster_primary_security_group_tags ? { for k, v in merge(var.tags, var.cluster_tags) :
+    k => v if k != "Name" && v != null
   } : {}
 
   resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id

--- a/main.tf
+++ b/main.tf
@@ -94,9 +94,10 @@ resource "aws_ec2_tag" "cluster_primary_security_group" {
   # This should not affect the name of the cluster primary security group
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
-  for_each = { for k, v in merge(var.tags, var.cluster_tags) :
-    k => v if local.create && k != "Name" && var.create_cluster_primary_security_group_tags && v != null
-  }
+  # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2760
+  for_each = var.create_cluster_primary_security_group_tags ? { for k, v in merge(var.tags, var.cluster_tags) :
+    k => v if local.create && k != "Name" && v != null
+  } : {}
 
   resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
   key         = each.key


### PR DESCRIPTION
## Description

When `var.create_cluster_primary_security_groups` is set to `false` it will correctly not do any work/not actually attempt to iterate over the map/create the for_each.

## Motivation and Context

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2760

## Breaking Changes

No, no breaking changes. I am now able to deploy my cluster with dynamic tags.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
