### PR TITLE
fix: Add map license_specifications into list

### DIFF
--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -147,7 +147,7 @@ module "eks_managed_node_group" {
 | <a name="input_launch_template_tags"></a> [launch\_template\_tags](#input\_launch\_template\_tags) | A map of additional tags to add to the tag\_specifications of launch template created | `map(string)` | `{}` | no |
 | <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Launch template version number. The default is `$Default` | `string` | `null` | no |
-| <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A map of license specifications to associate with | `any` | `{}` | no |
+| <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A list of license specifications to associate with | `map(string)` | `{}` | no |
 | <a name="input_maintenance_options"></a> [maintenance\_options](#input\_maintenance\_options) | The maintenance options for the instance | `any` | `{}` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of instances/nodes | `number` | `3` | no |
 | <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options for the instance | `map(string)` | <pre>{<br>  "http_endpoint": "enabled",<br>  "http_put_response_hop_limit": 2,<br>  "http_tokens": "required"<br>}</pre> | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -176,8 +176,7 @@ resource "aws_launch_template" "this" {
   key_name  = var.key_name
 
   dynamic "license_specification" {
-    for_each = length(var.license_specifications) > 0 ? var.license_specifications : {}
-
+    for_each = length(var.license_specifications) > 0 ? [var.license_specifications] : []
     content {
       license_configuration_arn = license_specification.value.license_configuration_arn
     }

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -229,8 +229,8 @@ variable "maintenance_options" {
 }
 
 variable "license_specifications" {
-  description = "A map of license specifications to associate with"
-  type        = any
+  description = "A list of license specifications to associate with"
+  type        = map(string)
   default     = {}
 }
 

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -138,7 +138,7 @@ module "self_managed_node_group" {
 | <a name="input_launch_template_tags"></a> [launch\_template\_tags](#input\_launch\_template\_tags) | A map of additional tags to add to the tag\_specifications of launch template created | `map(string)` | `{}` | no |
 | <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |
 | <a name="input_launch_template_version"></a> [launch\_template\_version](#input\_launch\_template\_version) | Launch template version. Can be version number, `$Latest`, or `$Default` | `string` | `null` | no |
-| <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A map of license specifications to associate with | `any` | `{}` | no |
+| <a name="input_license_specifications"></a> [license\_specifications](#input\_license\_specifications) | A list of license specifications to associate with | `map(string)` | `{}` | no |
 | <a name="input_maintenance_options"></a> [maintenance\_options](#input\_maintenance\_options) | The maintenance options for the instance | `any` | `{}` | no |
 | <a name="input_max_instance_lifetime"></a> [max\_instance\_lifetime](#input\_max\_instance\_lifetime) | The maximum amount of time, in seconds, that an instance can be in service, values must be either equal to 0 or between 604800 and 31536000 seconds | `number` | `null` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | The maximum size of the autoscaling group | `number` | `3` | no |

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -282,8 +282,7 @@ resource "aws_launch_template" "this" {
   key_name      = var.key_name
 
   dynamic "license_specification" {
-    for_each = length(var.license_specifications) > 0 ? var.license_specifications : {}
-
+    for_each = length(var.license_specifications) > 0 ? [var.license_specifications] : []
     content {
       license_configuration_arn = license_specification.value.license_configuration_arn
     }

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -193,8 +193,8 @@ variable "maintenance_options" {
 }
 
 variable "license_specifications" {
-  description = "A map of license specifications to associate with"
-  type        = any
+  description = "A list of license specifications to associate with"
+  type        = map(string)
   default     = {}
 }
 


### PR DESCRIPTION
## Description

Following those PRs <https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2798> <https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2796>

## Motivation and Context

In the first PR, #2796, changing the type to `map(string)` of the variable was omitted, causing this issue #2797.

However, defining license_specifications as a type list doesn't seem to be the best approach. That's why, in order to keep it as a map, the dynamic block should be declared as follows:

```tf
  dynamic "license_specification" {
    for_each = length(var.license_specifications) > 0 ? [var.license_specifications] : []
    content {
      license_configuration_arn = license_specification.value.license_configuration_arn
    }
  }
```

Because currently, this error is returned while using 19.17.4 module

```
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/self_managed_node_group/modules/self-managed-node-group/main.tf line 288, in resource "aws_launch_template" "this":
│  288:       license_configuration_arn = license_specification.value.license_configuration_arn
│     ├────────────────
│     │ license_specification.value is "arn:aws:license-manager:us-east-1:XXXXXX:license-configuration:lic-XXXXXXXXXX"
│ 
│ Can't access attributes on a primitive-typed value (string).
```

## Breaking Changes

I do not see any potential breaking changes.

## How Has This Been Tested?

* [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
* [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
* [x] I have executed `pre-commit run -a` on my pull request

This modification solves the issue of using `license_specifications` **while maintaining the map type into a list from dynamic block.** I have tested by declaring a module from scratch with and without a `license_specifications`, and this time I don't have any issues in the case where license_specifications is used.

**I didn't reinvent anything. I based the changes on the <https://github.com/terraform-aws-modules/terraform-aws-autoscaling/blob/master/main.tf> module, which doesn't have any issues with the `license_specifications`.**