### PR TITLE
fix: Remove gavinbunney/kubectl provider from Karpenter example

### DIFF
--- a/examples/karpenter/versions.tf
+++ b/examples/karpenter/versions.tf
@@ -14,10 +14,6 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.7"
     }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 3.0"


### PR DESCRIPTION
## Description

Refactor the Karpenter example, removing the gavinbunney/kubectl kubectl provider as it is abandoned and contains references to deprecated resources. References to `resource "kubectl_manifest"` are replaced with `resource "kubernetes_manifest"`. 

 
## Motivation and Context
The gavinbunney/kubectl provider is abandoned and contains references to `template` resource, which is deprecated.
This PR replaces these references with the equivalent resource from the kubernetes provider.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
No, this has not been tested.
