### PR TITLE
docs: Improve karpenter example to use service account for helm relea…

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -141,7 +141,7 @@ module "karpenter_disabled" {
 
 resource "helm_release" "karpenter" {
   namespace           = "kube-system"
-  name                = module.karpenter.service_account
+  name                = "karpenter"
   repository          = "oci://public.ecr.aws/karpenter"
   repository_username = data.aws_ecrpublic_authorization_token.token.user_name
   repository_password = data.aws_ecrpublic_authorization_token.token.password
@@ -151,6 +151,8 @@ resource "helm_release" "karpenter" {
 
   values = [
     <<-EOT
+    serviceAccount:
+      name: module.karpenter.service_account
     settings:
       clusterName: ${module.eks.cluster_name}
       clusterEndpoint: ${module.eks.cluster_endpoint}

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -141,7 +141,7 @@ module "karpenter_disabled" {
 
 resource "helm_release" "karpenter" {
   namespace           = "kube-system"
-  name                = "karpenter"
+  name                = module.karpenter.service_account
   repository          = "oci://public.ecr.aws/karpenter"
   repository_username = data.aws_ecrpublic_authorization_token.token.user_name
   repository_password = data.aws_ecrpublic_authorization_token.token.password

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -152,7 +152,7 @@ resource "helm_release" "karpenter" {
   values = [
     <<-EOT
     serviceAccount:
-      name: module.karpenter.service_account
+      name: ${module.karpenter.service_account}
     settings:
       clusterName: ${module.eks.cluster_name}
       clusterEndpoint: ${module.eks.cluster_endpoint}


### PR DESCRIPTION
Fixes #3064 

The karpenter helm release name is used to create its service account in the cluster, therefore it must be the same service account name used by the karpenter submodule for creating the Pod Identity Association.

This can be overlooked and cause permission issues if one changes the release name to something other than "karpenter" (which is the default service_account name used by the karpenter submodule), OR if one explicitly provide a different name for the karpenter submodule service_account variable.

Making the helm release name in the example to be `module.karpenter.service_account` makes it clear that they must match.