### PR TITLE
feat: Resolves #2850; Add support for EKS Pod Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,12 +256,15 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_eks_addon.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster) | resource |
 | [aws_eks_identity_provider_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_identity_provider_config) | resource |
+| [aws_eks_pod_identity_association.pod_identity_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_iam_openid_connect_provider.oidc_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.eks_pod_identity_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.eks_pod_identity_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -272,6 +275,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_addon_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
@@ -335,6 +339,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | Map of EKS managed node group definitions to create | `any` | `{}` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Determines whether to create an OpenID Connect Provider for EKS to enable IRSA | `bool` | `true` | no |
 | <a name="input_enable_kms_key_rotation"></a> [enable\_kms\_key\_rotation](#input\_enable\_kms\_key\_rotation) | Specifies whether key rotation is enabled. Defaults to `true` | `bool` | `true` | no |
+| <a name="input_enable_pod_identity"></a> [enable\_pod\_identity](#input\_enable\_pod\_identity) | Determines whether to create a Pod Identit for EKS | `bool` | `false` | no |
 | <a name="input_fargate_profile_defaults"></a> [fargate\_profile\_defaults](#input\_fargate\_profile\_defaults) | Map of Fargate Profile default configurations | `any` | `{}` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Map of Fargate Profile definitions to create | `any` | `{}` | no |
 | <a name="input_iam_role_additional_policies"></a> [iam\_role\_additional\_policies](#input\_iam\_role\_additional\_policies) | Additional policies to be added to the IAM role | `map(string)` | `{}` | no |
@@ -368,6 +373,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_outpost_config"></a> [outpost\_config](#input\_outpost\_config) | Configuration for the AWS Outpost to provision the cluster on | `any` | `{}` | no |
 | <a name="input_prefix_separator"></a> [prefix\_separator](#input\_prefix\_separator) | The separator to use between the prefix and the generated timestamp for resource names | `string` | `"-"` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
+| <a name="input_sa_namespace_policies_mapping"></a> [sa\_namespace\_policies\_mapping](#input\_sa\_namespace\_policies\_mapping) | A mapping between service accounts and their associated namespace and IAM policy ARN. | `map(map(string))` | `{}` | no |
 | <a name="input_self_managed_node_group_defaults"></a> [self\_managed\_node\_group\_defaults](#input\_self\_managed\_node\_group\_defaults) | Map of self-managed node group default configurations | `any` | `{}` | no |
 | <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Map of self-managed node group definitions to create | `any` | `{}` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs where the nodes/node groups will be provisioned. If `control_plane_subnet_ids` is not provided, the EKS cluster control plane (ENIs) will be provisioned in these subnets | `list(string)` | `[]` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -305,6 +305,18 @@ module "eks" {
     "888888888888",
   ]
 
+
+  enable_pod_identity = true
+  sa_namespace_policies_mapping = {
+    "namespace-1" = {
+      "service-account-1" = "arn:aws:iam::66666666666:policy/AmazonEC2ReadOnlyAccess",
+      "service-account-2" = "arn:aws:iam::66666666666:policy/AmazonS3ReadOnlyAccess"
+    }
+    "namespace-2" = {
+      "service-account-3" = "arn:aws:iam::66666666666:policy/AmazonDynamoDBReadOnlyAccess"
+    }
+  }
+
   tags = local.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -603,3 +603,15 @@ variable "aws_auth_accounts" {
   type        = list(any)
   default     = []
 }
+
+variable "sa_namespace_policies_mapping" {
+  description = "A mapping between service accounts and their associated namespace and IAM policy ARN."
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "enable_pod_identity" {
+  description = "Determines whether to create a Pod Identit for EKS"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Description
Added EKS Pod Identity support to the EKS Terraform module. The changes have been tested inside the `examples/complete/main.tf` file.

### Motivation and Context
The change is required to enhance the EKS Terraform module by adding support for EKS Pod Identity. This addition allows  integration with the new  identity management within Kubernetes pods running on the EKS cluster.

### Breaking Changes
- [x] This change does not introduce any breaking changes.

### How Has This Been Tested?
- [x] I have updated the `examples/complete` directory to demonstrate and validate my changes.
- [x] I have tested and validated these changes using the provided `examples/complete` project.
- [x] I have executed `pre-commit run -a` on my pull request to ensure code style and formatting compliance.


