### PR TITLE
feat: Add subnet AZ filter

### DIFF
--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -97,7 +97,7 @@ module "eks_managed_node_group" {
 | [aws_iam_policy_document.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_ssm_parameter.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
-| [aws_subnets.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 
 ## Inputs
 
@@ -177,6 +177,7 @@ module "eks_managed_node_group" {
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_remote_access"></a> [remote\_access](#input\_remote\_access) | Configuration block with remote access settings. Only valid when `use_custom_launch_template` = `false` | `any` | `{}` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |
+| <a name="input_subnet_az_filter"></a> [subnet\_az\_filter](#input\_subnet\_az\_filter) | Subnet availability zone filter for subnets where nodegroup nodes are allocated. e.g. ['eu-west-1a', 'eu-west-1b'] | `list(string)` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Identifiers of EC2 Subnets to associate with the EKS Node Group. These subnets must have the following resource tag: `kubernetes.io/cluster/CLUSTER_NAME` | `list(string)` | `null` | no |
 | <a name="input_tag_specifications"></a> [tag\_specifications](#input\_tag\_specifications) | The tags to apply to the resources during launch | `list(string)` | <pre>[<br>  "instance",<br>  "volume",<br>  "network-interface"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -388,7 +388,8 @@ resource "aws_eks_node_group" "this" {
   # Required
   cluster_name  = var.cluster_name
   node_role_arn = var.create_iam_role ? aws_iam_role.this[0].arn : var.iam_role_arn
-  subnet_ids    = var.enable_efa_support ? data.aws_subnets.efa[0].ids : var.subnet_ids
+
+  subnet_ids = data.aws_subnets.subnets[0].ids
 
   scaling_config {
     min_size     = var.min_size
@@ -463,8 +464,11 @@ resource "aws_eks_node_group" "this" {
 
   tags = merge(
     var.tags,
-    { Name = var.name }
+    { Name = var.name },
+    # tag is added to make sure the placement group is created first before the node group since the 'depends_on' block cannot accept non static conditional variables
+    var.create_placement_group ? { PlacementGroup = aws_placement_group.this[0].id } : {}
   )
+
 }
 
 ################################################################################
@@ -609,6 +613,13 @@ resource "aws_placement_group" "this" {
   strategy = var.placement_group_strategy
 
   tags = var.tags
+
+  lifecycle {
+    precondition {
+      condition     = var.placement_group_strategy == "cluster" ? var.subnet_az_filter != null ? length(var.subnet_az_filter) == 1 : true : true
+      error_message = "Placement group strategy 'cluster' requires a single subnet to be set in subnet_az_filter"
+    }
+  }
 }
 
 ################################################################################
@@ -634,17 +645,30 @@ data "aws_ec2_instance_type_offerings" "this" {
 
 # Reverse the lookup to find one of the subnets provided based on the availability
 # availability zone ID of the queried instance type (supported)
-data "aws_subnets" "efa" {
-  count = var.create && var.enable_efa_support ? 1 : 0
+data "aws_subnets" "subnets" {
+  count = var.create ? 1 : 0
 
   filter {
     name   = "subnet-id"
     values = var.subnet_ids
   }
 
-  filter {
-    name   = "availability-zone-id"
-    values = data.aws_ec2_instance_type_offerings.this[0].locations
+  dynamic "filter" {
+    for_each = var.enable_efa_support ? [1] : []
+
+    content {
+      name   = "availability-zone-id"
+      values = data.aws_ec2_instance_type_offerings.this[0].locations
+    }
+  }
+
+  dynamic "filter" {
+    for_each = var.subnet_az_filter != null ? [1] : []
+
+    content {
+      name   = "availability-zone"
+      values = var.subnet_az_filter
+    }
   }
 }
 

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -337,6 +337,12 @@ variable "subnet_ids" {
   default     = null
 }
 
+variable "subnet_az_filter" {
+  description = "Subnet availability zone filter for subnets where nodegroup nodes are allocated. e.g. ['eu-west-1a', 'eu-west-1b']"
+  type        = list(string)
+  default     = null
+}
+
 variable "min_size" {
   description = "Minimum number of instances/nodes"
   type        = number

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -78,7 +78,7 @@ module "self_managed_node_group" {
 | [aws_iam_policy_document.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_ssm_parameter.ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
-| [aws_subnets.efa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 
 ## Inputs
 
@@ -110,6 +110,7 @@ module "self_managed_node_group" {
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `true` | no |
 | <a name="input_create_iam_role_policy"></a> [create\_iam\_role\_policy](#input\_create\_iam\_role\_policy) | Determines whether an IAM role policy is created or not | `bool` | `true` | no |
 | <a name="input_create_launch_template"></a> [create\_launch\_template](#input\_create\_launch\_template) | Determines whether to create launch template or not | `bool` | `true` | no |
+| <a name="input_create_placement_group"></a> [create\_placement\_group](#input\_create\_placement\_group) | Determines whether a placement group is created & used by the nodegroup | `bool` | `true` | no |
 | <a name="input_create_schedule"></a> [create\_schedule](#input\_create\_schedule) | Determines whether to create autoscaling group schedule or not | `bool` | `true` | no |
 | <a name="input_credit_specification"></a> [credit\_specification](#input\_credit\_specification) | Customize the credit specification of the instance | `map(string)` | `{}` | no |
 | <a name="input_default_cooldown"></a> [default\_cooldown](#input\_default\_cooldown) | The amount of time, in seconds, after a scaling activity completes before another scaling activity can start | `number` | `null` | no |
@@ -169,6 +170,7 @@ module "self_managed_node_group" {
 | <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `list(any)` | `[]` | no |
 | <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `{}` | no |
 | <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The name of the placement group into which you'll launch your instances, if any | `string` | `null` | no |
+| <a name="input_placement_group_strategy"></a> [placement\_group\_strategy](#input\_placement\_group\_strategy) | The placement group strategy | `string` | `"cluster"` | no |
 | <a name="input_platform"></a> [platform](#input\_platform) | [DEPRECATED - must use `ami_type` instead. Will be removed in `v21.0`] | `string` | `null` | no |
 | <a name="input_post_bootstrap_user_data"></a> [post\_bootstrap\_user\_data](#input\_post\_bootstrap\_user\_data) | User data that is appended to the user data script after of the EKS bootstrap script. Not used when `ami_type` = `BOTTLEROCKET_*` | `string` | `""` | no |
 | <a name="input_pre_bootstrap_user_data"></a> [pre\_bootstrap\_user\_data](#input\_pre\_bootstrap\_user\_data) | User data that is injected into the user data script ahead of the EKS bootstrap script. Not used when `ami_type` = `BOTTLEROCKET_*` | `string` | `""` | no |
@@ -177,6 +179,7 @@ module "self_managed_node_group" {
 | <a name="input_ram_disk_id"></a> [ram\_disk\_id](#input\_ram\_disk\_id) | The ID of the ram disk | `string` | `null` | no |
 | <a name="input_schedules"></a> [schedules](#input\_schedules) | Map of autoscaling group schedule to create | `map(any)` | `{}` | no |
 | <a name="input_service_linked_role_arn"></a> [service\_linked\_role\_arn](#input\_service\_linked\_role\_arn) | The ARN of the service-linked role that the ASG will use to call other AWS services | `string` | `null` | no |
+| <a name="input_subnet_az_filter"></a> [subnet\_az\_filter](#input\_subnet\_az\_filter) | Subnet availability zone filter for subnets where nodegroup nodes are allocated. e.g. ['eu-west-1a', 'eu-west-1b'] | `list(string)` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones` | `list(string)` | `null` | no |
 | <a name="input_suspended_processes"></a> [suspended\_processes](#input\_suspended\_processes) | A list of processes to suspend for the Auto Scaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your Auto Scaling Group from functioning properly | `list(string)` | `[]` | no |
 | <a name="input_tag_specifications"></a> [tag\_specifications](#input\_tag\_specifications) | The tags to apply to the resources during launch | `list(string)` | <pre>[<br>  "instance",<br>  "volume",<br>  "network-interface"<br>]</pre> | no |

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -256,6 +256,18 @@ variable "placement" {
   default     = {}
 }
 
+variable "create_placement_group" {
+  description = "Determines whether a placement group is created & used by the nodegroup"
+  type        = bool
+  default     = true
+}
+
+variable "placement_group_strategy" {
+  description = "The placement group strategy"
+  type        = string
+  default     = "cluster"
+}
+
 variable "private_dns_name_options" {
   description = "The options for the instance hostname. The default values are inherited from the subnet"
   type        = map(string)
@@ -386,6 +398,12 @@ variable "availability_zones" {
 
 variable "subnet_ids" {
   description = "A list of subnet IDs to launch resources in. Subnets automatically determine which availability zones the group will reside. Conflicts with `availability_zones`"
+  type        = list(string)
+  default     = null
+}
+
+variable "subnet_az_filter" {
+  description = "Subnet availability zone filter for subnets where nodegroup nodes are allocated. e.g. ['eu-west-1a', 'eu-west-1b']"
   type        = list(string)
   default     = null
 }

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -307,7 +307,8 @@ module "eks_managed_node_group" {
   name            = try(each.value.name, each.key)
   use_name_prefix = try(each.value.use_name_prefix, var.eks_managed_node_group_defaults.use_name_prefix, true)
 
-  subnet_ids = try(each.value.subnet_ids, var.eks_managed_node_group_defaults.subnet_ids, var.subnet_ids)
+  subnet_ids       = try(each.value.subnet_ids, var.eks_managed_node_group_defaults.subnet_ids, var.subnet_ids)
+  subnet_az_filter = try(each.value.subnet_az_filter, var.eks_managed_node_group_defaults.subnet_az_filter, null)
 
   min_size     = try(each.value.min_size, var.eks_managed_node_group_defaults.min_size, 1)
   max_size     = try(each.value.max_size, var.eks_managed_node_group_defaults.max_size, 3)
@@ -430,6 +431,7 @@ module "self_managed_node_group" {
 
   availability_zones = try(each.value.availability_zones, var.self_managed_node_group_defaults.availability_zones, null)
   subnet_ids         = try(each.value.subnet_ids, var.self_managed_node_group_defaults.subnet_ids, var.subnet_ids)
+  subnet_az_filter   = try(each.value.subnet_az_filter, var.self_managed_node_group_defaults.subnet_az_filter, null)
 
   min_size                  = try(each.value.min_size, var.self_managed_node_group_defaults.min_size, 0)
   max_size                  = try(each.value.max_size, var.self_managed_node_group_defaults.max_size, 3)
@@ -520,6 +522,8 @@ module "self_managed_node_group" {
   metadata_options                   = try(each.value.metadata_options, var.self_managed_node_group_defaults.metadata_options, local.metadata_options)
   enable_monitoring                  = try(each.value.enable_monitoring, var.self_managed_node_group_defaults.enable_monitoring, true)
   enable_efa_support                 = try(each.value.enable_efa_support, var.self_managed_node_group_defaults.enable_efa_support, false)
+  create_placement_group             = try(each.value.create_placement_group, var.self_managed_node_group_defaults.create_placement_group, false)
+  placement_group_strategy           = try(each.value.placement_group_strategy, var.self_managed_node_group_defaults.placement_group_strategy, "cluster")
   network_interfaces                 = try(each.value.network_interfaces, var.self_managed_node_group_defaults.network_interfaces, [])
   placement                          = try(each.value.placement, var.self_managed_node_group_defaults.placement, {})
   maintenance_options                = try(each.value.maintenance_options, var.self_managed_node_group_defaults.maintenance_options, {})

--- a/tests/eks-managed-node-group/main.tf
+++ b/tests/eks-managed-node-group/main.tf
@@ -307,6 +307,28 @@ module "eks" {
       max_size     = 2
       desired_size = 2
     }
+
+    subnet_az_filter = {
+      subnet_az_filter = ["eu-west-1a"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
+
+    placement_group_with_az_filter = {
+      name = "pg-with-az-filter"
+
+      create_placement_group   = true
+      placement_group_strategy = "cluster"
+
+      subnet_az_filter = ["eu-west-1a"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
+
   }
 
   access_entries = {

--- a/tests/self-managed-node-group/main.tf
+++ b/tests/self-managed-node-group/main.tf
@@ -301,6 +301,27 @@ module "eks" {
       max_size     = 2
       desired_size = 2
     }
+
+    subnet_az_filter = {
+      subnet_az_filter = ["eu-west-1a"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
+
+    placement_group_with_az_filter = {
+      name = "pg-with-az-filter"
+
+      create_placement_group   = true
+      placement_group_strategy = "cluster"
+
+      subnet_az_filter = ["eu-west-1a"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
   }
 
   tags = local.tags


### PR DESCRIPTION
## Description

Allows deployment of instances in a node group to be restricted to a list of availability zones, specified as a "subnet AZ filter".

Applies to both EKS-managed and self-managed node groups.

An example of the proposed interface for both cases:

```
 eks_managed_node_groups = {
    my_nodegroup = {
      name            = "my-nodegroup"
      subnet_az_filter = ["eu-west-1a"]
    }
  }
```

Resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3044

Co-Authored-By: @Josephuss

## Motivation and Context

When using a node group with placement group and 'cluster' strategy, node group updates via autoscaling group (such as scale out and/or scale up) fail because the autoscaling group does not restrict the subnet to the AZ where the cluster placement group is set.

Example:

    Error: updating EKS Node Group version: operation error EKS: UpdateNodegroupVersion, https response error StatusCode: 400, RequestID: 58562857----********,
    InvalidRequestException: Instances in the Placement Group must be launched in the eu-west-1a Availability Zone.
    Specify the eu-west-1a Availability Zone and try again.

This is currently manageable by [overriding the subnet ids in the node group configuration](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/node_groups.tf#L308), for example:

```
eks_managed_node_groups = {
  my_custom_nodegroup = {
    name            = "customer1"
    subnet_ids = ["subnet-abc12345"]
  }
}
```

However, this is fragile because subnet IDs **change** after full destroy/create cycles that include re-creating the VPC, which is common in development environments. This requires manual intervention to update the subnet ID in the node group configuration.

Also, specifying subnets by their logical name is significantly easier than trying to use the raw subnet ID.

Placement group update is the one current use case for this feature, but subnet AZ filter is not limited to usage of placement groups.
It can be used without placement groups, in cases where the user wants to restrict the node group to a specific AZ.

## Breaking Changes

This doesn't break backwards compatibility with the current major version.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
