### PR TITLE
fix: Use null for tags on `aws_eks_pod_identity_association` when value is `{}` (#3137)

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -125,7 +125,7 @@ resource "aws_eks_pod_identity_association" "karpenter" {
   service_account = var.service_account
   role_arn        = aws_iam_role.controller[0].arn
 
-  tags = var.tags
+  tags = length(keys(var.tags)) > 0 ? var.tags : null
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
This change applies the value `null` on the tags for the `aws_eks_pod_identity_association` resources as the default value `{}` would cause an empty tag object to be added on every apply.

Also mentioned here: https://github.com/hashicorp/terraform-provider-aws/issues/37146

## Motivation and Context
Constant drift as terraform tries to always add empty tags on every apply.
Fixes #3137 

## Breaking Changes


## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
