### PR TITLE
feat: Add prometheus-service port 9090 to recommended sec groups

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -152,6 +152,15 @@ locals {
       type                          = "ingress"
       source_cluster_security_group = true
     }
+    # prometheus-service
+    ingress_cluster_9090_webhook = {
+      description                   = "Cluster API to node 9090/tcp webhook"
+      protocol                      = "tcp"
+      from_port                     = 9090
+      to_port                       = 9090
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
     # Karpenter
     ingress_cluster_8443_webhook = {
       description                   = "Cluster API to node 8443/tcp webhook"


### PR DESCRIPTION
## Description
Adding port 9090, typically used by Prometheus service in Kubernetes clusters to the default recommend security groups.

When Prometheus is deployed with e.g. Lens Metrics provider this port is used.

## Motivation and Context
This will make Prometheus metrics work by default for different providers for various applications that display Prometheus metrics.

## Breaking Changes
None

## How Has This Been Tested?
- [X] I tested this rule with `node_security_group_additional_rules`
