### PR TITLE
fix: Revert #3058 - fix: Invoke aws_iam_session_context data source only when required

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,6 @@ data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_session_context" "current" {
-  count = (var.create && var.enable_cluster_creator_admin_permissions) || (var.create && var.create_kms_key && local.enable_cluster_encryption_config) ? 1 : 0
   # This data source provides information on the IAM source role of an STS assumed role
   # For non-role ARNs, this data source simply passes the ARN through issuer ARN
   # Ref https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2327#issuecomment-1355581682
@@ -148,7 +147,7 @@ locals {
   # better controlled by users through Terraform
   bootstrap_cluster_creator_admin_permissions = {
     cluster_creator = {
-      principal_arn = data.aws_iam_session_context.current[0].issuer_arn
+      principal_arn = data.aws_iam_session_context.current.issuer_arn
       type          = "STANDARD"
 
       policy_associations = {
@@ -237,7 +236,7 @@ module "kms" {
   # Policy
   enable_default_policy     = var.kms_key_enable_default_policy
   key_owners                = var.kms_key_owners
-  key_administrators        = coalescelist(var.kms_key_administrators, [data.aws_iam_session_context.current[0].issuer_arn])
+  key_administrators        = coalescelist(var.kms_key_administrators, [data.aws_iam_session_context.current.issuer_arn])
   key_users                 = concat([local.cluster_role], var.kms_key_users)
   key_service_users         = var.kms_key_service_users
   source_policy_documents   = var.kms_key_source_policy_documents


### PR DESCRIPTION
## Description
- Revert #3058 - fix: Invoke aws_iam_session_context data source only when required

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3058#issuecomment-2211247209

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
