### PR TITLE
fix: Allow `"EC2"` access entry type for EKS Auto Mode custom node pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ locals {
           association_policy_arn              = pol_val.policy_arn
           association_access_scope_type       = pol_val.access_scope.type
           association_access_scope_namespaces = lookup(pol_val.access_scope, "namespaces", [])
-        } : k => v if !contains(["EC2", "EC2_LINUX", "EC2_WINDOWS", "FARGATE_LINUX", "HYBRID_LINUX"], lookup(entry_val, "type", "STANDARD")) },
+        } : k => v if !contains(["EC2_LINUX", "EC2_WINDOWS", "FARGATE_LINUX", "HYBRID_LINUX"], lookup(entry_val, "type", "STANDARD")) },
       )
     ]
   ])


### PR DESCRIPTION

While Creating Access entry for Self managed node role, we were getting below error as it seems EC2 type is in exception for policy attachment. Once I removed EC2 from exception condition, it started picking up Policy attachment and Access Entry got created. We need this for creating Access Entry for Node role in EKS Automode.

│ Error: Unsupported attribute
│ 
│   on .terraform/modules/eks/main.tf line 289, in resource "aws_eks_access_policy_association" "this":
│  289:   policy_arn    = each.value.association_policy_arn
│     ├────────────────
│     │ each.value is object with 3 attributes
│ 
│ This object does not have an attribute named "association_policy_arn".

## Description
I have removed EC2 from exception list of policy attachment. Once done, it start creating policy attachment for EC2 type access entry which is needed to create Access entry for Self managed Node role in EKS Automode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is required to create Access Entry for Node role in EKS Automode.

<!--- If it fixes an open issue, please link to the issue here. -->
unable to attach access policies to access entries of type EC2 #3274


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> 
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->

I have tested it with my EKS Automode cluster created through this EKS module and it created Access Entry Successfully.

<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
