### PR TITLE
feat: Add capacity reservation permissions to Karpenter IAM policy

### DIFF
--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -361,6 +361,7 @@ data "aws_iam_policy_document" "v1" {
       "arn:${local.partition}:ec2:${local.region}::snapshot/*",
       "arn:${local.partition}:ec2:${local.region}:*:security-group/*",
       "arn:${local.partition}:ec2:${local.region}:*:subnet/*",
+      "arn:${local.partition}:ec2:${local.region}:*:capacity-reservation/*",
     ]
 
     actions = [


### PR DESCRIPTION
…pacity-reservation permission as part of Karpenter version 1.3.0

## Description
Karpenter version 1.3.0 now has a feature that allows for On Demand Capacity Reservation Support. The policy attached to the KarpenterController needs to be updated to allow this. More info can be found here: https://github.com/aws/karpenter-provider-aws/releases/tag/v1.3.0


## Motivation and Context
As part of this update, the AllowScopedEC2InstanceAccessActions policy needs to be updated to allow for Capacity Reservations to be made through Karpenter. Karpenter have updated their docs for this see - https://github.com/aws/karpenter-provider-aws/pull/7801/files

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
