### PR TITLE
feat: Expect exactly one securityGroup tagged with kubernetes.io/cluster/eks-1 for ENI

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -194,7 +194,6 @@ resource "aws_security_group" "node" {
     var.tags,
     {
       "Name"                                      = local.node_sg_name
-      "kubernetes.io/cluster/${var.cluster_name}" = "owned"
     },
     var.node_security_group_tags
   )


### PR DESCRIPTION
## Description
"kubernetes.io/cluster/${var.cluster_name}" = "owned" - removing hardcoded  tag from node sg
## Motivation and Context
ENI can have only one sg with this tag
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1897

## Breaking Changes
Can be added into var.tags if needed on the node level

## How Has This Been Tested?
Cluster re-created, changes didn't affect anything before this tag was removed manually, but due to multiple terraform applied it recreates all the time casein manual follow-up
