### PR TITLE
docs: Lowercase Fargate compute type annotation value

### DIFF
--- a/examples/fargate_profile/main.tf
+++ b/examples/fargate_profile/main.tf
@@ -35,7 +35,7 @@ module "eks" {
     vpc-cni    = {}
     coredns = {
       configuration_values = jsonencode({
-        computeType = "Fargate"
+        computeType = "fargate"
       })
     }
   }


### PR DESCRIPTION
## Description
Change the custom annotation on coredns pods to `fargate` instead of `Fargate`.

## Motivation and Context
I just set up a cluster using Fargate for the `kube-system` namespace, and the additional configuration for coredns as expressed by the example subject of this PR failed, because the node taint is against an annotation with value `fargate`.
