### PR TITLE
fix: Optionalize cluster endpoint and cert data in templates

### DIFF
--- a/templates/linux_user_data.tpl
+++ b/templates/linux_user_data.tpl
@@ -7,8 +7,8 @@ ${pre_bootstrap_user_data ~}
 export SERVICE_IPV4_CIDR=${cluster_service_ipv4_cidr}
 %{ endif ~}
 %{ if enable_bootstrap_user_data ~}
-B64_CLUSTER_CA=${cluster_auth_base64}
-API_SERVER_URL=${cluster_endpoint}
-/etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL
+%{ if cluster_auth_base64 != "" }B64_CLUSTER_CA=${cluster_auth_base64}%{ endif }
+%{ if cluster_endpoint != "" }API_SERVER_URL=${cluster_endpoint}%{ endif }
+/etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} %{ if cluster_auth_base64 != "" }--b64-cluster-ca $B64_CLUSTER_CA%{ endif } %{ if cluster_endpoint != "" }--apiserver-endpoint $API_SERVER_URL%{ endif }
 ${post_bootstrap_user_data ~}
 %{ endif ~}

--- a/templates/windows_user_data.tpl
+++ b/templates/windows_user_data.tpl
@@ -3,7 +3,7 @@ ${pre_bootstrap_user_data ~}
 [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
 [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
 [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
-& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} -APIServerEndpoint ${cluster_endpoint} -Base64ClusterCA ${cluster_auth_base64} ${bootstrap_extra_args} 3>&1 4>&1 5>&1 6>&1
+& $EKSBootstrapScriptFile -EKSClusterName ${cluster_name} %{ if cluster_endpoint != "" }-APIServerEndpoint ${cluster_endpoint}%{ endif } %{ if cluster_auth_base64 != "" }-Base64ClusterCA ${cluster_auth_base64}%{ endif } ${bootstrap_extra_args} 3>&1 4>&1 5>&1 6>&1
 $LastError = if ($?) { 0 } else { $Error[0].Exception.HResult }
 ${post_bootstrap_user_data ~}
 </powershell>


### PR DESCRIPTION




## Description
The cluster endpoint and certificate data should not be rendered in the userdata template if they are not passed to the module.

## Motivation and Context
This is the case, when the cluster is configured for calico or another CNI plugin. The values are optional in terraform and should only be rendered when passed, else it creates an invalid bash command with possible unintended side effects.

The bootstrap script still works without the values due to an internal fallback to a describe cluster call.

fixes #2787

## Breaking Changes
no

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
