### PR TITLE
feat: Allow passing in empty map to disable instance refreshes

### DIFF
--- a/examples/self-managed-node-group/eks-bottlerocket.tf
+++ b/examples/self-managed-node-group/eks-bottlerocket.tf
@@ -45,6 +45,8 @@ module "eks_bottlerocket" {
         [settings.kernel]
         lockdown = "integrity"
       EOT
+
+      instance_refresh = {}
     }
   }
 

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -527,7 +527,10 @@ resource "aws_autoscaling_group" "this" {
   }
 
   dynamic "instance_refresh" {
-    for_each = try(length(var.instance_refresh),0) > 0 ? [var.instance_refresh] : []
+    for_each = alltrue([
+      length(var.instance_refresh) > 0,
+      var.instance_refresh != {}
+    ]) ? [var.instance_refresh] : []
 
     content {
       dynamic "preferences" {

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -527,7 +527,7 @@ resource "aws_autoscaling_group" "this" {
   }
 
   dynamic "instance_refresh" {
-    for_each = length(var.instance_refresh) > 0 ? [var.instance_refresh] : []
+    for_each = try(length(var.instance_refresh),0) > 0 ? [var.instance_refresh] : []
 
     content {
       dynamic "preferences" {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -567,7 +567,6 @@ variable "instance_refresh" {
       min_healthy_percentage = 66
     }
   }
-  nullable = true
 }
 
 variable "use_mixed_instances_policy" {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -567,6 +567,7 @@ variable "instance_refresh" {
       min_healthy_percentage = 66
     }
   }
+  nullable = true
 }
 
 variable "use_mixed_instances_policy" {


### PR DESCRIPTION
## Description
Allows a user to pass in `{}` for the instance_refresh argument and stop the dynamic block from creating the refresh. Currently you cannot disable an instance refresh without a separate module call.

## Motivation and Context
A user may want to only refresh a set of nodes and not enable it for every node group in the cluster. This adds support for that workflow by handling an empty config safely.

## Breaking Changes
No

## Resolves
This resolves https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3133 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

Have deployed this code to local clusters to confirm behavior is as expected.

- [x] I have executed `pre-commit run -a` on my pull request

