### PR TITLE
feat: Allow enable/disable of EKS pod identity for the Karpenter controller

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -135,7 +135,8 @@ No modules.
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether an IAM role is created | `bool` | `true` | no |
 | <a name="input_create_instance_profile"></a> [create\_instance\_profile](#input\_create\_instance\_profile) | Whether to create an IAM instance profile | `bool` | `false` | no |
 | <a name="input_create_node_iam_role"></a> [create\_node\_iam\_role](#input\_create\_node\_iam\_role) | Determines whether an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
-| <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Determines whether to enable support IAM role for service account | `bool` | `false` | no |
+| <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Determines whether to enable support for IAM role for service accounts | `bool` | `false` | no |
+| <a name="input_enable_pod_identities"></a> [enable\_pod\_identities](#input\_enable\_pod\_identities) | Determines whether to enable support for EKS pod identities | `bool` | `true` | no |
 | <a name="input_enable_spot_termination"></a> [enable\_spot\_termination](#input\_enable\_spot\_termination) | Determines whether to enable native spot termination handling | `bool` | `true` | no |
 | <a name="input_iam_policy_description"></a> [iam\_policy\_description](#input\_iam\_policy\_description) | IAM policy description | `string` | `"Karpenter controller IAM policy"` | no |
 | <a name="input_iam_policy_name"></a> [iam\_policy\_name](#input\_iam\_policy\_name) | Name of the IAM policy | `string` | `"KarpenterController"` | no |

--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -136,7 +136,7 @@ No modules.
 | <a name="input_create_instance_profile"></a> [create\_instance\_profile](#input\_create\_instance\_profile) | Whether to create an IAM instance profile | `bool` | `false` | no |
 | <a name="input_create_node_iam_role"></a> [create\_node\_iam\_role](#input\_create\_node\_iam\_role) | Determines whether an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Determines whether to enable support for IAM role for service accounts | `bool` | `false` | no |
-| <a name="input_enable_pod_identities"></a> [enable\_pod\_identities](#input\_enable\_pod\_identities) | Determines whether to enable support for EKS pod identities | `bool` | `true` | no |
+| <a name="input_enable_pod_identity"></a> [enable\_pod\_identity](#input\_enable\_pod\_identity) | Determines whether to enable support for EKS pod identity | `bool` | `true` | no |
 | <a name="input_enable_spot_termination"></a> [enable\_spot\_termination](#input\_enable\_spot\_termination) | Determines whether to enable native spot termination handling | `bool` | `true` | no |
 | <a name="input_iam_policy_description"></a> [iam\_policy\_description](#input\_iam\_policy\_description) | IAM policy description | `string` | `"Karpenter controller IAM policy"` | no |
 | <a name="input_iam_policy_name"></a> [iam\_policy\_name](#input\_iam\_policy\_name) | Name of the IAM policy | `string` | `"KarpenterController"` | no |

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -22,15 +22,19 @@ data "aws_iam_policy_document" "controller_assume_role" {
   count = local.create_iam_role ? 1 : 0
 
   # Pod Identity
-  statement {
-    actions = [
-      "sts:AssumeRole",
-      "sts:TagSession",
-    ]
+  dynamic "statement" {
+    for_each = var.enable_pod_identities ? [1] : []
 
-    principals {
-      type        = "Service"
-      identifiers = ["pods.eks.amazonaws.com"]
+    content {
+      actions = [
+        "sts:AssumeRole",
+        "sts:TagSession",
+      ]
+
+      principals {
+        type        = "Service"
+        identifiers = ["pods.eks.amazonaws.com"]
+      }
     }
   }
 

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "controller_assume_role" {
 
   # Pod Identity
   dynamic "statement" {
-    for_each = var.enable_pod_identities ? [1] : []
+    for_each = var.enable_pod_identity ? [1] : []
 
     content {
       actions = [

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -104,8 +104,8 @@ variable "ami_id_ssm_parameter_arns" {
   default     = []
 }
 
-variable "enable_pod_identities" {
-  description = "Determines whether to enable support for EKS pod identities"
+variable "enable_pod_identity" {
+  description = "Determines whether to enable support for EKS pod identity"
   type        = bool
   default     = true
 }

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -104,12 +104,18 @@ variable "ami_id_ssm_parameter_arns" {
   default     = []
 }
 
+variable "enable_pod_identities" {
+  description = "Determines whether to enable support for EKS pod identities"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # IAM Role for Service Account (IRSA)
 ################################################################################
 
 variable "enable_irsa" {
-  description = "Determines whether to enable support IAM role for service account"
+  description = "Determines whether to enable support for IAM role for service accounts"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Description
Made a new variable in the karpenter submodule "enable_pod_identity" which allows pod identities to be disabled.

## Motivation and Context

Pod identities are not currently available in all partitions, and this principal being present in these locations causes the module to fail.
- Resolves #2901 

## Breaking Changes
No, the default is set to true which has the same behavior as before

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
