### PR TITLE
feat: Add output for `access_policy_associations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | Name | Description |
 |------|-------------|
 | <a name="output_access_entries"></a> [access\_entries](#output\_access\_entries) | Map of access entries created and their attributes |
-| <a name="output_access_policy_associations"></a> [access\_policy\_associations](#output\_access\_policy\_associations) | Map of eks cluster policy associations created and their attributes |
+| <a name="output_access_policy_associations"></a> [access\_policy\_associations](#output\_access\_policy\_associations) | Map of eks cluster access policy associations created and their attributes |
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
 | <a name="output_cluster_addons"></a> [cluster\_addons](#output\_cluster\_addons) | Map of attribute maps for all EKS cluster addons enabled |

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | Name | Description |
 |------|-------------|
 | <a name="output_access_entries"></a> [access\_entries](#output\_access\_entries) | Map of access entries created and their attributes |
+| <a name="output_access_policy_associations"></a> [access\_policy\_associations](#output\_access\_policy\_associations) | Map of eks cluster policy associations created and their attributes |
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
 | <a name="output_cluster_addons"></a> [cluster\_addons](#output\_cluster\_addons) | Map of attribute maps for all EKS cluster addons enabled |

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,6 +61,11 @@ output "access_entries" {
   value       = aws_eks_access_entry.this
 }
 
+output "access_policy_associations" {
+  description = "Map of eks cluster policy associations created and their attributes"
+  value       = aws_eks_access_policy_association.this
+}
+
 ################################################################################
 # KMS Key
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,7 +62,7 @@ output "access_entries" {
 }
 
 output "access_policy_associations" {
-  description = "Map of eks cluster policy associations created and their attributes"
+  description = "Map of eks cluster access policy associations created and their attributes"
   value       = aws_eks_access_policy_association.this
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds to `outputs.tf`
```hcl
output "access_policy_associations" {
  description = "Map of eks cluster access policy associations created and their attributes"
  value       = aws_eks_access_policy_association.this
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #2903 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
n/a

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Ran this locally for the issue I mentioned in #2903 and was able to fix my dependency issue with explicit `depends_on` referencing `module.aws_eks.access_entries` and `module.aws_eks.access_policy_associations`.
