### PR TITLE
CloudWatch LogGroup depends_on

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,6 @@ resource "aws_eks_cluster" "this" {
     aws_iam_role_policy_attachment.this,
     aws_security_group_rule.cluster,
     aws_security_group_rule.node,
-    aws_cloudwatch_log_group.this,
     aws_iam_policy.cni_ipv6_policy,
   ]
 }
@@ -114,6 +113,10 @@ resource "aws_cloudwatch_log_group" "this" {
     var.tags,
     { Name = "/aws/eks/${var.cluster_name}/cluster" }
   )
+
+  depends_on = [
+    aws_eks_cluster.this
+  ]
 }
 
 ################################################################################


### PR DESCRIPTION
Due to the logGroup being recreated upon destroy when streams are still sending events the logGroup resource is left orphaned in AWS. 

If not recreating the cluster this just leaves orphaned resource. If being recreated the apply of the newly created cluster will fail due to the log group already existing.

This is to change the dependency order to only delete the cloudwatch log group after the cluster has been successfully destroyed. #2763

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
