### PR TITLE
fix: Enable cleaner and more robust compute_config variable for downstream module consumption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,12 +54,12 @@ resource "aws_eks_cluster" "this" {
   }
 
   dynamic "compute_config" {
-    for_each = length(var.cluster_compute_config) > 0 ? [var.cluster_compute_config] : []
+    for_each = local.auto_mode_enabled && length(try(var.cluster_compute_config.node_pools, [])) > 0 ? [var.cluster_compute_config] : []
 
     content {
-      enabled       = local.auto_mode_enabled
-      node_pools    = local.auto_mode_enabled ? try(compute_config.value.node_pools, []) : null
-      node_role_arn = local.auto_mode_enabled && length(try(compute_config.value.node_pools, [])) > 0 ? try(compute_config.value.node_role_arn, aws_iam_role.eks_auto[0].arn, null) : null
+      enabled       = true
+      node_pools    = var.cluster_compute_config.node_pools
+      node_role_arn = var.cluster_compute_config.node_role_arn
     }
   }
 


### PR DESCRIPTION
## Description
For the case where we are NOT using eks-auto mode, the previous for_each condition looks at length of var.cluster_compute_config, which is fine if we don't specify the variable cluster_compute_config. However, in the event if one needs to create a module referencing this module and makes an eks-auto toggle, this variable needs to be specified in the downstream module.

## Motivation and Context
By making this change, it is more robust and allows downstream consumer to make a module that works for both eks-auto and normal eks.

## Breaking Changes
No breaking change

## How Has This Been Tested?
- [x] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided examples/* projects
- [x] I have executed pre-commit run -a on my pull request

I have tested this in my environment, you could reproduce it by writing a new module to reference this eks module with the variable var.cluster_compute_config (type for each component needs to match).

In the new module:
```
module "eks" {
  cluster_compute_config = var.cluster_compute_config
  # everything else
}

variable "cluster_compute_config" {
  type = object({
    enabled = bool
    node_pools = list(string)
    node_role_arn = string
  })
  
  default = {
    enabled = false
    node_pools = []
    node_role_arn = ""
  }
```
### Examples to use this new module:
#### For enabling EKS auto:
```
module "eks-auto" {
  cluster_compute_config = {
    enabled = true
    node_pools = ["general-purpose"]
    node_role_arn = "NODE_ROLE_ARN"
   }
   # everything else
 }
}
```
#### For standard EKS (NOT EKS Auto)
You could ignore this variable and it will take the default variable value
