### PR TITLE
fix: Create dependency in the nodegroups on the aws_cloudwatch_log_group

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -371,6 +371,10 @@ module "eks_managed_node_group" {
   cluster_primary_security_group_id = try(each.value.attach_cluster_primary_security_group, var.eks_managed_node_group_defaults.attach_cluster_primary_security_group, false) ? aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id : null
 
   tags = merge(var.tags, try(each.value.tags, var.eks_managed_node_group_defaults.tags, {}))
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+  ]
 }
 
 ################################################################################
@@ -504,4 +508,8 @@ module "self_managed_node_group" {
   cluster_primary_security_group_id = try(each.value.attach_cluster_primary_security_group, var.self_managed_node_group_defaults.attach_cluster_primary_security_group, false) ? aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id : null
 
   tags = merge(var.tags, try(each.value.tags, var.self_managed_node_group_defaults.tags, {}))
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+  ]
 }


### PR DESCRIPTION
Create dependency in the nodegroups on the aws_cloudwatch_log_group.
Once the nodegroup is deleted then the logGroup can.

Fixes #2763 