### PR TITLE
feat: Allow Karpenter access to IAM:PassRole more than one node role arn

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -131,6 +131,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_entry_type"></a> [access\_entry\_type](#input\_access\_entry\_type) | Type of the access entry. `EC2_LINUX`, `FARGATE_LINUX`, or `EC2_WINDOWS`; defaults to `EC2_LINUX` | `string` | `"EC2_LINUX"` | no |
+| <a name="input_additional_node_iam_role_arns"></a> [additional\_node\_iam\_role\_arns](#input\_additional\_node\_iam\_role\_arns) | Additional node instance IAM role ARNs to allow Karpenter to pass | `list(string)` | `[]` | no |
 | <a name="input_ami_id_ssm_parameter_arns"></a> [ami\_id\_ssm\_parameter\_arns](#input\_ami\_id\_ssm\_parameter\_arns) | List of SSM Parameter ARNs that Karpenter controller is allowed read access (for retrieving AMI IDs) | `list(string)` | `[]` | no |
 | <a name="input_cluster_ip_family"></a> [cluster\_ip\_family](#input\_cluster\_ip\_family) | The IP family used to assign Kubernetes pod and service addresses. Valid values are `ipv4` (default) and `ipv6`. Note: If `ipv6` is specified, the `AmazonEKS_CNI_IPv6_Policy` must exist in the account. This policy is created by the EKS module with `create_cni_ipv6_iam_policy = true` | `string` | `"ipv4"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the EKS cluster | `string` | `""` | no |

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -189,7 +189,7 @@ data "aws_iam_policy_document" "v033" {
 
   statement {
     sid       = "AllowPassingInstanceRole"
-    resources = var.create_node_iam_role ? [aws_iam_role.node[0].arn] : [var.node_iam_role_arn]
+    resources = concat(var.create_node_iam_role ? [aws_iam_role.node[0].arn] : [var.node_iam_role_arn], var.additional_node_iam_role_arns)
     actions   = ["iam:PassRole"]
 
     condition {
@@ -579,7 +579,7 @@ data "aws_iam_policy_document" "v1" {
 
   statement {
     sid       = "AllowPassingInstanceRole"
-    resources = var.create_node_iam_role ? [aws_iam_role.node[0].arn] : [var.node_iam_role_arn]
+    resources = concat(var.create_node_iam_role ? [aws_iam_role.node[0].arn] : [var.node_iam_role_arn], var.additional_node_iam_role_arns)
     actions   = ["iam:PassRole"]
 
     condition {

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -283,6 +283,12 @@ variable "node_iam_role_tags" {
   default     = {}
 }
 
+variable "additional_node_iam_role_arns" {
+  description = "Additional node instance IAM role ARNs to allow Karpenter to pass"
+  type        = list(string)
+  default     = []
+}
+
 ################################################################################
 # Access Entry
 ################################################################################


### PR DESCRIPTION
## Description
Option to pass extra ARNs that can be used as instance profiles to Karpenter's policy.

## Motivation and Context
When creating a cluster with a mix of `Windows` and `Linux` nodes and using Access Entries we need two IAM Roles. One for the `Windows` instances that has an access entry of type `EC2_WINDOWS` and one for the `Linux` instances with an access entry of type `EC2_LINUX`.  

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
