### PR TITLE
feat: add iam_policy_path var for aws_iam_policy.custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_enable_security_groups_for_pods"></a> [enable\_security\_groups\_for\_pods](#input\_enable\_security\_groups\_for\_pods) | Determines whether to add the necessary IAM permission policy for security groups for pods | `bool` | `true` | no |
 | <a name="input_fargate_profile_defaults"></a> [fargate\_profile\_defaults](#input\_fargate\_profile\_defaults) | Map of Fargate Profile default configurations | `any` | `{}` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Map of Fargate Profile definitions to create | `any` | `{}` | no |
+| <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | The IAM policy path | `string` | `null` | no |
 | <a name="input_iam_role_additional_policies"></a> [iam\_role\_additional\_policies](#input\_iam\_role\_additional\_policies) | Additional policies to be added to the IAM role | `map(string)` | `{}` | no |
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | Existing IAM role ARN for the cluster. Required if `create_iam_role` is set to `false` | `string` | `null` | no |
 | <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | Description of the role | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -703,7 +703,7 @@ resource "aws_iam_policy" "custom" {
 
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
   name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
-  path        = var.iam_role_path
+  path        = var.iam_policy_path
   description = var.iam_role_description
 
   policy = data.aws_iam_policy_document.custom[0].json

--- a/variables.tf
+++ b/variables.tf
@@ -475,6 +475,12 @@ variable "iam_role_use_name_prefix" {
   default     = true
 }
 
+variable "iam_policy_path" {
+  description = "The IAM policy path"
+  type        = string
+  default     = null
+}
+
 variable "iam_role_path" {
   description = "The IAM role path"
   type        = string


### PR DESCRIPTION
## Description
Add `iam_policy_path` var to set specific path for the custom policy.


## Motivation and Context
We want to set a policy path different from the role path.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
