### PR TITLE
fix: Add `primary_ipv6` parameter to self-managed-node-group

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -417,6 +417,7 @@ resource "aws_launch_template" "this" {
       ipv6_prefixes                = try(network_interfaces.value.ipv6_prefixes, [])
       network_card_index           = try(network_interfaces.value.network_card_index, null)
       network_interface_id         = try(network_interfaces.value.network_interface_id, null)
+      primary_ipv6                 = try(network_interfaces.value.primary_ipv6, null)
       private_ip_address           = try(network_interfaces.value.private_ip_address, null)
       # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/4570
       security_groups = compact(concat(try(network_interfaces.value.security_groups, []), local.security_group_ids))


### PR DESCRIPTION
## Description
The launch template config in self-managed-node-group didn't include the parameter to set `primary_ipv6`, so I add it here. This has already been implemented for eks-managed-node-group in [this PR ](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3098)

## Motivation and Context
This parameter is needed to enable `Assign primary IPv6 IP` for self-managed-node-group nodes. This is required to make it possible to use instance-type targets when using IPv6 and AWS Load Balancer Controller

## Breaking Changes
Simple addition, no breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
