### PR TITLE
docs: Add ebs disk in complete example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -189,6 +189,19 @@ module "eks" {
         }
       }
 
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 100
+            volume_type           = "gp3"
+            iops                  = 3000
+            throughput            = 150
+            delete_on_termination = true
+          }
+        }
+      }
+
       update_config = {
         max_unavailable_percentage = 33 # or set `max_unavailable`
       }


### PR DESCRIPTION
## Description

Following issue https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2699, adding a sample in complete example in order to show how to add an EBS disk correctly

## Motivation and Context

Adding a disk doesn't seem to be explicite. Moreover, it doesn't appear in complete exemple

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
