### PR TITLE
Ignore `platform_version` on EKS Cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,8 @@ resource "aws_eks_cluster" "this" {
 
   lifecycle {
     ignore_changes = [
-      access_config[0].bootstrap_cluster_creator_admin_permissions
+      access_config[0].bootstrap_cluster_creator_admin_permissions,
+      platform_version
     ]
   }
 }


### PR DESCRIPTION
## Description
This PR ignores the `platform_version` value of an EKS Cluster. Per [documentation](https://docs.aws.amazon.com/eks/latest/userguide/platform-versions.html), AWS automatically updates existing clusters to the latest version for the corresponding Kubernetes version.

## Motivation and Context
At first glance, a proposed TF change for `platform_version` in a plan is a moment of concern. When you later find out that AWS automatically updates the version, then the concern is minimimized (no-op), I suggest ignoring this output from the AWS API. 

Note: I considered submitting this idea to `terraform-provider-aws` but deemed it was inappropriate because _this_ module is opinionated by the fact that it does **not** allow consumers to set the platform_version. This signals to me that consumers of this module are 'ok' with just letting AWS do the automatic upgrades.

For example, this is the output of a TF plan
<img width="517" alt="image" src="https://github.com/user-attachments/assets/f478591a-eaa9-4d5b-8353-0edaf8a5c08f">


## Testing
I am unsure how to test this change because new clusters are automatically at the latest version and I no longer have a test case.