### PR TITLE
feat: Added variable for TLS messaging in SQS queue from karpenter submodule

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -119,6 +119,8 @@ module "karpenter" {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
 
+  # Used to enforce TLS messaging on SQS queue
+  queue_enforce_tls_messages = true
   tags = local.tags
 }
 

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -121,7 +121,7 @@ module "karpenter" {
 
   # Used to enforce TLS messaging on SQS queue
   queue_enforce_tls_messages = true
-  tags = local.tags
+  tags                       = local.tags
 }
 
 module "karpenter_disabled" {

--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -175,6 +175,7 @@ No modules.
 | <a name="input_queue_kms_master_key_id"></a> [queue\_kms\_master\_key\_id](#input\_queue\_kms\_master\_key\_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
 | <a name="input_queue_managed_sse_enabled"></a> [queue\_managed\_sse\_enabled](#input\_queue\_managed\_sse\_enabled) | Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys | `bool` | `true` | no |
 | <a name="input_queue_name"></a> [queue\_name](#input\_queue\_name) | Name of the SQS queue | `string` | `null` | no |
+| <a name="input_queue_enforce_tls_messages"></a> [queue\_enforce\_tls\_messages](#input\_queue\_enforce\_tls\_messages) | Enforces the SQS queue to use TLS messaging | `bool` | `false` | no |
 | <a name="input_rule_name_prefix"></a> [rule\_name\_prefix](#input\_rule\_name\_prefix) | Prefix used for all event bridge rules | `string` | `"Karpenter"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to associate with the Karpenter Pod Identity | `string` | `"karpenter"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -171,11 +171,11 @@ No modules.
 | <a name="input_node_iam_role_permissions_boundary"></a> [node\_iam\_role\_permissions\_boundary](#input\_node\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the IAM role | `string` | `null` | no |
 | <a name="input_node_iam_role_tags"></a> [node\_iam\_role\_tags](#input\_node\_iam\_role\_tags) | A map of additional tags to add to the IAM role created | `map(string)` | `{}` | no |
 | <a name="input_node_iam_role_use_name_prefix"></a> [node\_iam\_role\_use\_name\_prefix](#input\_node\_iam\_role\_use\_name\_prefix) | Determines whether the Node IAM role name (`node_iam_role_name`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_queue_enforce_tls_messages"></a> [queue\_enforce\_tls\_messages](#input\_queue\_enforce\_tls\_messages) | Enforces TLS messaging on the SQS queue | `bool` | `false` | no |
 | <a name="input_queue_kms_data_key_reuse_period_seconds"></a> [queue\_kms\_data\_key\_reuse\_period\_seconds](#input\_queue\_kms\_data\_key\_reuse\_period\_seconds) | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again | `number` | `null` | no |
 | <a name="input_queue_kms_master_key_id"></a> [queue\_kms\_master\_key\_id](#input\_queue\_kms\_master\_key\_id) | The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK | `string` | `null` | no |
 | <a name="input_queue_managed_sse_enabled"></a> [queue\_managed\_sse\_enabled](#input\_queue\_managed\_sse\_enabled) | Boolean to enable server-side encryption (SSE) of message content with SQS-owned encryption keys | `bool` | `true` | no |
 | <a name="input_queue_name"></a> [queue\_name](#input\_queue\_name) | Name of the SQS queue | `string` | `null` | no |
-| <a name="input_queue_enforce_tls_messages"></a> [queue\_enforce\_tls\_messages](#input\_queue\_enforce\_tls\_messages) | Enforces the SQS queue to use TLS messaging | `bool` | `false` | no |
 | <a name="input_rule_name_prefix"></a> [rule\_name\_prefix](#input\_rule\_name\_prefix) | Prefix used for all event bridge rules | `string` | `"Karpenter"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to associate with the Karpenter Pod Identity | `string` | `"karpenter"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -188,6 +188,31 @@ data "aws_iam_policy_document" "queue" {
       ]
     }
   }
+    dynamic "statement" {
+    for_each = var.queue_enforce_tls_messages ? [1] : []
+    content {
+      sid = "DenyNonTLS"
+      effect = "Deny"
+      actions= [
+        "sqs:SendMessage",
+        "sqs:ReceiveMessage"
+      ]
+      resources = [aws_sqs_queue.this[0].arn]
+      condition {
+        test     = "Bool"
+        variable = "aws:SecureTransport"
+        values = [
+          "false"
+        ]
+      }
+      principals {
+        type = "*"
+        identifiers = [
+          "*"
+        ]
+      }
+    }
+  }
 }
 
 resource "aws_sqs_queue_policy" "this" {

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -188,12 +188,12 @@ data "aws_iam_policy_document" "queue" {
       ]
     }
   }
-    dynamic "statement" {
+  dynamic "statement" {
     for_each = var.queue_enforce_tls_messages ? [1] : []
     content {
-      sid = "DenyNonTLS"
+      sid    = "DenyNonTLS"
       effect = "Deny"
-      actions= [
+      actions = [
         "sqs:SendMessage",
         "sqs:ReceiveMessage"
       ]

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -207,6 +207,12 @@ variable "queue_kms_data_key_reuse_period_seconds" {
   default     = null
 }
 
+variable "queue_enforce_tls_messages" {
+  description = "Enforces TLS messaging on the SQS queue"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Node IAM Role
 ################################################################################


### PR DESCRIPTION
## Description
Added a the bool variable queue_enforce_tls_messages for the karpenter submodule. It enforces the usage of TLS messaging in the SQS queue

## Motivation and Context
I, like many of the users of this modules use them in a work environment. This change helps reaching compliance for security requirements in a corporative environment, allowing the SQS policy to only allow TLS messages in the queue

## Breaking Changes
This change is not a breaking change, as it only introduces a not required variable, by default set as false.

## How Has This Been Tested?
- [ x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I deployed the changes on my own deployment of the karpenter submodule. Then tested it by launching a plan on the example folder.
- [ x] I have executed `pre-commit run -a` on my pull request
