### PR TITLE
feat: Starting with `1.30`, do not use the cluster OIDC issuer URL by default in the identity provider config

### DIFF
--- a/docs/UPGRADE-19.0.md
+++ b/docs/UPGRADE-19.0.md
@@ -364,8 +364,12 @@ EKS managed node groups on `v18.x` by default create a security group that does 
 
   # OIDC Identity provider
   cluster_identity_providers = {
-    sts = {
-      client_id = "sts.amazonaws.com"
+    cognito = {
+      client_id      = "702vqsrjicklgb7c5b7b50i1gc"
+      issuer_url     = "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_re1u6bpRA"
+      username_claim = "email"
+      groups_claim   = "cognito:groups"
+      groups_prefix  = "gid:"
     }
   }
 


### PR DESCRIPTION
## Description
- Starting with `1.30`, do not use the cluster OIDC issuer URL by default in the identity provider config
- The example referenced in the v19 upgrade doc has been corrected to better reflect the intended behavior enforced by this change

## Motivation and Context
- Starting in Kubernetes 1.30, there are improved restrictions on authentication. From https://github.com/kubernetes/kubernetes/pull/123561:

> Conflicting issuers between JWT authenticators and service account config are now detected and fail on API server startup.  Previously such a config would run but would be inconsistently effective depending on the credential.

	The prior default value of the cluster (control plane) OIDC issuer URL was incorrect and should not be used in this context. Users should provider their issuer's URL for their identity provider (i.e. - Cognito, Okta, Auth0, etc.). Therefore, this change is aligning with the upstream Kubernetes project to ensure users provide the correct issuer URL when associating additional identity providers to their cluster

## Breaking Changes
- Yes'ish - it requires users to potentially make changes if they are currently, and incorrectly, utilizing the cluster's OIDC issuer url. But, if they don't, the API server will reject this and fail

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	1. Created a cluster on 1.29 with the following config:
	```hcl
      ...
	  cluster_identity_providers = {
	    example = {
	      client_id  = "1234567890abc"
	    }
	  }
      ...
	```
	2. Once the cluster has provisioned, change the Kubernetes version to 1.30 and execute:
	 ```sh
	 terraform plan
	 ```
	3. From the plan, the following error is now shown to users:
	![image](https://github.com/terraform-aws-modules/terraform-aws-eks/assets/10913471/399a37b6-639f-42ba-a0d5-f654174ff786)
	4. To resolve, users will need to explicitly provide the *correct issuer URL (if you incorrectly re-provide the cluster's OIDC issuer URL, the API server will fail). For example, continuing the example above, updating the configuration to something like this now plans successfully (these are contrived values, but they demonstrate the intended behavior of the change):
	```hcl
      ...
	  cluster_identity_providers = {
	    example = {
	      client_id  = "1234567890abc"
	      issuer_url = "https://myissuer.com"
	    }
	  }
      ...
	```

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
