### PR TITLE
fix: Auto Mode custom tag policy should apply to cluster role, not node role

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,14 +354,14 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_iam_openid_connect_provider.oidc_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.eks_auto_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.eks_auto](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.eks_auto](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.eks_auto_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.eks_auto_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -372,7 +372,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_eks_addon_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cni_ipv6_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eks_auto_custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.node_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
@@ -435,11 +435,11 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_dataplane_wait_duration"></a> [dataplane\_wait\_duration](#input\_dataplane\_wait\_duration) | Duration to wait after the EKS cluster has become active before creating the dataplane components (EKS managed node group(s), self-managed node group(s), Fargate profile(s)) | `string` | `"30s"` | no |
 | <a name="input_eks_managed_node_group_defaults"></a> [eks\_managed\_node\_group\_defaults](#input\_eks\_managed\_node\_group\_defaults) | Map of EKS managed node group default configurations | `any` | `{}` | no |
 | <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | Map of EKS managed node group definitions to create | `any` | `{}` | no |
+| <a name="input_enable_auto_mode_custom_tags"></a> [enable\_auto\_mode\_custom\_tags](#input\_enable\_auto\_mode\_custom\_tags) | Determines whether to enable permissions for custom tags resources created by EKS Auto Mode | `bool` | `true` | no |
 | <a name="input_enable_cluster_creator_admin_permissions"></a> [enable\_cluster\_creator\_admin\_permissions](#input\_enable\_cluster\_creator\_admin\_permissions) | Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry | `bool` | `false` | no |
 | <a name="input_enable_efa_support"></a> [enable\_efa\_support](#input\_enable\_efa\_support) | Determines whether to enable Elastic Fabric Adapter (EFA) support | `bool` | `false` | no |
 | <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Determines whether to create an OpenID Connect Provider for EKS to enable IRSA | `bool` | `true` | no |
 | <a name="input_enable_kms_key_rotation"></a> [enable\_kms\_key\_rotation](#input\_enable\_kms\_key\_rotation) | Specifies whether key rotation is enabled | `bool` | `true` | no |
-| <a name="input_enable_node_custom_tags_permissions"></a> [enable\_node\_custom\_tags\_permissions](#input\_enable\_node\_custom\_tags\_permissions) | Determines whether to enable permissions for custom tags for the EKS Auto node IAM role | `bool` | `true` | no |
 | <a name="input_enable_security_groups_for_pods"></a> [enable\_security\_groups\_for\_pods](#input\_enable\_security\_groups\_for\_pods) | Determines whether to add the necessary IAM permission policy for security groups for pods | `bool` | `true` | no |
 | <a name="input_fargate_profile_defaults"></a> [fargate\_profile\_defaults](#input\_fargate\_profile\_defaults) | Map of Fargate Profile default configurations | `any` | `{}` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Map of Fargate Profile definitions to create | `any` | `{}` | no |
@@ -467,7 +467,6 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_node_iam_role_name"></a> [node\_iam\_role\_name](#input\_node\_iam\_role\_name) | Name to use on the EKS Auto node IAM role created | `string` | `null` | no |
 | <a name="input_node_iam_role_path"></a> [node\_iam\_role\_path](#input\_node\_iam\_role\_path) | The EKS Auto node IAM role path | `string` | `null` | no |
 | <a name="input_node_iam_role_permissions_boundary"></a> [node\_iam\_role\_permissions\_boundary](#input\_node\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the EKS Auto node IAM role | `string` | `null` | no |
-| <a name="input_node_iam_role_policy_statements"></a> [node\_iam\_role\_policy\_statements](#input\_node\_iam\_role\_policy\_statements) | A list of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) - used for adding specific IAM permissions as needed | `any` | `[]` | no |
 | <a name="input_node_iam_role_tags"></a> [node\_iam\_role\_tags](#input\_node\_iam\_role\_tags) | A map of additional tags to add to the EKS Auto node IAM role created | `map(string)` | `{}` | no |
 | <a name="input_node_iam_role_use_name_prefix"></a> [node\_iam\_role\_use\_name\_prefix](#input\_node\_iam\_role\_use\_name\_prefix) | Determines whether the EKS Auto node IAM role name (`node_iam_role_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source | `any` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -563,6 +563,160 @@ resource "aws_iam_policy" "cluster_encryption" {
   tags = merge(var.tags, var.cluster_encryption_policy_tags)
 }
 
+data "aws_iam_policy_document" "custom" {
+  count = local.create_iam_role && var.enable_auto_mode_custom_tags ? 1 : 0
+
+  dynamic "statement" {
+    for_each = var.enable_auto_mode_custom_tags ? [1] : []
+
+    content {
+      sid = "Compute"
+      actions = [
+        "ec2:CreateFleet",
+        "ec2:RunInstances",
+        "ec2:CreateLaunchTemplate",
+      ]
+      resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:eks-cluster-name"
+        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
+      }
+
+      condition {
+        test     = "StringLike"
+        variable = "aws:RequestTag/eks:kubernetes-node-class-name"
+        values   = ["*"]
+      }
+
+      condition {
+        test     = "StringLike"
+        variable = "aws:RequestTag/eks:kubernetes-node-pool-name"
+        values   = ["*"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_auto_mode_custom_tags ? [1] : []
+
+    content {
+      sid = "Storage"
+      actions = [
+        "ec2:CreateVolume",
+        "ec2:CreateSnapshot",
+      ]
+      resources = [
+        "arn:${local.partition}:ec2:*:*:volume/*",
+        "arn:${local.partition}:ec2:*:*:snapshot/*",
+      ]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:eks-cluster-name"
+        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_auto_mode_custom_tags ? [1] : []
+
+    content {
+      sid       = "Networking"
+      actions   = ["ec2:CreateNetworkInterface"]
+      resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:eks-cluster-name"
+        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:kubernetes-cni-node-name"
+        values   = ["*"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_auto_mode_custom_tags ? [1] : []
+
+    content {
+      sid = "LoadBalancer"
+      actions = [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateRule",
+        "ec2:CreateSecurityGroup",
+      ]
+      resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:eks-cluster-name"
+        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_auto_mode_custom_tags ? [1] : []
+
+    content {
+      sid       = "ShieldProtection"
+      actions   = ["shield:CreateProtection"]
+      resources = ["*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:eks-cluster-name"
+        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_auto_mode_custom_tags ? [1] : []
+
+    content {
+      sid       = "ShieldTagResource"
+      actions   = ["shield:TagResource"]
+      resources = ["arn:${local.partition}:shield::*:protection/*"]
+
+      condition {
+        test     = "StringEquals"
+        variable = "aws:RequestTag/eks:eks-cluster-name"
+        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
+      }
+    }
+  }
+}
+
+resource "aws_iam_policy" "custom" {
+  count = local.create_iam_role && var.enable_auto_mode_custom_tags ? 1 : 0
+
+  name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  path        = var.iam_role_path
+  description = var.iam_role_description
+
+  policy = data.aws_iam_policy_document.custom[0].json
+
+  tags = merge(var.tags, var.iam_role_tags)
+}
+
+resource "aws_iam_role_policy_attachment" "custom" {
+  count = local.create_iam_role && var.enable_auto_mode_custom_tags ? 1 : 0
+
+  policy_arn = aws_iam_policy.custom[0].arn
+  role       = aws_iam_role.this[0].name
+}
+
 ################################################################################
 # EKS Addons
 ################################################################################
@@ -696,8 +850,6 @@ resource "aws_eks_identity_provider_config" "this" {
 locals {
   create_node_iam_role = local.create && var.create_node_iam_role && local.auto_mode_enabled
   node_iam_role_name   = coalesce(var.node_iam_role_name, "${var.cluster_name}-eks-auto")
-
-  create_node_iam_role_custom_policy = local.create_node_iam_role && (var.enable_node_custom_tags_permissions || length(var.node_iam_role_policy_statements) > 0)
 }
 
 data "aws_iam_policy_document" "node_assume_role_policy" {
@@ -748,158 +900,4 @@ resource "aws_iam_role_policy_attachment" "eks_auto_additional" {
 
   policy_arn = each.value
   role       = aws_iam_role.eks_auto[0].name
-}
-
-resource "aws_iam_role_policy_attachment" "eks_auto_custom" {
-  count = local.create_node_iam_role_custom_policy ? 1 : 0
-
-  policy_arn = aws_iam_policy.eks_auto_custom[0].arn
-  role       = aws_iam_role.eks_auto[0].name
-}
-
-data "aws_iam_policy_document" "eks_auto_custom" {
-  count = local.create_node_iam_role_custom_policy ? 1 : 0
-
-  dynamic "statement" {
-    for_each = var.enable_node_custom_tags_permissions ? [1] : []
-
-    content {
-      sid = "Compute"
-      actions = [
-        "ec2:CreateFleet",
-        "ec2:RunInstances",
-        "ec2:CreateLaunchTemplate",
-      ]
-      resources = ["*"]
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:eks-cluster-name"
-        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
-      }
-
-      condition {
-        test     = "StringLike"
-        variable = "aws:RequestTag/eks:kubernetes-node-class-name"
-        values   = ["*"]
-      }
-
-      condition {
-        test     = "StringLike"
-        variable = "aws:RequestTag/eks:kubernetes-node-pool-name"
-        values   = ["*"]
-      }
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.enable_node_custom_tags_permissions ? [1] : []
-
-    content {
-      sid = "Storage"
-      actions = [
-        "ec2:CreateVolume",
-        "ec2:CreateSnapshot",
-      ]
-      resources = [
-        "arn:${local.partition}:ec2:*:*:volume/*",
-        "arn:${local.partition}:ec2:*:*:snapshot/*",
-      ]
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:eks-cluster-name"
-        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
-      }
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.enable_node_custom_tags_permissions ? [1] : []
-
-    content {
-      sid       = "Networking"
-      actions   = ["ec2:CreateNetworkInterface"]
-      resources = ["*"]
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:eks-cluster-name"
-        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
-      }
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:kubernetes-cni-node-name"
-        values   = ["*"]
-      }
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.enable_node_custom_tags_permissions ? [1] : []
-
-    content {
-      sid = "LoadBalancer"
-      actions = [
-        "elasticloadbalancing:CreateLoadBalancer",
-        "elasticloadbalancing:CreateTargetGroup",
-        "elasticloadbalancing:CreateListener",
-        "elasticloadbalancing:CreateRule",
-        "ec2:CreateSecurityGroup",
-      ]
-      resources = ["*"]
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:eks-cluster-name"
-        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
-      }
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.enable_node_custom_tags_permissions ? [1] : []
-
-    content {
-      sid       = "ShieldProtection"
-      actions   = ["shield:CreateProtection"]
-      resources = ["*"]
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:eks-cluster-name"
-        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
-      }
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.enable_node_custom_tags_permissions ? [1] : []
-
-    content {
-      sid       = "ShieldTagResource"
-      actions   = ["shield:TagResource"]
-      resources = ["arn:${local.partition}:shield::*:protection/*"]
-
-      condition {
-        test     = "StringEquals"
-        variable = "aws:RequestTag/eks:eks-cluster-name"
-        values   = ["$${aws:PrincipalTag/eks:eks-cluster-name}"]
-      }
-    }
-  }
-}
-
-resource "aws_iam_policy" "eks_auto_custom" {
-  count = local.create_node_iam_role_custom_policy ? 1 : 0
-
-  name        = var.node_iam_role_use_name_prefix ? null : local.node_iam_role_name
-  name_prefix = var.node_iam_role_use_name_prefix ? "${local.node_iam_role_name}-" : null
-  path        = var.node_iam_role_path
-  description = var.node_iam_role_description
-
-  policy = data.aws_iam_policy_document.eks_auto_custom[0].json
-
-  tags = merge(var.tags, var.node_iam_role_tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -542,6 +542,12 @@ variable "dataplane_wait_duration" {
   default     = "30s"
 }
 
+variable "enable_auto_mode_custom_tags" {
+  description = "Determines whether to enable permissions for custom tags resources created by EKS Auto Mode"
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # EKS Addons
 ################################################################################
@@ -618,18 +624,6 @@ variable "node_iam_role_tags" {
   description = "A map of additional tags to add to the EKS Auto node IAM role created"
   type        = map(string)
   default     = {}
-}
-
-variable "enable_node_custom_tags_permissions" {
-  description = "Determines whether to enable permissions for custom tags for the EKS Auto node IAM role"
-  type        = bool
-  default     = true
-}
-
-variable "node_iam_role_policy_statements" {
-  description = "A list of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) - used for adding specific IAM permissions as needed"
-  type        = any
-  default     = []
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
- Auto Mode custom tag policy should apply to cluster role, not node role

## Motivation and Context
- Currently this is incorrect per https://docs.aws.amazon.com/eks/latest/userguide/auto-learn-iam.html#tag-prop and therefore instances fail to provision when custom tags are applied to a node class

## Breaking Changes
- Claiming this as a no since it never worked as intended. Yes, the policy will be destroyed and permissions removed from the node but those permissions were not being used for anything - they need to be applied to the cluster role

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
