### PR TITLE
fix: The `create_launch_template` variable description says the opposite to what it's actually doing.

### DIFF
--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -108,7 +108,7 @@ variable "cloudinit_post_nodeadm" {
 ################################################################################
 
 variable "create_launch_template" {
-  description = "Determines whether to create a launch template or not. If set to `false`, EKS will use its own default launch template"
+  description = "Determines whether to create a launch template or not. If set to `false`, EKS will use the launch template provided by `launch_template_id`"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description
Provides a concise description to what the variable is actually doing.

## Motivation and Context
While implementing my own nodegroup `launch_template` I realized the variable description is the opposite to the implementation.


## Breaking Changes
Do no apply

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
