### PR TITLE
fix: Ensure vpc-cni is installed before adding nodes to the cluster (Manag…

### DIFF
--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -166,6 +166,7 @@ module "eks_managed_node_group" {
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of instances/nodes | `number` | `3` | no |
 | <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options for the instance | `map(string)` | <pre>{<br>  "http_endpoint": "enabled",<br>  "http_put_response_hop_limit": 2,<br>  "http_tokens": "required"<br>}</pre> | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum number of instances/nodes | `number` | `0` | no |
+| <a name="input_module_depends_on"></a> [module\_depends\_on](#input\_module\_depends\_on) | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the EKS managed node group | `string` | `""` | no |
 | <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `list(any)` | `[]` | no |
 | <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `{}` | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -470,6 +470,8 @@ resource "aws_eks_node_group" "this" {
     var.tags,
     { Name = var.name }
   )
+
+  depends_on = [var.module_depends_on]
 }
 
 ################################################################################

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -460,6 +460,12 @@ variable "timeouts" {
   default     = {}
 }
 
+variable "module_depends_on" {
+  type        = any
+  default     = null
+  description = "Can be any value desired. Module will wait for this value to be computed before creating node group."
+}
+
 ################################################################################
 # IAM Role
 ################################################################################

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -408,6 +408,8 @@ module "eks_managed_node_group" {
   cluster_primary_security_group_id = try(each.value.attach_cluster_primary_security_group, var.eks_managed_node_group_defaults.attach_cluster_primary_security_group, false) ? aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id : null
 
   tags = merge(var.tags, try(each.value.tags, var.eks_managed_node_group_defaults.tags, {}))
+
+  module_depends_on = [aws_eks_addon.before_compute]
 }
 
 ################################################################################


### PR DESCRIPTION
Ensure vpc-cni is installed before adding nodes to the cluster (Managed nodegroup)

## Description
The aws_eks_node_group resource must wait for vpc-cni or add-on to be added before adding the node group to the cluster.

Add depend_on to `aws_eks_node_group` resource (modules/eks-managed-node-group) with variable `module_depends_on`. On main module, set `aws_eks_addon.before_compute` as depend

## Motivation and Context


Resolves [Add depends_on for the 'resource "aws_eks_addon" "before_compute"' #3114
](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3114)


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
