### PR TITLE
Add support for al2023 self-managed nodes

### DIFF
--- a/templates/userdata_al2023.tpl
+++ b/templates/userdata_al2023.tpl
@@ -1,0 +1,9 @@
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: ${cluster_name}
+    apiServerEndpoint: ${endpoint}
+    certificateAuthority: ${cluster_auth_base64}
+    cidr: ${cluster_service_cidr}


### PR DESCRIPTION
Add support for al2023 node user data.  This is enabled by adding `platform = al2023` to the worker config.

