### PR TITLE
feat: Allow apiserver to access Vertical Pod Autoscaler Webhook on port 8000

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -170,6 +170,15 @@ locals {
       type                          = "ingress"
       source_cluster_security_group = true
     }
+    # vertical pod autoscaler, vpa-admission-controller webhook
+    vertical_pod_autoscaler_8000_webhook = {
+      description                   = "Cluster API to node 8000/tcp webhook"
+      protocol                      = "tcp"
+      from_port                     = 8000
+      to_port                       = 8000
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
     egress_all = {
       description      = "Allow all egress"
       protocol         = "-1"


### PR DESCRIPTION
## Description
This PR is to allow requests from the kube-apiserver to the MutatingWebHook of the Virtual Pod Autoscaler

## Motivation and Context
Since the VirtualPodAutoscaler is a standard and common K8s component, access to the webhook should be allowed by default. Otherwise one might get into the situation that the whole EKS cluster gets unusable, because the VPA webhook is called on every Pod creation, leading to a 30 seconds timeout.
The webhook has been enabled by default in the new release of the Fairwinds VPA Chart (https://github.com/FairwindsOps/charts/tree/master/stable/vpa)

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
The error messages in the EKS ApiServer logs disappeared after applying these changes.
```
Failed calling webhook, failing open vpa.k8s.io: failed calling webhook "vpa.k8s.io": failed to call webhook: Post "[https://vpa-webhook.vpa.svc:443/?timeout=30s](https://vpa-webhook.vpa.svc/?timeout=30s)": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```