### PR TITLE
fix(karpenter) include primary_security_group_tags variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_ec2_tag" "cluster_primary_security_group" {
   # This should not affect the name of the cluster primary security group
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2006
   # Ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2008
-  for_each = { for k, v in merge(var.tags, var.cluster_tags) :
+  for_each = { for k, v in merge(var.tags, var.cluster_tags, var.primary_security_group_tags) :
     k => v if local.create && k != "Name" && var.create_cluster_primary_security_group_tags && v != null
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -583,3 +583,9 @@ variable "putin_khuylo" {
   type        = bool
   default     = true
 }
+
+variable "primary_security_group_tags" {
+  description = "Map of tag to be included in the primary security group"
+  type = map(string)
+  default = {}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Following the [karpenter docs](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#5-create-nodepool) the primary security group needs a tag `karpenter.sh/discovery` and with this new `variable` is possible to include only on this security group.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using this module to create eks cluster and karpenter, the nodepool is not finding the security group because it`s not possible to include only on this security group.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
