### PR TITLE
Expand the module to configure secondary subnets before creating the worker nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,7 +189,7 @@ resource "aws_eks_cluster" "this" {
 }
 
 resource "kubectl_manifest" "eni_config" {
-  for_each = local.optional_pod_subnet_count > 0 ? zipmap(var.azs, slice(var.subnet_ids, local.eks_cluster_subnet_count, sum([local.eks_cluster_subnet_count, local.optional_pod_subnet_count]))) : {}
+  for_each = local.optional_pod_subnet_count > 0 ? zipmap(var.availability_zones, slice(var.subnet_ids, local.eks_cluster_subnet_count, sum([local.eks_cluster_subnet_count, local.optional_pod_subnet_count]))) : {}
 
   yaml_body = yamlencode({
     apiVersion = "crd.k8s.amazonaws.com/v1alpha1"

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,17 @@ variable "subnet_ids" {
   default     = []
 }
 
+variable "azs" {
+  description = "A list of availability zones in the region"
+  type        = list(string)
+}
+
+variable "secondary_subnet_ids" {
+  description = "Optional list of subnets to use for pods.If list is empty, pods will be placed in the subnet_ids subnets. Must be the length of the number of availability zones"
+  type        = list(string)
+  default     = []
+}
+
 variable "cluster_endpoint_private_access" {
   description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "azs" {
+variable "availability_zones" {
   description = "A list of availability zones in the region"
   type        = list(string)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "hashicorp/time"
       version = ">= 0.9"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.18"
+    }
   }
 }


### PR DESCRIPTION
## Description
Add the option to configure secondary subnets on the EKS cluster before creating the worker nodes

## Motivation and Context
This will enable the create cluster module to configure secondary subnets for pods per AWS standard process


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
