### PR TITLE
Add root_block_device input for module self_managed_node_group

### DIFF
--- a/examples/self_managed_node_group/main.tf
+++ b/examples/self_managed_node_group/main.tf
@@ -69,6 +69,10 @@ module "eks" {
       "k8s.io/cluster-autoscaler/enabled" : true,
       "k8s.io/cluster-autoscaler/${local.name}" : "owned",
     }
+    root_block_device = {
+      volume_type = "standard"
+      volume_size = 15
+    }
   }
 
   self_managed_node_groups = {
@@ -84,7 +88,10 @@ module "eks" {
       instance_type = "m5.large"
       desired_size  = 2
       key_name      = module.key_pair.key_pair_name
-
+      root_block_device = {
+        volume_type = "standard"
+        volume_size = 20
+      }
       bootstrap_extra_args = <<-EOT
         # The admin host container provides SSH access and runs with "superpowers".
         # It is disabled by default, but can be disabled explicitly.
@@ -117,7 +124,10 @@ module "eks" {
       min_size     = 1
       max_size     = 5
       desired_size = 2
-
+      root_block_device = {
+        volume_type = "standard"
+        volume_size = 25
+      }
       bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
 
       use_mixed_instances_policy = true
@@ -148,7 +158,10 @@ module "eks" {
 
       # aws ec2 describe-instance-types --region eu-west-1 --filters Name=network-info.efa-supported,Values=true --query "InstanceTypes[*].[InstanceType]" --output text | sort
       instance_type = "c5n.9xlarge"
-
+      root_block_device = {
+        volume_type = "standard"
+        volume_size = 30
+      }
       post_bootstrap_user_data = <<-EOT
         # Install EFA
         curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
@@ -201,9 +214,19 @@ module "eks" {
       ebs_optimized     = true
       enable_monitoring = true
 
+      root_block_device = {
+        volume_size           = 75
+        volume_type           = "gp3"
+        iops                  = 3000
+        throughput            = 150
+        encrypted             = true
+        kms_key_id            = module.ebs_kms_key.key_arn
+        delete_on_termination = true
+      }
+
       block_device_mappings = {
-        xvda = {
-          device_name = "/dev/xvda"
+        xvdb = {
+          device_name = "/dev/xvdb"
           ebs = {
             volume_size           = 75
             volume_type           = "gp3"

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -27,6 +27,11 @@ module "self_managed_node_group" {
   max_size     = 10
   desired_size = 1
 
+  root_block_device = {
+    volume_type = "standard"
+    volume_size = 40
+  }
+
   launch_template_name   = "separate-self-mng"
   instance_type          = "m5.large"
 
@@ -69,6 +74,7 @@ module "self_managed_node_group" {
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_ami.eks_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.final_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -157,6 +163,7 @@ module "self_managed_node_group" {
 | <a name="input_private_dns_name_options"></a> [private\_dns\_name\_options](#input\_private\_dns\_name\_options) | The options for the instance hostname. The default values are inherited from the subnet | `map(string)` | `{}` | no |
 | <a name="input_protect_from_scale_in"></a> [protect\_from\_scale\_in](#input\_protect\_from\_scale\_in) | Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events. | `bool` | `false` | no |
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
+| <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | Specify volume to replace the volume by the AMI | `any` | `{}` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones` | `list(string)` | `null` | no |

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -132,6 +132,12 @@ variable "ram_disk_id" {
   default     = null
 }
 
+variable "root_block_device" {
+  description = "Specify volume to replace the volume by the AMI"
+  type        = any
+  default     = {}
+}
+
 variable "block_device_mappings" {
   description = "Specify volumes to attach to the instance besides the volumes specified by the AMI"
   type        = any

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -467,6 +467,7 @@ module "self_managed_node_group" {
   kernel_id                            = try(each.value.kernel_id, var.self_managed_node_group_defaults.kernel_id, null)
   ram_disk_id                          = try(each.value.ram_disk_id, var.self_managed_node_group_defaults.ram_disk_id, null)
 
+  root_block_device                  = try(each.value.root_block_device, var.self_managed_node_group_defaults.root_block_device, {})
   block_device_mappings              = try(each.value.block_device_mappings, var.self_managed_node_group_defaults.block_device_mappings, {})
   capacity_reservation_specification = try(each.value.capacity_reservation_specification, var.self_managed_node_group_defaults.capacity_reservation_specification, {})
   cpu_options                        = try(each.value.cpu_options, var.self_managed_node_group_defaults.cpu_options, {})


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace the root volume by specifying `root_block_device` as [describe](https://registry.terraform.io/providers/hashicorp/aws/5.20.1/docs/resources/instance#ebs-ephemeral-and-root-block-devices) for module `self_managed_node_group`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Currently, we can achieve this purpose by declaring in the `block_device_mappings` but we must specify `device_name` correctly. `device_name`  depends on the `root_block_device` attribute of the `AMI` and it is `/dev/xvda` as usual.
- With this feature, we won't worry about filling exactly `device_name` if we want to replace the root block device.
- Replacing the `AMI` supports `ebs` device type via the `root_device_type` attribute.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None
## How Has This Been Tested?
- [ ok] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ok] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ok] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
