### PR TITLE
fix: Karpenter `enable_spot_termination = false` should not result in an error

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -252,15 +252,19 @@ data "aws_iam_policy_document" "controller" {
     actions   = ["pricing:GetProducts"]
   }
 
-  statement {
-    sid       = "AllowInterruptionQueueActions"
-    resources = [aws_sqs_queue.this[0].arn]
-    actions = [
-      "sqs:DeleteMessage",
-      "sqs:GetQueueAttributes",
-      "sqs:GetQueueUrl",
-      "sqs:ReceiveMessage"
-    ]
+  dynamic "statement" {
+    for_each = local.enable_spot_termination ? [1] : []
+
+    content {
+      sid       = "AllowInterruptionQueueActions"
+      resources = [aws_sqs_queue.this[0].arn]
+      actions = [
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:ReceiveMessage"
+      ]
+    }
   }
 
   statement {

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "controller" {
 
     content {
       sid       = "AllowInterruptionQueueActions"
-      resources = [aws_sqs_queue.this[0].arn]
+      resources = [try(aws_sqs_queue.this[0].arn, null)]
       actions = [
         "sqs:DeleteMessage",
         "sqs:GetQueueAttributes",


### PR DESCRIPTION
## Description
This change adds a condition on the statement with id `AllowInterruptionQueueActions` that checks `enable_spot_termination` value, since, if the variable is false, the `aws_sqs_queue` resource will not be created.

## Motivation and Context
Resolves: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2906

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
