### PR TITLE
fix: Remove additional conditional on Karpenter instance profile creation to support upgrading

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -386,7 +386,7 @@ locals {
 }
 
 resource "aws_iam_instance_profile" "this" {
-  count = var.create && var.create_instance_profile && !var.enable_karpenter_instance_profile_creation ? 1 : 0
+  count = var.create && var.create_instance_profile ? 1 : 0
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
   name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null


### PR DESCRIPTION
## Description
- Remove additional conditional on Karpenter instance profile creation to support upgrading

## Motivation and Context
- When upgrading to 0.32, Karpenter will now create the instance profile used by the nodes that it creates. The permissions to support this were added in #2800. However, removing the instance profile too soon can cause disruptions since existing nodes will still be using this profile until Karpenter replaces all of those existing nodes with new nodes that are using an instance profile that *IT has created. Since there is already a conditional on the profile creation (`create_instance_profile`), we are removing the additional conditional added in #2800 to allow users to opt into the new permissions required for 0.32, and then later opt out of the module created instance profile once they feel its safe to do so (i.e. - after all nodes have been replaced with nodes using the Karpenter created instance profile)

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
