### PR TITLE
docs: Set ami_type for AL2023 in the example

### DIFF
--- a/examples/eks-managed-node-group/eks-al2023.tf
+++ b/examples/eks-managed-node-group/eks-al2023.tf
@@ -20,6 +20,7 @@ module "eks_al2023" {
     example = {
       # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
       instance_types = ["m6i.large"]
+      ami_type       = "AL2023_x86_64_STANDARD"
 
       min_size = 2
       max_size = 5


### PR DESCRIPTION
Set AMI type explicitly   into user data type to be able to use cloudinit_pre_nodeadm 

https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/_user_data/main.tf#L33

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If I dont set ami_type       = "AL2023_x86_64_STANDARD",
cloudinit_pre_nodeadm is not configured for user-data 
it is used https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/modules/_user_data/main.tf#L19 and 
default ami_type is null in the examples

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
