### PR TITLE
docs: Include ref to addon naming and config documentation 

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,8 +4,8 @@
 - [I received an error: `expect exactly one securityGroup tagged with kubernetes.io/cluster/<NAME> ...`](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#i-received-an-error-expect-exactly-one-securitygroup-tagged-with-kubernetesioclustername-)
 - [Why are nodes not being registered?](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#why-are-nodes-not-being-registered)
 - [Why are there no changes when a node group's `desired_size` is modified?](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#why-are-there-no-changes-when-a-node-groups-desired_size-is-modified)
-- [How can I deploy Windows based nodes?](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#how-can-i-deploy-windows-based-nodes)
 - [How do I access compute resource attributes?](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#how-do-i-access-compute-resource-attributes)
+- [How do I discover and configure cluster addons?](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#how-do-i-discover-and-configure-cluster-addons)
 
 ### Setting `disk_size` or `remote_access` does not make any changes
 
@@ -78,3 +78,31 @@ self_managed_role_arns = [for group in module.self_managed_node_group : group.ia
 ```hcl
 fargate_profile_pod_execution_role_arns = [for group in module.fargate_profile : group.fargate_profile_pod_execution_role_arn]
 ```
+
+### How do I discover and configure cluster addons?
+
+A top level description of all available cluster addons can be [found here](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html). To simply retrieve a list of all available addons from the API, you can use the following command:
+
+`aws eks describe-addon-versions --query 'addons[*].addonName'`
+
+If you would like to adjust specific configuration values within the body of an addon, you can obtain the schema with this command: 
+
+`aws eks describe-addon-configuration --addon-name <value> --addon-version <value>`
+
+Below is an example of configuration values being set within the module: 
+
+```
+cluster_addons = {
+    vpc-cni = {
+      most_recent    = true
+      before_compute = true
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
+    }
+  }
+```
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -89,7 +89,7 @@ If you would like to adjust specific configuration values within the body of an 
 
 `aws eks describe-addon-configuration --addon-name <value> --addon-version <value>`
 
-Below is an example of configuration values being set within the module:
+Below is an example of configuration values being set for an addon within the module:
 
 ```
 cluster_addons = {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -85,11 +85,11 @@ A top level description of all available cluster addons can be [found here](http
 
 `aws eks describe-addon-versions --query 'addons[*].addonName'`
 
-If you would like to adjust specific configuration values within the body of an addon, you can obtain the schema with this command: 
+If you would like to adjust specific configuration values within the body of an addon, you can obtain the schema with this command:
 
 `aws eks describe-addon-configuration --addon-name <value> --addon-version <value>`
 
-Below is an example of configuration values being set within the module: 
+Below is an example of configuration values being set within the module:
 
 ```
 cluster_addons = {
@@ -105,4 +105,3 @@ cluster_addons = {
     }
   }
 ```
-

--- a/main.tf
+++ b/main.tf
@@ -485,7 +485,6 @@ resource "aws_iam_policy" "cluster_encryption" {
 
 ################################################################################
 # EKS Addons
-# Addon names and configuration ref: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
 ################################################################################
 
 data "aws_eks_addon_version" "this" {

--- a/main.tf
+++ b/main.tf
@@ -485,6 +485,7 @@ resource "aws_iam_policy" "cluster_encryption" {
 
 ################################################################################
 # EKS Addons
+# Addon names and configuration ref: https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html
 ################################################################################
 
 data "aws_eks_addon_version" "this" {


### PR DESCRIPTION
## Description
Includes a reference to AWS documentation for EKS Cluster addon names and configuration details. 

I'm happy to write a more in-depth description with examples but I wasn't sure of the best place to do so, so I went with the simplest solution. Feel free to let me know if there's a more reasonable place for this to live. 

## Motivation and Context
Assists operators in more easily discerning the precise addon names to include in their modules. 
Closes #3008 

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
