### PR TITLE
fix: Do not attach policy if Karpenter node role is not created by module

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -570,7 +570,7 @@ resource "aws_iam_role_policy_attachment" "node" {
     AmazonEC2ContainerRegistryReadOnly = "${local.node_iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
     AmazonEKS_CNI_IPv6_Policy          = var.node_iam_role_attach_cni_policy && var.cluster_ip_family == "ipv6" ? local.cni_policy : ""
     AmazonEKS_CNI_Policy               = var.node_iam_role_attach_cni_policy && var.cluster_ip_family == "ipv4" ? local.cni_policy : ""
-  } : k => v if var.create && var.create_iam_role && v != "" }
+  } : k => v if local.create_node_iam_role && v != "" }
 
   policy_arn = each.value
   role       = aws_iam_role.node[0].name


### PR DESCRIPTION
## Description

Karpenter module fails

```
│ Error: Invalid index
│ 
│   on .terraform/modules/eks.eks_karpenter/modules/karpenter/main.tf line 576, in resource "aws_iam_role_policy_attachment" "node":
│  576:   role       = aws_iam_role.node[0].name
│     ├────────────────
│     │ aws_iam_role.node is empty tuple
│ 
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
╵
```

if node role is not created:

```
module "eks_karpenter" {
  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
  version = "~> 20.0"

  cluster_name = module.eks.cluster_name

  create_iam_role          = true
  create_node_iam_role          = false
}
```

<!--- Describe your changes in detail -->

## Motivation and Context
Bugfix

## Breaking Changes
No, it's a minor fix

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
