### PR TITLE
feat: Add node repair config to managed node group

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
 
@@ -326,7 +326,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
 

--- a/examples/eks-auto-mode/README.md
+++ b/examples/eks-auto-mode/README.md
@@ -25,13 +25,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/examples/eks-auto-mode/versions.tf
+++ b/examples/eks-auto-mode/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/examples/eks-hybrid-nodes/README.md
+++ b/examples/eks-hybrid-nodes/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.16 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.4 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.5 |
@@ -36,8 +36,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
-| <a name="provider_aws.remote"></a> [aws.remote](#provider\_aws.remote) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
+| <a name="provider_aws.remote"></a> [aws.remote](#provider\_aws.remote) | >= 5.83 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.16 |
 | <a name="provider_http"></a> [http](#provider\_http) | >= 3.4 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.5 |

--- a/examples/eks-hybrid-nodes/versions.tf
+++ b/examples/eks-hybrid-nodes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/eks-managed-node-group/eks-al2.tf
+++ b/examples/eks-managed-node-group/eks-al2.tf
@@ -7,10 +7,11 @@ module "eks_al2" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                = {}
-    eks-pod-identity-agent = {}
-    kube-proxy             = {}
-    vpc-cni                = {}
+    coredns                   = {}
+    eks-pod-identity-agent    = {}
+    kube-proxy                = {}
+    vpc-cni                   = {}
+    eks-node-monitoring-agent = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -27,6 +28,8 @@ module "eks_al2" {
       # This value is ignored after the initial creation
       # https://github.com/bryantbiggs/eks-desired-size-hack
       desired_size = 2
+
+      node_repair_config_enabled = true
     }
   }
 

--- a/examples/eks-managed-node-group/eks-al2.tf
+++ b/examples/eks-managed-node-group/eks-al2.tf
@@ -7,11 +7,10 @@ module "eks_al2" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                   = {}
-    eks-pod-identity-agent    = {}
-    kube-proxy                = {}
-    vpc-cni                   = {}
-    eks-node-monitoring-agent = {}
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+    vpc-cni                = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -28,8 +27,6 @@ module "eks_al2" {
       # This value is ignored after the initial creation
       # https://github.com/bryantbiggs/eks-desired-size-hack
       desired_size = 2
-
-      node_repair_config_enabled = true
     }
   }
 

--- a/examples/eks-managed-node-group/eks-al2023.tf
+++ b/examples/eks-managed-node-group/eks-al2023.tf
@@ -7,11 +7,10 @@ module "eks_al2023" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                   = {}
-    eks-pod-identity-agent    = {}
-    kube-proxy                = {}
-    vpc-cni                   = {}
-    eks-node-monitoring-agent = {}
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+    vpc-cni                = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -27,8 +26,6 @@ module "eks_al2023" {
       # This value is ignored after the initial creation
       # https://github.com/bryantbiggs/eks-desired-size-hack
       desired_size = 2
-
-      node_repair_config_enabled = true
 
       # This is not required - demonstrates how to pass additional configuration to nodeadm
       # Ref https://awslabs.github.io/amazon-eks-ami/nodeadm/doc/api/

--- a/examples/eks-managed-node-group/eks-al2023.tf
+++ b/examples/eks-managed-node-group/eks-al2023.tf
@@ -7,10 +7,11 @@ module "eks_al2023" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                = {}
-    eks-pod-identity-agent = {}
-    kube-proxy             = {}
-    vpc-cni                = {}
+    coredns                   = {}
+    eks-pod-identity-agent    = {}
+    kube-proxy                = {}
+    vpc-cni                   = {}
+    eks-node-monitoring-agent = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -26,6 +27,8 @@ module "eks_al2023" {
       # This value is ignored after the initial creation
       # https://github.com/bryantbiggs/eks-desired-size-hack
       desired_size = 2
+
+      node_repair_config_enabled = true
 
       # This is not required - demonstrates how to pass additional configuration to nodeadm
       # Ref https://awslabs.github.io/amazon-eks-ami/nodeadm/doc/api/

--- a/examples/eks-managed-node-group/eks-bottlerocket.tf
+++ b/examples/eks-managed-node-group/eks-bottlerocket.tf
@@ -7,11 +7,10 @@ module "eks_bottlerocket" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                   = {}
-    eks-pod-identity-agent    = {}
-    kube-proxy                = {}
-    vpc-cni                   = {}
-    eks-node-monitoring-agent = {}
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+    vpc-cni                = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -27,8 +26,6 @@ module "eks_bottlerocket" {
       # This value is ignored after the initial creation
       # https://github.com/bryantbiggs/eks-desired-size-hack
       desired_size = 2
-
-      node_repair_config_enabled = true
 
       # This is not required - demonstrates how to pass additional configuration
       # Ref https://bottlerocket.dev/en/os/1.19.x/api/settings/

--- a/examples/eks-managed-node-group/eks-bottlerocket.tf
+++ b/examples/eks-managed-node-group/eks-bottlerocket.tf
@@ -7,10 +7,11 @@ module "eks_bottlerocket" {
 
   # EKS Addons
   cluster_addons = {
-    coredns                = {}
-    eks-pod-identity-agent = {}
-    kube-proxy             = {}
-    vpc-cni                = {}
+    coredns                   = {}
+    eks-pod-identity-agent    = {}
+    kube-proxy                = {}
+    vpc-cni                   = {}
+    eks-node-monitoring-agent = {}
   }
 
   vpc_id     = module.vpc.vpc_id
@@ -26,6 +27,8 @@ module "eks_bottlerocket" {
       # This value is ignored after the initial creation
       # https://github.com/bryantbiggs/eks-desired-size-hack
       desired_size = 2
+
+      node_repair_config_enabled = true
 
       # This is not required - demonstrates how to pass additional configuration
       # Ref https://bottlerocket.dev/en/os/1.19.x/api/settings/

--- a/examples/eks-managed-node-group/versions.tf
+++ b/examples/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -94,15 +94,15 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
-| <a name="provider_aws.virginia"></a> [aws.virginia](#provider\_aws.virginia) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
+| <a name="provider_aws.virginia"></a> [aws.virginia](#provider\_aws.virginia) | >= 5.83 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.7 |
 
 ## Modules

--- a/examples/karpenter/versions.tf
+++ b/examples/karpenter/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/self-managed-node-group/versions.tf
+++ b/examples/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -64,13 +64,13 @@ module "eks_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 
@@ -170,7 +170,7 @@ module "eks_managed_node_group" {
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum number of instances/nodes | `number` | `0` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the EKS managed node group | `string` | `""` | no |
 | <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `list(any)` | `[]` | no |
-| <a name="input_node_repair_config_enabled"></a> [node\_repair\_config\_enabled](#input\_node\_repair\_config\_enabled) | Determines whether to enable the node auto repair feature. | `bool` | `false` | no |
+| <a name="input_node_repair_config"></a> [node\_repair\_config](#input\_node\_repair\_config) | The node auto repair configuration for the node group | <pre>object({<br/>    enabled = optional(bool, true)<br/>  })</pre> | `null` | no |
 | <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `{}` | no |
 | <a name="input_placement_group_az"></a> [placement\_group\_az](#input\_placement\_group\_az) | Availability zone where placement group is created (ex. `eu-west-1c`) | `string` | `null` | no |
 | <a name="input_placement_group_strategy"></a> [placement\_group\_strategy](#input\_placement\_group\_strategy) | The placement group strategy | `string` | `"cluster"` | no |

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -170,6 +170,7 @@ module "eks_managed_node_group" {
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum number of instances/nodes | `number` | `0` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the EKS managed node group | `string` | `""` | no |
 | <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Customize network interfaces to be attached at instance boot time | `list(any)` | `[]` | no |
+| <a name="input_node_repair_config_enabled"></a> [node\_repair\_config\_enabled](#input\_node\_repair\_config\_enabled) | Determines whether to enable the node auto repair feature. | `bool` | `false` | no |
 | <a name="input_placement"></a> [placement](#input\_placement) | The placement of the instance | `map(string)` | `{}` | no |
 | <a name="input_placement_group_az"></a> [placement\_group\_az](#input\_placement\_group\_az) | Availability zone where placement group is created (ex. `eu-west-1c`) | `string` | `null` | no |
 | <a name="input_placement_group_strategy"></a> [placement\_group\_strategy](#input\_placement\_group\_strategy) | The placement group strategy | `string` | `"cluster"` | no |

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -459,10 +459,10 @@ resource "aws_eks_node_group" "this" {
   }
 
   dynamic "node_repair_config" {
-    for_each = var.node_repair_config_enabled ? [1] : []
+    for_each = var.node_repair_config != null ? [var.node_repair_config] : []
 
     content {
-      enabled = var.node_repair_config_enabled
+      enabled = node_repair_config.value.enabled
     }
   }
 

--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -458,6 +458,14 @@ resource "aws_eks_node_group" "this" {
     }
   }
 
+  dynamic "node_repair_config" {
+    for_each = var.node_repair_config_enabled ? [1] : []
+
+    content {
+      enabled = var.node_repair_config_enabled
+    }
+  }
+
   timeouts {
     create = lookup(var.timeouts, "create", null)
     update = lookup(var.timeouts, "update", null)

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -468,10 +468,12 @@ variable "update_config" {
   }
 }
 
-variable "node_repair_config_enabled" {
-  description = "Determines whether to enable the node auto repair feature."
-  type        = bool
-  default     = false
+variable "node_repair_config" {
+  description = "The node auto repair configuration for the node group"
+  type = object({
+    enabled = optional(bool, true)
+  })
+  default = null
 }
 
 variable "timeouts" {

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -468,6 +468,12 @@ variable "update_config" {
   }
 }
 
+variable "node_repair_config_enabled" {
+  description = "Determines whether to enable the node auto repair feature."
+  type        = bool
+  default     = false
+}
+
 variable "timeouts" {
   description = "Create, update, and delete timeout configurations for the node group"
   type        = map(string)

--- a/modules/eks-managed-node-group/versions.tf
+++ b/modules/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/modules/fargate-profile/README.md
+++ b/modules/fargate-profile/README.md
@@ -29,13 +29,13 @@ module "fargate_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/modules/fargate-profile/versions.tf
+++ b/modules/fargate-profile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/modules/hybrid-node-role/README.md
+++ b/modules/hybrid-node-role/README.md
@@ -75,13 +75,13 @@ module "eks_hybrid_node_role" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/modules/hybrid-node-role/versions.tf
+++ b/modules/hybrid-node-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -86,13 +86,13 @@ module "karpenter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/modules/karpenter/versions.tf
+++ b/modules/karpenter/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -43,13 +43,13 @@ module "self_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/modules/self-managed-node-group/versions.tf
+++ b/modules/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -323,11 +323,11 @@ module "eks_managed_node_group" {
   force_update_version = try(each.value.force_update_version, var.eks_managed_node_group_defaults.force_update_version, null)
   instance_types       = try(each.value.instance_types, var.eks_managed_node_group_defaults.instance_types, null)
   labels               = try(each.value.labels, var.eks_managed_node_group_defaults.labels, null)
-
-  remote_access = try(each.value.remote_access, var.eks_managed_node_group_defaults.remote_access, {})
-  taints        = try(each.value.taints, var.eks_managed_node_group_defaults.taints, {})
-  update_config = try(each.value.update_config, var.eks_managed_node_group_defaults.update_config, local.default_update_config)
-  timeouts      = try(each.value.timeouts, var.eks_managed_node_group_defaults.timeouts, {})
+  node_repair_config   = try(each.value.node_repair_config, var.eks_managed_node_group_defaults.node_repair_config, null)
+  remote_access        = try(each.value.remote_access, var.eks_managed_node_group_defaults.remote_access, {})
+  taints               = try(each.value.taints, var.eks_managed_node_group_defaults.taints, {})
+  update_config        = try(each.value.update_config, var.eks_managed_node_group_defaults.update_config, local.default_update_config)
+  timeouts             = try(each.value.timeouts, var.eks_managed_node_group_defaults.timeouts, {})
 
   # User data
   platform                   = try(each.value.platform, var.eks_managed_node_group_defaults.platform, "linux")
@@ -356,8 +356,6 @@ module "eks_managed_node_group" {
   launch_template_description            = try(each.value.launch_template_description, var.eks_managed_node_group_defaults.launch_template_description, "Custom launch template for ${try(each.value.name, each.key)} EKS managed node group")
   launch_template_tags                   = try(each.value.launch_template_tags, var.eks_managed_node_group_defaults.launch_template_tags, {})
   tag_specifications                     = try(each.value.tag_specifications, var.eks_managed_node_group_defaults.tag_specifications, ["instance", "volume", "network-interface"])
-
-  node_repair_config_enabled = try(each.value.node_repair_config_enabled, var.eks_managed_node_group_defaults.node_repair_config_enabled, false)
 
   ebs_optimized           = try(each.value.ebs_optimized, var.eks_managed_node_group_defaults.ebs_optimized, null)
   key_name                = try(each.value.key_name, var.eks_managed_node_group_defaults.key_name, null)

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -357,6 +357,8 @@ module "eks_managed_node_group" {
   launch_template_tags                   = try(each.value.launch_template_tags, var.eks_managed_node_group_defaults.launch_template_tags, {})
   tag_specifications                     = try(each.value.tag_specifications, var.eks_managed_node_group_defaults.tag_specifications, ["instance", "volume", "network-interface"])
 
+  node_repair_config_enabled = try(each.value.node_repair_config_enabled, var.eks_managed_node_group_defaults.node_repair_config_enabled, false)
+
   ebs_optimized           = try(each.value.ebs_optimized, var.eks_managed_node_group_defaults.ebs_optimized, null)
   key_name                = try(each.value.key_name, var.eks_managed_node_group_defaults.key_name, null)
   disable_api_termination = try(each.value.disable_api_termination, var.eks_managed_node_group_defaults.disable_api_termination, null)

--- a/tests/eks-fargate-profile/README.md
+++ b/tests/eks-fargate-profile/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/tests/eks-fargate-profile/versions.tf
+++ b/tests/eks-fargate-profile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/tests/eks-hybrid-nodes/README.md
+++ b/tests/eks-hybrid-nodes/README.md
@@ -18,7 +18,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers

--- a/tests/eks-hybrid-nodes/versions.tf
+++ b/tests/eks-hybrid-nodes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/tests/eks-managed-node-group/README.md
+++ b/tests/eks-managed-node-group/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/tests/eks-managed-node-group/main.tf
+++ b/tests/eks-managed-node-group/main.tf
@@ -52,6 +52,9 @@ module "eks" {
     coredns = {
       most_recent = true
     }
+    eks-node-monitoring-agent = {
+      most_recent = true
+    }
     eks-pod-identity-agent = {
       before_compute = true
       most_recent    = true
@@ -287,6 +290,10 @@ module "eks" {
         http_tokens                 = "required"
         http_put_response_hop_limit = 2
         instance_metadata_tags      = "disabled"
+      }
+
+      node_repair_config = {
+        enabled = true
       }
 
       create_iam_role          = true

--- a/tests/eks-managed-node-group/versions.tf
+++ b/tests/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/tests/fast-addons/README.md
+++ b/tests/fast-addons/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/tests/fast-addons/versions.tf
+++ b/tests/fast-addons/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/tests/self-managed-node-group/README.md
+++ b/tests/self-managed-node-group/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.2 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.81 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.81 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
 
 ## Modules
 

--- a/tests/self-managed-node-group/versions.tf
+++ b/tests/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.81"
+      version = ">= 5.83"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add `node_repair_config_enabled` to `modules/eks-managed-node-group/main.tf`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes terraform-aws-modules/terraform-aws-eks#3249

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
