### PR TITLE
fix: add eks:DescribeCluster to irsa policy

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -84,6 +84,7 @@ data "aws_iam_policy_document" "irsa" {
       "ec2:DescribeInstanceTypeOfferings",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeSpotPriceHistory",
+      "eks:DescribeCluster",
       "pricing:GetProducts",
     ]
 


### PR DESCRIPTION
## Description
According to the docs, the IRSA policy requires `eks:DescribeCluster`

## Motivation and Context
https://github.com/aws/karpenter/issues/3584

## Breaking Changes
N/A

## How Has This Been Tested?
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects

