### PR TITLE
fix: Use the `launch_template_tags` on the launch template

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -264,6 +264,12 @@ module "eks" {
         additional                         = aws_iam_policy.node_additional.arn
       }
 
+      launch_template_tags = {
+        # enable discovery of autoscaling groups by cluster-autoscaler
+        "k8s.io/cluster-autoscaler/enabled" : true,
+        "k8s.io/cluster-autoscaler/${local.name}" : "owned",
+      }
+
       tags = {
         ExtraTag = "EKS managed node group complete example"
       }

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -312,7 +312,10 @@ resource "aws_launch_template" "this" {
   user_data              = module.user_data.user_data
   vpc_security_group_ids = length(local.network_interfaces) > 0 ? [] : local.security_group_ids
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    var.launch_template_tags,
+  )
 
   # Prevent premature access of policies by pods that
   # require permissions on create/destroy that depend on nodes


### PR DESCRIPTION
## Description
- Use the `launch_template_tags` on the launch template

## Motivation and Context
- Ensure the variable is used as it was intended - on the launch template

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
