### PR TITLE
fix: Replace Karpenter SQS policy dynamic service princpal DNS suffixes with static `amazonaws.com`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
+    rev: v1.87.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -4,7 +4,6 @@ data "aws_caller_identity" "current" {}
 
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  dns_suffix = data.aws_partition.current.dns_suffix
   partition  = data.aws_partition.current.partition
   region     = data.aws_region.current.name
 }
@@ -445,8 +444,8 @@ data "aws_iam_policy_document" "queue" {
     principals {
       type = "Service"
       identifiers = [
-        "events.${local.dns_suffix}",
-        "sqs.${local.dns_suffix}",
+        "events.amazonaws.com",
+        "sqs.amazonaws.com",
       ]
     }
   }


### PR DESCRIPTION
## Description
- Replace Karpenter SQS policy dynamic service princpal DNS suffixes with static `amazonaws.com`

## Motivation and Context
- Resolves #2932 

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
