### PR TITLE
fix: Update access entries `kubernetes_groups` default value to `null`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ resource "aws_eks_access_entry" "this" {
   for_each = { for k, v in local.merged_access_entries : k => v if local.create }
 
   cluster_name      = aws_eks_cluster.this[0].name
-  kubernetes_groups = try(each.value.kubernetes_groups, [])
+  kubernetes_groups = try(each.value.kubernetes_groups, null)
   principal_arn     = each.value.principal_arn
   type              = try(each.value.type, "STANDARD")
   user_name         = try(each.value.user_name, null)


### PR DESCRIPTION
## Description
Change the default kubernetes group from [] to null - it's possible that EKS will manage this attribute by adding in groups like system:nodes when specifying a type of EC2_LINUX or similar. This attribute should be unspecified if STANDARD is not defined. 

## Motivation and Context
Resolves the module attempting to change EC2_LINUX from removing the kubernetes groups set by EKS and EC2_LINUX types. 

- Resolves #2896

## Breaking Changes
No

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
Tested on eks_managed_node_group by modifying the access_entities to use a EC2_LINUX type. 
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
