### PR TITLE
fix: Use variable to enable EKS cluster creation with CONFIG_MAP authentication mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,12 +44,8 @@ resource "aws_eks_cluster" "this" {
   access_config {
     authentication_mode = var.authentication_mode
 
-    # See access entries below - this is a one time operation from the EKS API.
-    # Instead, we are hardcoding this to false and if users wish to achieve this
-    # same functionality, we will do that through an access entry which can be
-    # enabled or disabled at any time of their choosing using the variable
-    # var.enable_cluster_creator_admin_permissions
-    bootstrap_cluster_creator_admin_permissions = false
+    # The variable enable_cluster_creator_admin_permissions must be set to true to avoid an EKS error when creating a cluster using the CONFIG_MAP authentication mode.
+    bootstrap_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
   }
 
   dynamic "compute_config" {


### PR DESCRIPTION
## Description
Using `enable_cluster_creator_admin_permissions` variable for `bootstrap_cluster_creator_admin_permissions` in place of hard coded `false` value to support EKS cluster creation when authentication mode is `CONFIG_MAP` only. I think alternatively we can use API_AND_CONFIG_MAP, but this will take time for us to migrate our clusters and customers clusters. 
## Motivation and Context
It allows a user to create an EKS cluster when authentication mode is `CONFIG_MAP` only by using `bootstrap_cluster_creator_admin_permissions=true` . 
Without this value, the user will be facing the below error.
```
Error: creating EKS Cluster (k8s-dev-eks-xyz: operation error EKS: CreateCluster, https response error StatusCode: 400, RequestID: eec24135-0159-484f-b0d7-b5c5518b3cd5, InvalidParameterException: bootstrapClusterCreatorAdminPermissions must be true if cluster authentication mode is set to CONFIG_MAP
```
It fixes the following open issue. 
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3247 
## Breaking Changes
The default value for `bootstrap_cluster_creator_admin_permissions` variable is still `false`. So it doesn't break anything. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
