### PR TITLE
fix: Use dynamic partition data source to determine DNS suffix for Karpenter EC2 pass role permission

### DIFF
--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -195,7 +195,7 @@ data "aws_iam_policy_document" "v033" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = local.partition == "aws" ? ["ec2.amazonaws.com"] : ["ec2.amazonaws.com.cn"]
+      values   = ["ec2.${local.dns_suffix}"]
     }
   }
 
@@ -584,7 +584,7 @@ data "aws_iam_policy_document" "v1" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = local.partition == "aws" ? ["ec2.amazonaws.com"] : ["ec2.amazonaws.com.cn"]
+      values   = ["ec2.${local.dns_suffix}"]
     }
   }
 

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -195,7 +195,7 @@ data "aws_iam_policy_document" "v033" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["ec2.amazonaws.com"]
+      values   = local.partition == "aws" ? ["ec2.amazonaws.com"] : ["ec2.amazonaws.com.cn"]
     }
   }
 
@@ -584,7 +584,7 @@ data "aws_iam_policy_document" "v1" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["ec2.amazonaws.com"]
+      values   = local.partition == "aws" ? ["ec2.amazonaws.com"] : ["ec2.amazonaws.com.cn"]
     }
   }
 


### PR DESCRIPTION
## Description
Fix Karpenter module iam policy passrole to ec2 api bug. Related issue: #3190 

## Motivation and Context
The current iam:PassRole action condition only works for ec2.amazonaws.com, can't work for ec2.amazonaws.com.cn
If use karpenter module at AWS CN, it would throw the unauthorized error when Karpenter pods try to create new instances, the Karpenter iam role can't pass to Karpenter node iam role because of the ec2 api(ec2.amazonaws.com) is not correct.

- Resolves #3190
`
statement {
    sid       = "AllowPassingInstanceRole"
    resources = var.create_node_iam_role ? [aws_iam_role.node[0].arn] : [var.node_iam_role_arn]
    actions   = ["iam:PassRole"]

    condition {
      test     = "StringEquals"
      variable = "iam:PassedToService"
      values   = ["ec2.amazonaws.com"]
    }
  }
`


## Breaking Changes
No, it does not break backwards compatibility with the current major version.

## How Has This Been Tested?
- [Y] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [Y] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
