### PR TITLE
fix: Correct cluster access entry to create multiple policy associations per access entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Terraform module which creates AWS EKS (Kubernetes) resources
   - [Upgrade to v17.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-17.0.md)
   - [Upgrade to v18.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-18.0.md)
   - [Upgrade to v19.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md)
+  - [Upgrade to v20.x](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md)
 
 ### External Documentation
 
 Please note that we strive to provide a comprehensive suite of documentation for __*configuring and utilizing the module(s)*__ defined here, and that documentation regarding EKS (including EKS managed node group, self managed node group, and Fargate profile) and/or Kubernetes features, usage, etc. are better left up to their respective sources:
+
 - [AWS EKS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
 - [Kubernetes Documentation](https://kubernetes.io/docs/home/)
 
@@ -78,38 +80,16 @@ module "eks" {
 
   access_entries = {
     # One access entry with a policy associated
-    ex-single = {
+    example = {
       kubernetes_groups = []
       principal_arn     = "arn:aws:iam::123456789012:role/something"
 
       policy_associations = {
-        single = {
+        example = {
           policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
           access_scope = {
             namespaces = ["default"]
             type       = "namespace"
-          }
-        }
-      }
-    }
-
-    # Example of adding multiple policies to a single access entry
-    ex-multiple = {
-      kubernetes_groups = []
-      principal_arn     = "arn:aws:iam::123456789012:role/something-else"
-
-      policy_associations = {
-        ex-one = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSEditPolicy"
-          access_scope = {
-            namespaces = ["default"]
-            type       = "namespace"
-          }
-        }
-        ex-two = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
-          access_scope = {
-            type = "cluster"
           }
         }
       }

--- a/examples/eks_managed_node_group/README.md
+++ b/examples/eks_managed_node_group/README.md
@@ -55,6 +55,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Type |
 |------|------|
 | [aws_iam_policy.node_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_security_group.remote_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ami.eks_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ami.eks_default_arm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |


### PR DESCRIPTION
## Description
- Correct cluster access entry to create one entry and multiple policy associations. Currently, it is trying to use the flattened logic that was intended for supporting multiple policy associations
	- Want: Per access entry, support multiple policy associations
	- Current: One access entry per policy association, and if multiple policies are provided, it will fail since entry already exists

## Motivation and Context
- Provide code to validate the functionality as well as document the schema for users
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2881#issuecomment-1924502935

## Breaking Changes
- Technically, yes - the looping logic of the access entry has changed. However, this is not working as it was intended and we are coming off a breaking change so I am inclined to add this as a bugfix since it was never working as intended from the last major release

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
