### PR TITLE
chore: Deprecation warning for resolve_conflicts

### DIFF
--- a/docs/irsa_integration.md
+++ b/docs/irsa_integration.md
@@ -12,8 +12,9 @@ module "eks" {
 
   cluster_addons = {
     vpc-cni = {
-      resolve_conflicts        = "OVERWRITE"
-      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts_on_update = "OVERWRITE"
+      service_account_role_arn    = module.vpc_cni_irsa.iam_role_arn
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -393,11 +393,12 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
-  configuration_values     = try(each.value.configuration_values, null)
-  preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
-  service_account_role_arn = try(each.value.service_account_role_arn, null)
+  addon_version               = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
+  configuration_values        = try(each.value.configuration_values, null)
+  preserve                    = try(each.value.preserve, null)
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts, "OVERWRITE")
+  service_account_role_arn    = try(each.value.service_account_role_arn, null)
 
   timeouts {
     create = try(each.value.timeouts.create, var.cluster_addons_timeouts.create, null)
@@ -421,11 +422,12 @@ resource "aws_eks_addon" "before_compute" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
-  configuration_values     = try(each.value.configuration_values, null)
-  preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
-  service_account_role_arn = try(each.value.service_account_role_arn, null)
+  addon_version               = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
+  configuration_values        = try(each.value.configuration_values, null)
+  preserve                    = try(each.value.preserve, null)
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts, "OVERWRITE")
+  service_account_role_arn    = try(each.value.service_account_role_arn, null)
 
   timeouts {
     create = try(each.value.timeouts.create, var.cluster_addons_timeouts.create, null)


### PR DESCRIPTION
## Description
Fix for the following deprecation warning

```
Warning: Argument is deprecated
│ 
│   with module.staging_eks1.aws_eks_addon.this["kube-proxy"],
│   on .terraform/modules/staging_eks1/main.tf line 399, in resource "aws_eks_addon" "this":
│  399:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│ 
│ The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial resource creation. Use "resolve_conflicts_on_create" and/or "resolve_conflicts_on_update" instead
│ 
│ (and 2 more similar warnings elsewhere)
```

## Motivation and Context
Fixing deprecation before the attribute is removed from newer versions of terraform.


## Breaking Changes
Unsure, but testing shows that it does not break anything

## How Has This Been Tested?
- I have tested the changes using it to create my own EKS cluster with `cluster_addons` attribute enabled. This has gotten rid of the above stated deprecation warning.
