### PR TITLE
fix: Added Name Tag for EKS Nodes if using NOT Custom Launch Template

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -698,3 +698,13 @@ resource "aws_autoscaling_schedule" "this" {
   # Cron examples: https://crontab.guru/examples.html
   recurrence = try(each.value.recurrence, null)
 }
+
+resource "aws_autoscaling_group_tag" "nodes_group" {
+  count                  = var.use_custom_launch_template ? 0 : 1
+  autoscaling_group_name = aws_eks_node_group.this[0].resources[0].autoscaling_groups[0].name
+  tag {
+    key                 = "Name"
+    value               = "${var.name}-node"
+    propagate_at_launch = true
+  }
+}


### PR DESCRIPTION
Added Name tag to EKS Nodes if using EKS Native Launch Template otherwise no tag Name exist

## Description
Added Name tag to EKS Nodes if using EKS Native Launch Template otherwise no tag Name exist

## Motivation and Context
If  `var.use_custom_launch_templat=false`  EKS nodes doesn't have any Name Tags
In AWS Console nodes seen with empty Name.

## Breaking Changes
NO

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects

![image](https://github.com/user-attachments/assets/2ce12754-d890-4bcd-b1a6-21223cad8966)

