### PR TITLE
feat: Allow to pass `additional_cluster_dns_ips` as a parameter in cluster module

### DIFF
--- a/examples/eks_managed_node_group/main.tf
+++ b/examples/eks_managed_node_group/main.tf
@@ -140,6 +140,12 @@ module "eks" {
       ami_id   = data.aws_ami.eks_default_bottlerocket.image_id
       ami_type = "BOTTLEROCKET_x86_64"
 
+      # Add custom dns server to cluster-dns-ip list for node-local-dns as example.
+      additional_cluster_dns_ips = [
+        "169.254.20.10"
+      ]
+      # We have to use custom launch template if we want to bootstrap our own user_data
+      use_custom_launch_template = true
       # Use module user data template to bootstrap
       enable_bootstrap_user_data = true
       # This will get added to the template

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -101,6 +101,7 @@ module "eks_managed_node_group" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_cluster_dns_ips"></a> [additional\_cluster\_dns\_ips](#input\_additional\_cluster\_dns\_ips) | Additional DNS IP addresses to use for the cluster. Only used when `ami_type` = `BOTTLEROCKET_*` | `list(string)` | `[]` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | The AMI from which to launch the instance. If not supplied, EKS will use its own default image | `string` | `""` | no |
 | <a name="input_ami_release_version"></a> [ami\_release\_version](#input\_ami\_release\_version) | The AMI version. Defaults to latest AMI release version for the given Kubernetes version and AMI type | `string` | `null` | no |
 | <a name="input_ami_type"></a> [ami\_type](#input\_ami\_type) | Type of Amazon Machine Image (AMI) associated with the EKS Node Group. See the [AWS documentation](https://docs.aws.amazon.com/eks/latest/APIReference/API_Nodegroup.html#AmazonEKS-Type-Nodegroup-amiType) for valid values | `string` | `null` | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -12,11 +12,12 @@ module "user_data" {
   platform = var.platform
   ami_type = var.ami_type
 
-  cluster_name         = var.cluster_name
-  cluster_endpoint     = var.cluster_endpoint
-  cluster_auth_base64  = var.cluster_auth_base64
-  cluster_ip_family    = var.cluster_ip_family
-  cluster_service_cidr = try(coalesce(var.cluster_service_cidr, var.cluster_service_ipv4_cidr), "")
+  cluster_name               = var.cluster_name
+  cluster_endpoint           = var.cluster_endpoint
+  cluster_auth_base64        = var.cluster_auth_base64
+  cluster_ip_family          = var.cluster_ip_family
+  cluster_service_cidr       = try(coalesce(var.cluster_service_cidr, var.cluster_service_ipv4_cidr), "")
+  additional_cluster_dns_ips = var.additional_cluster_dns_ips
 
   enable_bootstrap_user_data = var.enable_bootstrap_user_data
   pre_bootstrap_user_data    = var.pre_bootstrap_user_data

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -57,6 +57,12 @@ variable "cluster_service_ipv4_cidr" {
   default     = null
 }
 
+variable "additional_cluster_dns_ips" {
+  description = "Additional DNS IP addresses to use for the cluster. Only used when `ami_type` = `BOTTLEROCKET_*`"
+  type        = list(string)
+  default     = []
+}
+
 variable "pre_bootstrap_user_data" {
   description = "User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `ami_type` = `BOTTLEROCKET_*`"
   type        = string

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -341,6 +341,7 @@ module "eks_managed_node_group" {
   user_data_template_path    = try(each.value.user_data_template_path, var.eks_managed_node_group_defaults.user_data_template_path, "")
   cloudinit_pre_nodeadm      = try(each.value.cloudinit_pre_nodeadm, var.eks_managed_node_group_defaults.cloudinit_pre_nodeadm, [])
   cloudinit_post_nodeadm     = try(each.value.cloudinit_post_nodeadm, var.eks_managed_node_group_defaults.cloudinit_post_nodeadm, [])
+  additional_cluster_dns_ips = try(each.value.additional_cluster_dns_ips, var.eks_managed_node_group_defaults.additional_cluster_dns_ips, [])
 
   # Launch Template
   create_launch_template                 = try(each.value.create_launch_template, var.eks_managed_node_group_defaults.create_launch_template, true)
@@ -467,17 +468,18 @@ module "self_managed_node_group" {
   # User data
   platform = try(each.value.platform, var.self_managed_node_group_defaults.platform, "linux")
   # TODO - update this when `var.platform` is removed in v21.0
-  ami_type                 = try(each.value.ami_type, var.self_managed_node_group_defaults.ami_type, "AL2_x86_64")
-  cluster_endpoint         = try(time_sleep.this[0].triggers["cluster_endpoint"], "")
-  cluster_auth_base64      = try(time_sleep.this[0].triggers["cluster_certificate_authority_data"], "")
-  cluster_service_cidr     = try(time_sleep.this[0].triggers["cluster_service_cidr"], "")
-  cluster_ip_family        = var.cluster_ip_family
-  pre_bootstrap_user_data  = try(each.value.pre_bootstrap_user_data, var.self_managed_node_group_defaults.pre_bootstrap_user_data, "")
-  post_bootstrap_user_data = try(each.value.post_bootstrap_user_data, var.self_managed_node_group_defaults.post_bootstrap_user_data, "")
-  bootstrap_extra_args     = try(each.value.bootstrap_extra_args, var.self_managed_node_group_defaults.bootstrap_extra_args, "")
-  user_data_template_path  = try(each.value.user_data_template_path, var.self_managed_node_group_defaults.user_data_template_path, "")
-  cloudinit_pre_nodeadm    = try(each.value.cloudinit_pre_nodeadm, var.self_managed_node_group_defaults.cloudinit_pre_nodeadm, [])
-  cloudinit_post_nodeadm   = try(each.value.cloudinit_post_nodeadm, var.self_managed_node_group_defaults.cloudinit_post_nodeadm, [])
+  ami_type                   = try(each.value.ami_type, var.self_managed_node_group_defaults.ami_type, "AL2_x86_64")
+  cluster_endpoint           = try(time_sleep.this[0].triggers["cluster_endpoint"], "")
+  cluster_auth_base64        = try(time_sleep.this[0].triggers["cluster_certificate_authority_data"], "")
+  cluster_service_cidr       = try(time_sleep.this[0].triggers["cluster_service_cidr"], "")
+  cluster_ip_family          = var.cluster_ip_family
+  pre_bootstrap_user_data    = try(each.value.pre_bootstrap_user_data, var.self_managed_node_group_defaults.pre_bootstrap_user_data, "")
+  post_bootstrap_user_data   = try(each.value.post_bootstrap_user_data, var.self_managed_node_group_defaults.post_bootstrap_user_data, "")
+  bootstrap_extra_args       = try(each.value.bootstrap_extra_args, var.self_managed_node_group_defaults.bootstrap_extra_args, "")
+  user_data_template_path    = try(each.value.user_data_template_path, var.self_managed_node_group_defaults.user_data_template_path, "")
+  cloudinit_pre_nodeadm      = try(each.value.cloudinit_pre_nodeadm, var.self_managed_node_group_defaults.cloudinit_pre_nodeadm, [])
+  cloudinit_post_nodeadm     = try(each.value.cloudinit_post_nodeadm, var.self_managed_node_group_defaults.cloudinit_post_nodeadm, [])
+  additional_cluster_dns_ips = try(each.value.additional_cluster_dns_ips, var.self_managed_node_group_defaults.additional_cluster_dns_ips, [])
 
   # Launch Template
   create_launch_template                 = try(each.value.create_launch_template, var.self_managed_node_group_defaults.create_launch_template, true)


### PR DESCRIPTION
## Description
Add posibility to pass `additional_cluster_dns_ips` for `self_managed` and `eks_managed` node groups in cluster module without directly calling a submodule.

## Motivation and Context
In the #3051 was added possibility to pass `additional_cluster_dns_ips` but unfortunately current implementation has some limitations:
1. This option works only for `self_managed_node_group`
2. It works only when you call submodule directly and it is impossible now to pass mentioned variable as a parameter for node group variable in cluster module.

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

