### PR TITLE
ci: Add pre-commit mixed-line-ending hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,5 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: mixed-line-ending
+        args: [--fix=lf]


### PR DESCRIPTION
## Description
Add pre-commit [mixed-line-ending](https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#mixed-line-ending) hook with the option to force conversion of line endings to LF (\n)

## Motivation and Context
PR https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2973  introduced 6 files with CRLF (\r\n) line endings.
This ensures contributors commit files with LF (\n) line endings.

## Breaking Changes
N/A

## How Has This Been Tested?
File with CRLF (\r\n) line endings:
```
terraform-aws-eks ci/add-pre-commit-mixed-line-ending-hook*​ 
❯ od -c examples/user_data/rendered/al2/eks-mng-additional.sh
0000000    C   o   n   t   e   n   t   -   T   y   p   e   :       m   u
0000020    l   t   i   p   a   r   t   /   m   i   x   e   d   ;       b
0000040    o   u   n   d   a   r   y   =   "   /   /   "  \n   M   I   M
0000060    E   -   V   e   r   s   i   o   n   :       1   .   0  \r  \n
0000100   \r  \n   -   -   /   /  \r  \n   C   o   n   t   e   n   t   -
0000120    T   r   a   n   s   f   e   r   -   E   n   c   o   d   i   n
0000140    g   :       7   b   i   t  \r  \n   C   o   n   t   e   n   t
0000160    -   T   y   p   e   :       t   e   x   t   /   x   -   s   h
0000200    e   l   l   s   c   r   i   p   t  \r  \n   M   i   m   e   -
0000220    V   e   r   s   i   o   n   :       1   .   0  \r  \n  \r  \n
0000240    e   x   p   o   r   t       U   S   E   _   M   A   X   _   P
0000260    O   D   S   =   f   a   l   s   e  \n  \r  \n   -   -   /   /
0000300    -   -  \r  \n                                                
0000304
```

Hook detects CRLF (\r\n) line endings and fixes them:
```
❯ pre-commit run mixed-line-ending -a
mixed line ending........................................................Failed
- hook id: mixed-line-ending
- exit code: 1
- files were modified by this hook

examples/user_data/rendered/al2023/eks-mng-custom-ami.sh: fixed mixed line endings
examples/user_data/rendered/al2023/self-mng-bootstrap.sh: fixed mixed line endings
examples/user_data/rendered/al2/eks-mng-additional.sh: fixed mixed line endings
examples/user_data/rendered/al2023/eks-mng-additional.sh: fixed mixed line endings
examples/user_data/rendered/al2023/eks-mng-custom-template.sh: fixed mixed line endings
examples/user_data/rendered/al2023/self-mng-custom-template.sh: fixed mixed line endings
```

git diff shows no changes to file content:
```
terraform-aws-eks ci/add-pre-commit-mixed-line-ending-hook*​ 
❯ git diff examples/user_data/rendered/al2/eks-mng-additional.sh
diff --git a/examples/user_data/rendered/al2/eks-mng-additional.sh b/examples/user_data/rendered/al2/eks-mng-additional.sh
index 70b3142..151f0cb 100755
--- a/examples/user_data/rendered/al2/eks-mng-additional.sh
+++ b/examples/user_data/rendered/al2/eks-mng-additional.sh
@@ -1,11 +1,11 @@
 Content-Type: multipart/mixed; boundary="//"
-MIME-Version: 1.0
-
---//
-Content-Transfer-Encoding: 7bit
-Content-Type: text/x-shellscript
-Mime-Version: 1.0
-
+MIME-Version: 1.0
+
+--//
+Content-Transfer-Encoding: 7bit
+Content-Type: text/x-shellscript
+Mime-Version: 1.0
+
 export USE_MAX_PODS=false
-
---//--
+
+--//--
```

File now has LF (\n) line endings:
```
terraform-aws-eks ci/add-pre-commit-mixed-line-ending-hook*​ 9s 
❯ od -c examples/user_data/rendered/al2/eks-mng-additional.sh
0000000    C   o   n   t   e   n   t   -   T   y   p   e   :       m   u
0000020    l   t   i   p   a   r   t   /   m   i   x   e   d   ;       b
0000040    o   u   n   d   a   r   y   =   "   /   /   "  \n   M   I   M
0000060    E   -   V   e   r   s   i   o   n   :       1   .   0  \n  \n
0000100    -   -   /   /  \n   C   o   n   t   e   n   t   -   T   r   a
0000120    n   s   f   e   r   -   E   n   c   o   d   i   n   g   :    
0000140    7   b   i   t  \n   C   o   n   t   e   n   t   -   T   y   p
0000160    e   :       t   e   x   t   /   x   -   s   h   e   l   l   s
0000200    c   r   i   p   t  \n   M   i   m   e   -   V   e   r   s   i
0000220    o   n   :       1   .   0  \n  \n   e   x   p   o   r   t    
0000240    U   S   E   _   M   A   X   _   P   O   D   S   =   f   a   l
0000260    s   e  \n  \n   -   -   /   /   -   -  \n                    
0000273
```