### PR TITLE
fix: Don't create a launch template if a custom one is used

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -34,7 +34,7 @@ locals {
 }
 
 resource "aws_launch_template" "this" {
-  count = var.create && var.create_launch_template && var.use_custom_launch_template ? 1 : 0
+  count = var.create && var.create_launch_template && !var.use_custom_launch_template ? 1 : 0
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings


### PR DESCRIPTION
## Description

## Motivation and Context

If `use_custom_launch_template` is set to `true`, then the module should not attempt to create a launch template regardless if the `create_launch_template` is also `true`.

## Breaking Changes

N/A

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

I am note sure if I need to update one of the examples but I did test locally and we can see that the plan is going from 83 resources to add to 82:
<p align="center"><img src="https://github.com/terraform-aws-modules/terraform-aws-eks/assets/87599075/dfc558e0-e587-405f-b3b5-dccacb2d9818"></p>
<p align="center">Before</p>

<p align="center"><img src="https://github.com/terraform-aws-modules/terraform-aws-eks/assets/87599075/f234ab28-8017-4bc9-bafe-18af6341a45b"></p>
<p align="center">After</p>

Another way to see the result is in the outputs: The `launch_template_id` and other properties are `null` because the module is not creating the resource anymore.

<p align="center"><img src="https://github.com/terraform-aws-modules/terraform-aws-eks/assets/87599075/eeed21ce-c676-4e31-b524-c11acebbabd6"></p>
<p align="center">Before</p>

<p align="center"><img src="https://github.com/terraform-aws-modules/terraform-aws-eks/assets/87599075/04566d07-df78-4c88-8600-8f164f6e114b"></p>
<p align="center">After</p>