### PR TITLE
fix: Added conditonal for creation of  kubernetes.io/cluster/cluster_name: Owned tag on Nodegroup SG

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -194,6 +194,7 @@ resource "aws_security_group" "node" {
     var.tags,
     {
       "Name"                                      = local.node_sg_name
+      "kubernetes.io/cluster/${var.cluster_name}" = var.nodegroup_sg_kubernetes_owner_tag_enabled == true ? "owned" : null
     },
     var.node_security_group_tags
   )

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -194,7 +194,6 @@ resource "aws_security_group" "node" {
     var.tags,
     {
       "Name"                                      = local.node_sg_name
-      "kubernetes.io/cluster/${var.cluster_name}" = "owned"
     },
     var.node_security_group_tags
   )

--- a/variables.tf
+++ b/variables.tf
@@ -597,3 +597,9 @@ variable "aws_auth_accounts" {
   type        = list(any)
   default     = []
 }
+
+variable "nodegroup_sg_kubernetes_owner_tag_enabled" {
+  type        = bool
+  default     = true
+  description = "Creates kubernetes.io/cluster/cluster_name owned Tag on Nodegroup Security Group. If false, no tag is created. Created to address issue with Cluster Autoscaler discovery"
+}


### PR DESCRIPTION
## Description
- Added boolean conditonal for creation of  kubernetes.io/cluster/cluster_name: Owned tag on Nodegroup SG
- Added default value for non-disruptive change

## Motivation and Context
- The presence of this tag is causing an issue for target group discovery with the Cluster Autoscaler
- Removal of the tag resolves the issue
- Have created non-disruptive change to address issue 

## Breaking Changes
Non-disruptive change to address issue, given variable default value of true

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
