### PR TITLE
IAM for Karpenter v1beta1 resources

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -139,6 +139,7 @@ No modules.
 | [aws_iam_policy_document.irsa_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -170,7 +171,7 @@ No modules.
 | <a name="input_irsa_path"></a> [irsa\_path](#input\_irsa\_path) | Path of IAM role for service accounts | `string` | `"/"` | no |
 | <a name="input_irsa_permissions_boundary_arn"></a> [irsa\_permissions\_boundary\_arn](#input\_irsa\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role for service accounts | `string` | `null` | no |
 | <a name="input_irsa_policy_name"></a> [irsa\_policy\_name](#input\_irsa\_policy\_name) | Name of IAM policy for service accounts | `string` | `null` | no |
-| <a name="input_irsa_ssm_parameter_arns"></a> [irsa\_ssm\_parameter\_arns](#input\_irsa\_ssm\_parameter\_arns) | List of SSM Parameter ARNs that contain AMI IDs launched by Karpenter | `list(string)` | <pre>[<br>  "arn:aws:ssm:*:*:parameter/aws/service/*"<br>]</pre> | no |
+| <a name="input_irsa_ssm_parameter_arns"></a> [irsa\_ssm\_parameter\_arns](#input\_irsa\_ssm\_parameter\_arns) | List of SSM Parameter ARNs that contain AMI IDs launched by Karpenter | `list(string)` | `[]` | no |
 | <a name="input_irsa_subnet_account_id"></a> [irsa\_subnet\_account\_id](#input\_irsa\_subnet\_account\_id) | Account ID of where the subnets Karpenter will utilize resides. Used when subnets are shared from another account | `string` | `""` | no |
 | <a name="input_irsa_tag_key"></a> [irsa\_tag\_key](#input\_irsa\_tag\_key) | Tag key (`{key = value}`) applied to resources launched by Karpenter through the Karpenter provisioner | `string` | `"karpenter.sh/discovery"` | no |
 | <a name="input_irsa_tag_values"></a> [irsa\_tag\_values](#input\_irsa\_tag\_values) | Tag values (`{key = value}`) applied to resources launched by Karpenter through the Karpenter provisioner. Defaults to cluster name when not set. | `list(string)` | `[]` | no |

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -95,8 +95,7 @@ variable "irsa_tag_values" {
 variable "irsa_ssm_parameter_arns" {
   description = "List of SSM Parameter ARNs that contain AMI IDs launched by Karpenter"
   type        = list(string)
-  # https://github.com/aws/karpenter/blob/ed9473a9863ca949b61b9846c8b9f33f35b86dbd/pkg/cloudprovider/aws/ami.go#L105-L123
-  default = ["arn:aws:ssm:*:*:parameter/aws/service/*"]
+  default     = []
 }
 
 variable "irsa_subnet_account_id" {


### PR DESCRIPTION
## Description
Add IAM support for Karpenter v1beta1 resources. Might fix #2733.

## Motivation and Context
The upcoming Karpenter v0.32 release is adding support for v1beta1 resources, as described in https://github.com/aws/karpenter/blob/main/designs/v1beta1-full-changelist.md. As part of this change, many tags applied to resources are changing, since they are renaming the Provisioner CRD to NodeClass.

The new controller IAM policy is described in https://github.com/aws/karpenter/blob/main/website/content/en/preview/upgrading/v1beta1-controller-policy.json

On top of that, even before the v1beta1 change, in https://github.com/aws/karpenter/pull/3948 the recommended policy was changed to add a lot of scoping rules to restrict the operations that Karpenter could do by checking request and resource tags. The version of the IAM policy in this repo pre-dates those changes.

This PR applies both those changes, and tries to maintain compatibility with both v1alpha5 and v1beta1 policies by having clauses that support both the v1alpha5 tags (using `aws:RequestTag/karpenter.sh/provisioner-name`) and v1beta1 tags (using `aws:RequestTag/karpenter.k8s.aws/ec2nodeclass`). The clauses for v1alpha5 compatibility retain the same SID but appended with "ALPHA"

In addition the policies in this repo had some unique policy conditions, restricting ec2:TerminateInstances, ec2:DeleteLaunchTemplate and ec2:RunInstances by the `ec2:ResourceTag/${var.irsa_tag_key}` tag (where var.irsa_tag_key was defaulting to `karpenter.sh/discovery`). This restriction shows up in none of the above policies. We make attempts to preserve backwards compatibility for previous users of this module while simultaneously adding the policies above. (I would much prefer to lose this and make a backwards incompatible change, but want to see what the PR discussion settles on.)

The PR attempts to maintain backwards compatibility in several other ways:
* var.irsa_ssm_parameter_arns was the default value for ssm:GetParameter, but it is less restrictive than the recommended value from the above policies (i.e. it allows a lot more "*" wildcards). Since a default value cannot have string interpolation in it, we blanked the default value, and instead moved the default as a coalescelist argument.
* Encode local.account_id in the ARNs even though the base IAM policies used `"*"` for account_id.
* AllowScopedEC2InstanceActions SID retains the `coalesce(var.irsa_subnet_account_id, local.account_id)` even after refactor.

## Breaking Changes
This might break compatibility in order to make this closer to the official IAM policies. Karpenter's tagging should have already been consistent so it shouldn't break existing deployments, but there's no guarantees without testing the new policies (and I do not have older clusters setup with v1alpha5 to do that.)

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
