### PR TITLE
fix: Set a correct default value for `irsa_namespace_service_accounts`

### DIFF
--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -142,7 +142,7 @@ variable "irsa_oidc_provider_arn" {
 variable "irsa_namespace_service_accounts" {
   description = "List of `namespace:serviceaccount`pairs to use in trust policy for IAM role for service accounts"
   type        = list(string)
-  default     = ["karpenter:karpenter"]
+  default     = ["${var.namespace}:${var.service_account}"]
 }
 
 variable "irsa_assume_role_condition_test" {


### PR DESCRIPTION
## Description
The default value of `irsa_namespace_service_accounts` does not match other settings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
