### PR TITLE
feat: Add `SourceArn` condition to Fargate profile trust policy

### DIFF
--- a/modules/fargate-profile/README.md
+++ b/modules/fargate-profile/README.md
@@ -52,6 +52,7 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -1,5 +1,6 @@
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
 
 locals {
   create_iam_role = var.create && var.create_iam_role
@@ -29,6 +30,15 @@ data "aws_iam_policy_document" "assume_role_policy" {
     principals {
       type        = "Service"
       identifiers = ["eks-fargate-pods.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+
+      values = [
+        "arn:${data.aws_partition.current.partition}:eks:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:fargateprofile/${var.cluster_name}/*",
+      ]
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
[As suggested in AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html#check-pod-execution-role) to prevent the security issue known as the [confused deputy problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html), adds `SourceArn` condition to `fargate-profile` module's `assume_role_policy`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3038.
[Suggested IAM trust policy per AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html#check-pod-execution-role) "to avoid a [confused deputy security problem](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html)."


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Potentially breaks workflows where users may be using/assuming the IAM role generated by `fargate-profile` in an unintended manner, namely from other EKS instances.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
