### PR TITLE
fix: Allow for a new tag created by Karpenter as of v1

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -188,6 +188,7 @@ data "aws_iam_policy_document" "controller" {
       values = [
         "karpenter.sh/nodeclaim",
         "Name",
+        "eks:eks-cluster-name",
       ]
     }
   }


### PR DESCRIPTION
## Description
Karpenter added a new tag that it applies to instances in v1. Updating the policy allows this tag to be set.

See: https://github.com/aws/karpenter-provider-aws/blob/e28477489c64c3433498e087811072ce0a8c9ed6/designs/v1-api.md?plain=1#L211

## Breaking Changes
None

## How Has This Been Tested?
I have manually applied the change to my IAM role
