### PR TITLE
Ignore `status` field in aws_eks_node_group

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -463,6 +463,9 @@ resource "aws_eks_node_group" "this" {
     create_before_destroy = true
     ignore_changes = [
       scaling_config[0].desired_size,
+      # status is reported by AWS, but cannot be set.
+      # See https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3150
+      status,
     ]
   }
 


### PR DESCRIPTION
## Description

Mark `status` as ignored, as the field is output-only.

## Motivation and Context

Fixes https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3150

## Breaking Changes

None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
  - N/A - this only affects state / plan diffs
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - N/A - this only affects state / plan diffs
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
