### PR TITLE
feat: Replace the use of `toset()` with static keys for node IAM role policy attachment

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -504,11 +504,12 @@ resource "aws_iam_role" "this" {
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_role }
+  for_each = { for k, v in {
+    AmazonEKSWorkerNodePolicy          = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy"
+    AmazonEC2ContainerRegistryReadOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
+    AmazonEKS_CNI_IPv6_Policy          = var.iam_role_attach_cni_policy && var.cluster_ip_family == "ipv6" ? local.cni_policy : ""
+    AmazonEKS_CNI_Policy               = var.iam_role_attach_cni_policy && var.cluster_ip_family == "ipv4" ? local.cni_policy : ""
+  } : k => v if var.create && var.create_iam_role && v != "" }
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name

--- a/modules/eks-managed-node-group/migrations.tf
+++ b/modules/eks-managed-node-group/migrations.tf
@@ -16,5 +16,5 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
-  to   = aws_iam_role_policy_attachment.this["AmazonEC2ContainerRegistryReadOnly"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEKS_CNI_Policy"]
 }

--- a/modules/eks-managed-node-group/migrations.tf
+++ b/modules/eks-managed-node-group/migrations.tf
@@ -1,0 +1,20 @@
+################################################################################
+# Migrations: v20.7 -> v20.8
+################################################################################
+
+# Node IAM role policy attachment
+# Commercial partition only - `moved` does now allow multiple moves to same target
+moved {
+  from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEKSWorkerNodePolicy"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEC2ContainerRegistryReadOnly"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEC2ContainerRegistryReadOnly"]
+}

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -565,11 +565,12 @@ resource "aws_iam_role" "node" {
 
 # Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
 resource "aws_iam_role_policy_attachment" "node" {
-  for_each = { for k, v in toset(compact([
-    "${local.node_iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.node_iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.node_iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if local.create_node_iam_role }
+  for_each = { for k, v in {
+    AmazonEKSWorkerNodePolicy          = "${local.node_iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy"
+    AmazonEC2ContainerRegistryReadOnly = "${local.node_iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
+    AmazonEKS_CNI_IPv6_Policy          = var.node_iam_role_attach_cni_policy && var.cluster_ip_family == "ipv6" ? local.cni_policy : ""
+    AmazonEKS_CNI_Policy               = var.node_iam_role_attach_cni_policy && var.cluster_ip_family == "ipv4" ? local.cni_policy : ""
+  } : k => v if var.create && var.create_iam_role && v != "" }
 
   policy_arn = each.value
   role       = aws_iam_role.node[0].name

--- a/modules/karpenter/migrations.tf
+++ b/modules/karpenter/migrations.tf
@@ -73,5 +73,5 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
-  to   = aws_iam_role_policy_attachment.node["AmazonEC2ContainerRegistryReadOnly"]
+  to   = aws_iam_role_policy_attachment.node["AmazonEKS_CNI_Policy"]
 }

--- a/modules/karpenter/migrations.tf
+++ b/modules/karpenter/migrations.tf
@@ -54,3 +54,24 @@ moved {
   from = aws_cloudwatch_event_rule.this["spot_interupt"]
   to   = aws_cloudwatch_event_rule.this["spot_interrupt"]
 }
+
+################################################################################
+# Migrations: v20.7 -> v20.8
+################################################################################
+
+# Node IAM role policy attachment
+# Commercial partition only - `moved` does now allow multiple moves to same target
+moved {
+  from = aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"]
+  to   = aws_iam_role_policy_attachment.node["AmazonEKSWorkerNodePolicy"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]
+  to   = aws_iam_role_policy_attachment.node["AmazonEC2ContainerRegistryReadOnly"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.node["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
+  to   = aws_iam_role_policy_attachment.node["AmazonEC2ContainerRegistryReadOnly"]
+}

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -768,12 +768,14 @@ resource "aws_iam_role" "this" {
   tags = merge(var.tags, var.iam_role_tags)
 }
 
+# Policies attached ref https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
 resource "aws_iam_role_policy_attachment" "this" {
-  for_each = { for k, v in toset(compact([
-    "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
-    "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
-    var.iam_role_attach_cni_policy ? local.cni_policy : "",
-  ])) : k => v if var.create && var.create_iam_instance_profile }
+  for_each = { for k, v in {
+    AmazonEKSWorkerNodePolicy          = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy"
+    AmazonEC2ContainerRegistryReadOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
+    AmazonEKS_CNI_IPv6_Policy          = var.iam_role_attach_cni_policy && var.cluster_ip_family == "ipv6" ? local.cni_policy : ""
+    AmazonEKS_CNI_Policy               = var.iam_role_attach_cni_policy && var.cluster_ip_family == "ipv4" ? local.cni_policy : ""
+  } : k => v if var.create && var.create_iam_instance_profile && v != "" }
 
   policy_arn = each.value
   role       = aws_iam_role.this[0].name

--- a/modules/self-managed-node-group/migrations.tf
+++ b/modules/self-managed-node-group/migrations.tf
@@ -16,5 +16,5 @@ moved {
 
 moved {
   from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
-  to   = aws_iam_role_policy_attachment.this["AmazonEC2ContainerRegistryReadOnly"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEKS_CNI_Policy"]
 }

--- a/modules/self-managed-node-group/migrations.tf
+++ b/modules/self-managed-node-group/migrations.tf
@@ -1,0 +1,20 @@
+################################################################################
+# Migrations: v20.7 -> v20.8
+################################################################################
+
+# Node IAM role policy attachment
+# Commercial partition only - `moved` does now allow multiple moves to same target
+moved {
+  from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEKSWorkerNodePolicy"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEC2ContainerRegistryReadOnly"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.this["arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"]
+  to   = aws_iam_role_policy_attachment.this["AmazonEC2ContainerRegistryReadOnly"]
+}


### PR DESCRIPTION
## Description
- Use static keys for IAM role policy attachment

## Motivation and Context
The use of `toset()` in `for_each` loops is known to be problematic. In hindsight, this should have been corrected during v20.0 but it must have been an oversight on my part. The use of `toset()` on the static policy attachment (custom/additional policy attachment was added awhile back with static keys) has worked without issue except for scenarios where users try to use an explicit `depends_on` (which is [not recommended](https://github.com/hashicorp/terraform/issues/30340#issuecomment-1010202582) across modules for a number of reasons). 

Why is this an issue now? We have an issue with our user data where the cluster service CIDR is not being passed properly, causing nodes to have the wrong internal IP. Oddly enough, we haven't seen user reports for this prior to #2955, and I first noticed it on https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2960#issue-2176398616 (see screen shot - some internal IPs are IPv6, others are IPv4 - they all should be IPv6). While [drafting a PR to resolve the service CIDR issue](https://github.com/terraform-aws-modules/terraform-aws-eks/compare/master...bryantbiggs:fix/service-cidr?expand=1), the dreaded `Error: Invalid for_each argument` appeared for reasons I can't quite understand (yet):

```
Error: Invalid for_each argument
│
│   on ../../modules/eks-managed-node-group/main.tf line 506, in resource "aws_iam_role_policy_attachment" "this":
│  506:   for_each = var.create && var.create_iam_role ? toset(compact([
│  507:     "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy",
│  508:     "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly",
│  509:     var.iam_role_attach_cni_policy ? local.cni_policy : "",
│  510:   ])) : object()
│     ├────────────────
│     │ local.cni_policy is a string, known only after apply
│     │ local.iam_role_policy_prefix is "arn:aws:iam::aws:policy"
│     │ var.create is true
│     │ var.create_iam_role is true
│     │ var.iam_role_attach_cni_policy is true
│
│ The "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances
│ of this resource.
```

## Breaking Changes

From an API perspective, no. However, there will be a very brief (< 1s-2s) period where permission(s) will be removed and re-attached to the IAM role used by nodes. This has been minimized with the use of Terraform state `move` blocks, but due to limitations of the current `move` functionality, they are unable to support moving from multiple sources to a single target (i.e. - the source will vary based on the partition - `aws`, `aws-cn`, `aws-us-gov`) so only the commercial `aws` region (majority) is supported. In addition, `move` blocks do not support variables/dynamic values (which would also resolve the prior issue), which means that the IPv6 CNI policy attachment, which is not a managed policy and therefore user created and its ARN will contain the account ID, cannot be moved either. However, the majority use case for the commercial `aws` partition, using the managed IPv4 CNI policy, is supported without disruption

The potential disruption while unfortunate, is quite minimal and could be equated to a small blip in network connectivity. Therefore, I am proposing this change be made under the current v20 major version so that we can continue on to resolve the service CIDR issue and avoid introducing further, larger disruptions that would be captured under v21 at a later date. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request