### PR TITLE
fix: Do not fetch versions of the add-on if an explicit version is specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -394,7 +394,7 @@ resource "aws_eks_addon" "this" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
+  addon_version            = coalesce(try(each.value.addon_version, null), try(data.aws_eks_addon_version.this[each.key].version, null))
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
@@ -422,7 +422,7 @@ resource "aws_eks_addon" "before_compute" {
   cluster_name = aws_eks_cluster.this[0].name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = coalesce(try(each.value.addon_version, null), data.aws_eks_addon_version.this[each.key].version)
+  addon_version            = coalesce(try(each.value.addon_version, null), try(data.aws_eks_addon_version.this[each.key].version, null))
   configuration_values     = try(each.value.configuration_values, null)
   preserve                 = try(each.value.preserve, null)
   resolve_conflicts        = try(each.value.resolve_conflicts, "OVERWRITE")
@@ -438,7 +438,7 @@ resource "aws_eks_addon" "before_compute" {
 }
 
 data "aws_eks_addon_version" "this" {
-  for_each = { for k, v in var.cluster_addons : k => v if local.create && !local.create_outposts_local_cluster }
+  for_each = { for k, v in var.cluster_addons : k => v if try(v.addon_version == null, true) && local.create && !local.create_outposts_local_cluster }
 
   addon_name         = try(each.value.name, each.key)
   kubernetes_version = coalesce(var.cluster_version, aws_eks_cluster.this[0].version)


### PR DESCRIPTION
## Description

Fixes #2855

## Motivation and Context

Currently the usage of the module is broken because of the broken add-on metadata on the AWS side.
The fix allows circumventing the metadata issue by using explicit add-on version.

## Breaking Changes

No

## How Has This Been Tested?

The change has been tested extensively in our own environment.
All combinations of explicit, latest, default versions of the add-ons were tested.
I haven't updated the examples because they all rely on the latest versions of the add-ons. Having specific add-on versions in the code risks creating a maintenance burden.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
