### PR TITLE
feat: Deny HTTP on Karpenter SQS policy

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -464,6 +464,27 @@ data "aws_iam_policy_document" "queue" {
       ]
     }
   }
+  statement {
+    sid    = "DenyHTTP"
+    effect = "Deny"
+    actions = [
+      "sqs:*"
+    ]
+    resources = [aws_sqs_queue.this[0].arn]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+    principals {
+      type = "*"
+      identifiers = [
+        "*"
+      ]
+    }
+  }
 }
 
 resource "aws_sqs_queue_policy" "this" {


### PR DESCRIPTION
## Description
I would like to deny access to AWS SQS through HTTP by AWS SQS access policy due to security reasons.

## Motivation and Context
[SQS security best practices](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-security-best-practices.html)
https://github.com/aws/karpenter-provider-aws/pull/6395
## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

