### PR TITLE
fix: Avoid trying to attach the node role when Auto Mode nodepools are not specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_eks_cluster" "this" {
     content {
       enabled       = try(compute_config.value.enabled, null)
       node_pools    = local.auto_mode_enabled ? try(compute_config.value.node_pools, []) : null
-      node_role_arn = local.auto_mode_enabled ? try(compute_config.value.node_role_arn, aws_iam_role.eks_auto[0].arn, null) : null
+      node_role_arn = local.auto_mode_enabled && length(try(compute_config.value.node_pools, [])) > 0 ? try(compute_config.value.node_role_arn, aws_iam_role.eks_auto[0].arn, null) : null
     }
   }
 


### PR DESCRIPTION
## Description
- Avoid trying to attach the node role when Auto Mode nodepools are not specified

## Motivation and Context
- Resolves #3238

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
