### PR TITLE
fix: Supports setting `cluster_compute_config = null` or `cluster_compute_config.enabled = false`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_eks_cluster" "this" {
   }
 
   dynamic "compute_config" {
-    for_each = length(var.cluster_compute_config) > 0 ? [var.cluster_compute_config] : []
+    for_each = local.auto_mode_enabled ? [var.cluster_compute_config] : []
 
     content {
       enabled       = local.auto_mode_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,7 @@ variable "authentication_mode" {
 variable "cluster_compute_config" {
   description = "Configuration block for the cluster compute configuration"
   type        = any
+  nullable    = false
   default     = {}
 }
 


### PR DESCRIPTION
## Description

Couple logic issues around `cluster_compute_config` that this is addressing:

1. The logic around enabling Auto Mode is based on the value never being `null`, otherwise the `length()` function fails, so we use `nullable = false` in the variable definition so that a null value will be interpreted as an empty map (the default value).
2. The API will return an error if `compute_config.enabled` is set to `false`, when every other required option for auto mode is also not provided. So we just condition the block on `local.auto_mode_enabled` so the entire block is absent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #3307

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
