### PR TITLE
fix: Configure public.ecr.aws password in provider

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -19,6 +19,11 @@ provider "helm" {
       args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
     }
   }
+  registry {
+    url      = "oci://public.ecr.aws/karpenter"
+    username = data.aws_ecrpublic_authorization_token.token.user_name
+    password = data.aws_ecrpublic_authorization_token.token.password
+  }
 }
 
 provider "kubectl" {
@@ -154,8 +159,6 @@ resource "helm_release" "karpenter" {
   namespace           = "kube-system"
   name                = "karpenter"
   repository          = "oci://public.ecr.aws/karpenter"
-  repository_username = data.aws_ecrpublic_authorization_token.token.user_name
-  repository_password = data.aws_ecrpublic_authorization_token.token.password
   chart               = "karpenter"
   version             = "1.0.6"
   wait                = false


### PR DESCRIPTION

## Description
This PR prevents `helm_release.karpenter` from being upgraded each time of `terraform apply` even when the `main.tf` is unchanged

## Motivation and Context
Currently `data.aws_ecrpublic_authorization_token` can invalidate `helm_release.karpenter` even when the `main.tf` is unchanged


## Breaking Changes
N/A

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
