### PR TITLE
feat: Add support for newly released AL2023 accelerated AMI types

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "eks" {
   version = "~> 20.0"
 
   cluster_name    = "my-cluster"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   cluster_endpoint_public_access  = true
 
@@ -175,7 +175,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
 
@@ -183,7 +183,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
 

--- a/docs/compute_resources.md
+++ b/docs/compute_resources.md
@@ -113,7 +113,7 @@ Refer to the [Self Managed Node Group documentation](https://docs.aws.amazon.com
 1. The `self-managed-node-group` uses the latest AWS EKS Optimized AMI (Linux) for the given Kubernetes version by default:
 
 ```hcl
-  cluster_version = "1.27"
+  cluster_version = "1.31"
 
   # This self managed node group will use the latest AWS EKS Optimized AMI for Kubernetes 1.27
   self_managed_node_groups = {
@@ -124,7 +124,7 @@ Refer to the [Self Managed Node Group documentation](https://docs.aws.amazon.com
 2. To use Bottlerocket, specify the `ami_type` as one of the respective `"BOTTLEROCKET_*" types` and supply a Bottlerocket OS AMI:
 
 ```hcl
-  cluster_version = "1.27"
+  cluster_version = "1.31"
 
   self_managed_node_groups = {
     bottlerocket = {

--- a/examples/eks-managed-node-group/eks-al2.tf
+++ b/examples/eks-managed-node-group/eks-al2.tf
@@ -3,7 +3,7 @@ module "eks_al2" {
   version = "~> 20.0"
 
   cluster_name    = "${local.name}-al2"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # EKS Addons
   cluster_addons = {

--- a/examples/eks-managed-node-group/eks-al2023.tf
+++ b/examples/eks-managed-node-group/eks-al2023.tf
@@ -3,7 +3,7 @@ module "eks_al2023" {
   version = "~> 20.0"
 
   cluster_name    = "${local.name}-al2023"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # EKS Addons
   cluster_addons = {

--- a/examples/eks-managed-node-group/eks-bottlerocket.tf
+++ b/examples/eks-managed-node-group/eks-bottlerocket.tf
@@ -3,7 +3,7 @@ module "eks_bottlerocket" {
   version = "~> 20.0"
 
   cluster_name    = "${local.name}-bottlerocket"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # EKS Addons
   cluster_addons = {

--- a/examples/eks-managed-node-group/versions.tf
+++ b/examples/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -89,7 +89,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.7 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0 |
 
@@ -97,8 +97,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
-| <a name="provider_aws.virginia"></a> [aws.virginia](#provider\_aws.virginia) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
+| <a name="provider_aws.virginia"></a> [aws.virginia](#provider\_aws.virginia) | >= 5.70 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.7 |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0 |
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -62,7 +62,7 @@ module "eks" {
   source = "../.."
 
   cluster_name    = local.name
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # Gives Terraform identity admin access to cluster which will
   # allow deploying resources (Karpenter) into the cluster
@@ -157,7 +157,7 @@ resource "helm_release" "karpenter" {
   repository_username = data.aws_ecrpublic_authorization_token.token.user_name
   repository_password = data.aws_ecrpublic_authorization_token.token.password
   chart               = "karpenter"
-  version             = "1.0.0"
+  version             = "1.0.6"
   wait                = false
 
   values = [

--- a/examples/karpenter/versions.tf
+++ b/examples/karpenter/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/self-managed-node-group/eks-al2.tf
+++ b/examples/self-managed-node-group/eks-al2.tf
@@ -3,7 +3,7 @@ module "eks_al2" {
   version = "~> 20.0"
 
   cluster_name    = "${local.name}-al2"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # EKS Addons
   cluster_addons = {

--- a/examples/self-managed-node-group/eks-al2023.tf
+++ b/examples/self-managed-node-group/eks-al2023.tf
@@ -3,7 +3,7 @@ module "eks_al2023" {
   version = "~> 20.0"
 
   cluster_name    = "${local.name}-al2023"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # EKS Addons
   cluster_addons = {

--- a/examples/self-managed-node-group/eks-bottlerocket.tf
+++ b/examples/self-managed-node-group/eks-bottlerocket.tf
@@ -3,7 +3,7 @@ module "eks_bottlerocket" {
   version = "~> 20.0"
 
   cluster_name    = "${local.name}-bottlerocket"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
 
   # EKS Addons
   cluster_addons = {

--- a/examples/self-managed-node-group/versions.tf
+++ b/examples/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/modules/_user_data/main.tf
+++ b/modules/_user_data/main.tf
@@ -30,6 +30,8 @@ locals {
     WINDOWS_FULL_2022_x86_64   = "windows"
     AL2023_x86_64_STANDARD     = "al2023"
     AL2023_ARM_64_STANDARD     = "al2023"
+    AL2023_x86_64_NEURON       = "al2023"
+    AL2023_x86_64_NVIDIA       = "al2023"
   }
   # Try to use `ami_type` first, but fall back to current, default behavior
   # TODO - will be removed in v21.0

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -10,7 +10,7 @@ module "eks_managed_node_group" {
 
   name            = "separate-eks-mng"
   cluster_name    = "my-cluster"
-  cluster_version = "1.27"
+  cluster_version = "1.31"
 
   subnet_ids = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
 
@@ -64,13 +64,13 @@ module "eks_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -362,6 +362,8 @@ locals {
     WINDOWS_FULL_2022_x86_64   = "/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-${local.ssm_cluster_version}"
     AL2023_x86_64_STANDARD     = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/x86_64/standard/recommended/release_version"
     AL2023_ARM_64_STANDARD     = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/arm64/standard/recommended/release_version"
+    AL2023_x86_64_NEURON       = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/x86_64/neuron/recommended/release_version"
+    AL2023_x86_64_NVIDIA       = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/x86_64/nvidia/recommended/release_version"
   }
 
   # The Windows SSM params currently do not have a release version, so we have to get the full output JSON blob and parse out the release version

--- a/modules/eks-managed-node-group/versions.tf
+++ b/modules/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/modules/fargate-profile/README.md
+++ b/modules/fargate-profile/README.md
@@ -29,13 +29,13 @@ module "fargate_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/modules/fargate-profile/versions.tf
+++ b/modules/fargate-profile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -86,13 +86,13 @@ module "karpenter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/modules/karpenter/versions.tf
+++ b/modules/karpenter/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -10,7 +10,7 @@ module "self_managed_node_group" {
 
   name                = "separate-self-mng"
   cluster_name        = "my-cluster"
-  cluster_version     = "1.27"
+  cluster_version     = "1.31"
   cluster_endpoint    = "https://012345678903AB2BAE5D1E0BFE0E2B50.gr7.us-east-1.eks.amazonaws.com"
   cluster_auth_base64 = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKbXFqQ1VqNGdGR2w3ZW5PeWthWnZ2RjROOTVOUEZCM2o0cGhVZUsrWGFtN2ZSQnZya0d6OGxKZmZEZWF2b2plTwpQK2xOZFlqdHZncmxCUEpYdHZIZmFzTzYxVzdIZmdWQ2EvamdRM2w3RmkvL1dpQmxFOG9oWUZkdWpjc0s1SXM2CnNkbk5KTTNYUWN2TysrSitkV09NT2ZlNzlsSWdncmdQLzgvRU9CYkw3eUY1aU1hS3lsb1RHL1V3TlhPUWt3ZUcKblBNcjdiUmdkQ1NCZTlXYXowOGdGRmlxV2FOditsTDhsODBTdFZLcWVNVlUxbjQyejVwOVpQRTd4T2l6L0xTNQpYV2lXWkVkT3pMN0xBWGVCS2gzdkhnczFxMkI2d1BKZnZnS1NzWllQRGFpZTloT1NNOUJkNFNPY3JrZTRYSVBOCkVvcXVhMlYrUDRlTWJEQzhMUkVWRDdCdVZDdWdMTldWOTBoL3VJUy9WU2VOcEdUOGVScE5DakszSjc2aFlsWm8KWjNGRG5QWUY0MWpWTHhiOXF0U1ROdEp6amYwWXBEYnFWci9xZzNmQWlxbVorMzd3YWM1eHlqMDZ4cmlaRUgzZgpUM002d2lCUEVHYVlGeWN5TmNYTk5aYW9DWDJVL0N1d2JsUHAKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ=="
 
@@ -43,13 +43,13 @@ module "self_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -24,6 +24,8 @@ locals {
     WINDOWS_FULL_2022_x86_64   = "windows"
     AL2023_x86_64_STANDARD     = "al2023"
     AL2023_ARM_64_STANDARD     = "al2023"
+    AL2023_x86_64_NEURON       = "al2023"
+    AL2023_x86_64_NVIDIA       = "al2023"
   }
 
   user_data_type = local.ami_type_to_user_data_type[var.ami_type]
@@ -43,6 +45,8 @@ locals {
     WINDOWS_FULL_2022_x86_64   = "/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-${local.ssm_cluster_version}/image_id"
     AL2023_x86_64_STANDARD     = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/x86_64/standard/recommended/image_id"
     AL2023_ARM_64_STANDARD     = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/arm64/standard/recommended/image_id"
+    AL2023_x86_64_NEURON       = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/x86_64/neuron/recommended/image_id"
+    AL2023_x86_64_NVIDIA       = "/aws/service/eks/optimized-ami/${local.ssm_cluster_version}/amazon-linux-2023/x86_64/nvidia/recommended/image_id"
   }
 }
 

--- a/modules/self-managed-node-group/versions.tf
+++ b/modules/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/tests/eks-managed-node-group/README.md
+++ b/tests/eks-managed-node-group/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/tests/eks-managed-node-group/main.tf
+++ b/tests/eks-managed-node-group/main.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {}
 
 locals {
   name            = "ex-${replace(basename(path.cwd), "_", "-")}"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
   region          = "eu-west-1"
 
   vpc_cidr = "10.0.0.0/16"

--- a/tests/eks-managed-node-group/versions.tf
+++ b/tests/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/tests/fargate-profile/README.md
+++ b/tests/fargate-profile/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/tests/fargate-profile/main.tf
+++ b/tests/fargate-profile/main.tf
@@ -6,7 +6,7 @@ data "aws_availability_zones" "available" {}
 
 locals {
   name            = "ex-${basename(path.cwd)}"
-  cluster_version = "1.30"
+  cluster_version = "1.31"
   region          = "eu-west-1"
 
   vpc_cidr = "10.0.0.0/16"

--- a/tests/fargate-profile/versions.tf
+++ b/tests/fargate-profile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/tests/self-managed-node-group/README.md
+++ b/tests/self-managed-node-group/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
 
 ## Modules
 

--- a/tests/self-managed-node-group/main.tf
+++ b/tests/self-managed-node-group/main.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {}
 
 locals {
   name            = "ex-${replace(basename(path.cwd), "_", "-")}"
-  cluster_version = "1.29"
+  cluster_version = "1.31"
   region          = "eu-west-1"
 
   vpc_cidr = "10.0.0.0/16"
@@ -138,6 +138,7 @@ module "eks" {
       max_size     = 5
       desired_size = 2
 
+      ami_type             = "AL2_x86_64"
       bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
 
       use_mixed_instances_policy = true
@@ -172,7 +173,8 @@ module "eks" {
       max_size     = 7
       desired_size = 1
 
-      ami_id = data.aws_ami.eks_default.id
+      ami_id   = data.aws_ami.eks_default.id
+      ami_type = "AL2_x86_64"
 
       pre_bootstrap_user_data = <<-EOT
         export FOO=bar
@@ -213,6 +215,7 @@ module "eks" {
         max_size     = 2
         desired_size = 1
 
+        ami_type             = "AL2_x86_64"
         bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
 
         instance_type = null

--- a/tests/self-managed-node-group/versions.tf
+++ b/tests/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.70"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Description
- Add support for newly released AL2023 accelerated AMI types
- Update Kubernetes version to 1.31 throughout

## Motivation and Context
- New accelerated AMI variants based on AL2023

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
