### PR TITLE
fix: Correct syntax for correctly ignoring `bootstrap_cluster_creator_admin_permissions` and not all of `access_config`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,7 +105,7 @@ resource "aws_eks_cluster" "this" {
 
   lifecycle {
     ignore_changes = [
-      access_config["bootstrap_cluster_creator_admin_permissions"]
+      access_config[0].bootstrap_cluster_creator_admin_permissions
     ]
   }
 }


### PR DESCRIPTION
## Description
- Correct syntax for correctly ignoring `bootstrap_cluster_creator_admin_permissions` and not all of `access_config`

## Motivation and Context
- Resolves #3052

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
