### PR TITLE
fix: Coalesce local `resolve_conflicts_on_create_default` value to a boolean since default is `null`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -483,7 +483,7 @@ resource "aws_iam_policy" "cluster_encryption" {
 
 locals {
   # TODO - Set to `NONE` on next breaking change when default addons are disabled
-  resolve_conflicts_on_create_default = var.bootstrap_self_managed_addons ? "OVERWRITE" : "NONE"
+  resolve_conflicts_on_create_default = coalesce(var.bootstrap_self_managed_addons, true) ? "OVERWRITE" : "NONE"
 }
 
 data "aws_eks_addon_version" "this" {


### PR DESCRIPTION
## Description
- Coalesce local `resolve_conflicts_on_create_default` value to a boolean since default is `null`

## Motivation and Context
- Resolves #3220

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- reproduced in a local `locals {}` block
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
