### PR TITLE
Fix cluster security group tags after security_group update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -194,7 +194,7 @@ resource "aws_ec2_tag" "cluster_primary_security_group" {
     k => v if local.create && k != "Name" && var.create_cluster_primary_security_group_tags
   }
 
-  resource_id = aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
+  resource_id = local.cluster_security_group_id
   key         = each.key
   value       = each.value
 }


### PR DESCRIPTION
## Description
Use local.cluster_security_group_id instead aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id to refer to the actual cluster security group used by the cluster

## Motivation and Context
We had a cluster up an running and we decided to change the naming of the cluster security groups:
As a side effect aws_eks_cluster kept the old security group reference in aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id and added the new security group id to additional security groups:
vpc_config {
        cluster_security_group_id = "sg-old"
        endpoint_private_access   = false
        endpoint_public_access    = true
        public_access_cidrs       = [
            "0.0.0.0/0",
        ]
        security_group_ids        = [
            "sg-new",
        ]
