### PR TITLE
feat: Removes deprecated `resolve_conflicts` attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -396,7 +396,8 @@ resource "aws_eks_addon" "this" {
   addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
-  resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
+  resolve_conflicts_on_create = try(each.value.resolve_conflicts_on_create, "OVERWRITE")
+  resolve_conflicts_on_update = try(each.value.resolve_conflicts_on_update, "OVERWRITE")
   service_account_role_arn = try(each.value.service_account_role_arn, null)
 
   timeouts {


### PR DESCRIPTION
## Description
The resolve_conflicts attribute in the `aws_eks_addon` resource is deprecated and cannot be set to `PRESERVE` on initial resource creation. 

## Motivation and Context
Terraform's new version uses resolve_conflicts_on_create and/or resolve_conflicts_on_update attributes.
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2635
```
|
│ Warning: Argument is deprecated
│ 
│   with module.eks.aws_eks_addon.this["aws-ebs-csi-driver"],
│   on .terraform/modules/eks/main.tf line 399, in resource "aws_eks_addon" "this":
│  399:   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
│ 
│ The "resolve_conflicts" attribute can't be set to "PRESERVE" on initial resource creation. Use "resolve_conflicts_on_create" and/or
│ "resolve_conflicts_on_update" instead
│ 
│ (and 3 more similar warnings elsewhere)
```


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
