### PR TITLE
fix: Correct key used on `license_configuration_arn` 

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -176,10 +176,10 @@ resource "aws_launch_template" "this" {
   key_name  = var.key_name
 
   dynamic "license_specification" {
-    for_each = length(var.license_specifications) > 0 ? var.license_specifications : {}
+    for_each = length(var.license_specifications) > 0 ? var.license_specifications : []
 
     content {
-      license_configuration_arn = license_specifications.value.license_configuration_arn
+      license_configuration_arn = license_specification.value.license_configuration_arn
     }
   }
 

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -282,10 +282,10 @@ resource "aws_launch_template" "this" {
   key_name      = var.key_name
 
   dynamic "license_specification" {
-    for_each = length(var.license_specifications) > 0 ? var.license_specifications : {}
+    for_each = length(var.license_specifications) > 0 ? var.license_specifications : []
 
     content {
-      license_configuration_arn = license_specifications.value.license_configuration_arn
+      license_configuration_arn = license_specification.value.license_configuration_arn
     }
   }
 


### PR DESCRIPTION
## Description
Following issue #2753.

## Motivation and Context
Currently, it is not possible to provide a license through the `self-managed-node-group` and `eks-managed-node-group` modules. 
This is necessary in cases like the following configuration:

```tf
placement = {
  tenancy                 = "host"
  host_resource_group_arn = ......
}
```

- Resolves #2753

## Breaking Changes
I do not see any potential breaking changes.


## How Has This Been Tested?
* [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
* [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
* [x] I have executed `pre-commit run -a` on my pull request

After these modifications, I can define `license_configuration_arn` as follows:

```tf
module "self_managed_node_group" {
  source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
  version = "19.17.2"

  name                = local.eks_name
  cluster_name        = module.eks.cluster_name
  cluster_version     = var.eks_version
  cluster_endpoint    = module.eks.cluster_endpoint
  cluster_auth_base64 = module.eks.cluster_certificate_authority_data

  ....

  placement = {
    tenancy                 = "host"
    host_resource_group_arn = "arn:aws:resource-groups:us-east-1:XXXXXXX:group/XXXXXX"
  }

  license_specifications = [
    {
      license_configuration_arn = "arn:aws:license-manager:us-east-1:XXXXXX:license-configuration:lic-XXXXXXXXX"
    }
  ]
}

```
I'm not entirely sure in this case if it makes sense to have the map within a list. If you have a better idea, please feel free to suggest it. Nevertheless, it's currently working well for me in this way.