### PR TITLE
fix: Use 'Bool' instead of 'StringEquals' for DenyHTTP queue policy

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -175,7 +175,7 @@ data "aws_iam_policy_document" "queue" {
     ]
     resources = [aws_sqs_queue.this[0].arn]
     condition {
-      test     = "StringEquals"
+      test     = "Bool"
       variable = "aws:SecureTransport"
       values = [
         "false"


### PR DESCRIPTION
## Description

This change fixes the `DenyHTTP` SQS queue policy used for Karpenter.
It replaces `StringEquals` test by `Bool` test. 

## Motivation and Context

Several SIEM tools are checking that TLS transit encryption is enabled in the SQS policy.
They are checking that there is a `Bool` condition on the `aws:SecureTransport` field set to `false`.
If the test is `StringEquals`, an issue is raised by the tool.
In addition, as stated in the example of AWS documentation, the valid test to use for aws:SecureTransport is: `Bool`
See example here: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html#Conditions_Boolean

## Breaking Changes
No.
It just follows the good AWS practices.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
Deployed the module in AWS and everything is OK.
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
