### PR TITLE
fix: Forces cluster outputs to wait until access entries are complete

### DIFF
--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -41,11 +41,6 @@ kubectl delete node -l karpenter.sh/provisioner-name=default
 2. Remove the resources created by Terraform
 
 ```bash
-# Necessary to avoid removing Terraform's permissions too soon before its finished
-# cleaning up the resources it deployed inside the cluster
-terraform state rm 'module.eks.aws_eks_access_entry.this["cluster_creator"]' || true
-terraform state rm 'module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]' || true
-
 terraform destroy
 ```
 

--- a/examples/outposts/README.md
+++ b/examples/outposts/README.md
@@ -37,9 +37,6 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 ```bash
-# Necessary to avoid removing Terraform's permissions too soon before its finished
-# cleaning up the resources it deployed inside the clsuter
-terraform state rm 'module.eks.aws_eks_access_entry.this["cluster_creator_admin"]' || true
 terraform destroy
 ```
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,16 +5,31 @@
 output "cluster_arn" {
   description = "The Amazon Resource Name (ARN) of the cluster"
   value       = try(aws_eks_cluster.this[0].arn, null)
+
+  depends_on = [
+    aws_eks_access_entry.this,
+    aws_eks_access_policy_association.this,
+  ]
 }
 
 output "cluster_certificate_authority_data" {
   description = "Base64 encoded certificate data required to communicate with the cluster"
   value       = try(aws_eks_cluster.this[0].certificate_authority[0].data, null)
+
+  depends_on = [
+    aws_eks_access_entry.this,
+    aws_eks_access_policy_association.this,
+  ]
 }
 
 output "cluster_endpoint" {
   description = "Endpoint for your Kubernetes API server"
   value       = try(aws_eks_cluster.this[0].endpoint, null)
+
+  depends_on = [
+    aws_eks_access_entry.this,
+    aws_eks_access_policy_association.this,
+  ]
 }
 
 output "cluster_id" {
@@ -25,6 +40,11 @@ output "cluster_id" {
 output "cluster_name" {
   description = "The name of the EKS cluster"
   value       = try(aws_eks_cluster.this[0].name, "")
+
+  depends_on = [
+    aws_eks_access_entry.this,
+    aws_eks_access_policy_association.this,
+  ]
 }
 
 output "cluster_oidc_issuer_url" {


### PR DESCRIPTION
## Description
This changeset adds `depends_on` to a few cluster outputs. This will tell terraform that these cluster outputs should not be made "known" and available until all the EKS access entries have completed. The outputs selected in this PR are limited to those used for authenticating to the EKS cluster. If it turns out more are needed, it is easy enough to add them, and I am not aware of any further repercussions to this particular usage of `depends_on`.

## Motivation and Context
- Resolves #2923

Without this change, it can be difficult to order the terraform lifecycle on create and destroy when also using the helm, kubectl, and/or kubernetes providers. It requires using `state rm` and `-target` to get things to complete successfully. With this change, you can just apply and destroy normally. See also the comment and issue thread here:

https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2923#issuecomment-2043123795

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I also ran `terraform apply -auto-approve && terraform destroy -auto-approve` on the ["complete" example in the blueprints-addons project](https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/tree/main/tests/complete), three times successfully, without using any state rm or target steps.
