### PR TITLE
feat: Resolve name_prefix error in main.tf

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -35,6 +35,9 @@ locals {
 
 resource "aws_launch_template" "this" {
   count = var.create && var.create_launch_template && var.use_custom_launch_template ? 1 : 0
+ 
+  name        = var.launch_template_use_name_prefix ? null : local.launch_template_name
+  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name}-" : null
 
   dynamic "block_device_mappings" {
     for_each = var.block_device_mappings
@@ -211,8 +214,7 @@ resource "aws_launch_template" "this" {
     }
   }
 
-  name        = var.launch_template_use_name_prefix ? null : local.launch_template_name
-  name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name}-" : null
+  
 
   dynamic "network_interfaces" {
     for_each = var.network_interfaces


### PR DESCRIPTION
feat: Resolve name_prefix error in main.tf

## Description
The name_prefix should be defined within the aws_launch_template resource block, not outside it.
name and name_prefix are set based on the condition in the aws_launch_template resource block.
this change ensures that name and name_prefix are conditionally set based on the value of var.launch_template_use_name_prefix.

## Motivation and Context
i encountered ""name_prefix" cannot be less than 3 characters" error on 215:   name_prefix = var.launch_template_use_name_prefix ? "${local.launch_template_name}-" : null
so i did my research and found this error in the code hope these changes would fix and help other with the same error.

## Breaking Changes
this does make this module compatible with the newer versions as this module has been quite old now so this might the compatibility issues too
## How Has This Been Tested?
i've tested it during my deployment with terraform on aws and this worked just fine and solved my errors which occurred before the changes