### PR TITLE
feat: Added configurable delay before addons creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_security_group.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [time_sleep.addon_delay](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.this](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_addon_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |
@@ -232,6 +233,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_entries"></a> [access\_entries](#input\_access\_entries) | Map of access entries to add to the cluster | `any` | `{}` | no |
+| <a name="input_addon_delay_duration"></a> [addon\_delay\_duration](#input\_addon\_delay\_duration) | Duration to wait after the EKS cluster has become active before creating the addons | `string` | `"0s"` | no |
 | <a name="input_attach_cluster_encryption_policy"></a> [attach\_cluster\_encryption\_policy](#input\_attach\_cluster\_encryption\_policy) | Indicates whether or not to attach an additional policy for the cluster IAM role to utilize the encryption key provided | `bool` | `true` | no |
 | <a name="input_authentication_mode"></a> [authentication\_mode](#input\_authentication\_mode) | The authentication mode for the cluster. Valid values are `CONFIG_MAP`, `API` or `API_AND_CONFIG_MAP` | `string` | `"API_AND_CONFIG_MAP"` | no |
 | <a name="input_bootstrap_self_managed_addons"></a> [bootstrap\_self\_managed\_addons](#input\_bootstrap\_self\_managed\_addons) | Indicates whether or not to bootstrap self-managed addons after the cluster has been created | `bool` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -538,6 +538,12 @@ variable "cluster_addons_timeouts" {
   default     = {}
 }
 
+variable "addon_delay_duration" {
+  description = "Duration to wait after the EKS cluster has become active before creating the addons"
+  type        = string
+  default     = "0s"
+}
+
 ################################################################################
 # EKS Identity Provider
 ################################################################################


### PR DESCRIPTION
## Description

Currently, even though the cluster status is active, the addon API is not completely ready yet. This causes retries and significant delays during addon creation, potentially negating the before_compute delay.

## Motivation and Context
when implementing vpc-cni custom networking, addon fails to create in the configured dataplane_wait_duration time interval, causing pods using host network. I opened a case with AWS support and they informed me that there is a 3 minutes delay between cluster marked as ACTIVE and addon VPI to be ready, without delay vpc-cni creation (or any add-on, but vpc-cni is critical) can take up to 20 minutes.

I left default to 0s, for those who do not use custom networking, but in my test suite I set it to 3 minutes and each time addon was created under 20 seconds

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
