### PR TITLE
fix: Only include CA thumbprint in OIDC provider list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count = local.create && var.enable_irsa && !local.create_outposts_local_cluster ? 1 : 0
 
   client_id_list  = distinct(compact(concat(["sts.${local.dns_suffix}"], var.openid_connect_audiences)))
-  thumbprint_list = concat(data.tls_certificate.this[0].certificates[*].sha1_fingerprint, var.custom_oidc_thumbprints)
+  thumbprint_list = concat([data.tls_certificate.this[0].certificates[0].sha1_fingerprint], var.custom_oidc_thumbprints)
   url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 
   tags = merge(


### PR DESCRIPTION
## Description

This change modifies the OIDC provider `thumbprint_list`, so that it only contains the CA fingerprint, rather than all fingerprints.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Addresses #2732, by reverting the change from #2307.

According to the description of #2732, #2307 introduced the inclusion of all certificate fingerprints in the `thumbprint_list`. Based on a later documentation change in hashicorp/terraform-provider-aws#32847, only the CA fingerprint should be included in the `thumbprint_list`.

From the [latest docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#enabling-iam-roles-for-service-accounts), the following should be used:

> thumbprint_list = [data.tls_certificate.example.certificates[0].sha1_fingerprint]

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

This shouldn't break existing functionality, since the root CA encompasses the authority provided by any other certificates that were previously included.

## How Has This Been Tested?

I tested this change by modifying the reproduction code provided in #2768 to reference the modified `eks` module.

Before the change, 4 fingerprints were included for the OIDC provider. After the change, only the single root CA fingerprint was included.

<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
