### PR TITLE
fix: add example for add eks_managed_node_groups arn to aws-auth

### DIFF
--- a/docs/UPGRADE-20.0.md
+++ b/docs/UPGRADE-20.0.md
@@ -176,13 +176,13 @@ To give users advanced notice and provide some future direction for this module,
 
 +   manage_aws_auth_configmap = true
 
-+   aws_auth_roles = [
++   aws_auth_roles = concat([
 +     {
 +       rolearn  = "arn:aws:iam::66666666666:role/role1"
 +       username = "role1"
 +       groups   = ["custom-role-group"]
 +     },
-+   ]
++   ], local.roles)
 
 +   aws_auth_users = [
 +     {
@@ -192,6 +192,19 @@ To give users advanced notice and provide some future direction for this module,
 +     },
 +   ]
 + }
+
++ locals {
++    roles = [for role_arn in module.eks.eks_managed_node_groups : {
++     rolearn  = role_arn.iam_role_arn
++     username = "system:node:{{EC2PrivateDNSName}}"
++     groups = [
++       "system:bootstrappers",
++       "system:nodes"
++     ]
++     }
++   ]
++ }
+
 ```
 
 ### Karpenter Diff of Before (v19.21) vs After (v20.0)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Broken env with lost access to cluster during update to new version
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
No
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
