### PR TITLE
fix: API error when disabling EKS Auto Mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,9 +134,13 @@ resource "aws_eks_cluster" "this" {
     }
   }
 
-  storage_config {
-    block_storage {
-      enabled = local.auto_mode_enabled
+  dynamic "storage_config" {
+    for_each = length(var.cluster_compute_config) > 0 ? [var.cluster_compute_config] : []
+
+    content {
+      block_storage {
+        enabled = local.auto_mode_enabled
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Fixes the API error 400 when disabling the EKS Auto Mode

## Motivation and Context
When disabling the EKS Auto Mode, the AWS API is returning with a 400 error
```
│ Error: updating EKS Cluster (***) compute config: operation error EKS: UpdateClusterConfig, https response error StatusCode: 400, RequestID: 2a4498b9-8469-42e8-8712-b22c5a5930b2, InvalidParameterException: The type for cluster update was not provided.
│
│   with module.eks_cluster1.aws_eks_cluster.this[0],
│   on .terraform/stage/modules/eks_cluster1/main.tf line 35, in resource "aws_eks_cluster" "this":
│   35: resource "aws_eks_cluster" "this" {
````

Pending change from terroform apply:
```
  # module.eks_cluster1.aws_eks_cluster.this[0] will be updated in-place
  ~ resource "aws_eks_cluster" "this" {
        id                            = "stage-cluster1"
        name                          = "stage-cluster1"
        tags                          = {
            "terraform-aws-modules" = "eks"
        }
        # (12 unchanged attributes hidden)

      - storage_config {
          - block_storage {
              - enabled = false -> null
            }
        }

        # (7 unchanged blocks hidden)
    }
````
Looks like the change back to null is causing the API error 400, if its always set to false it works as intended

## Breaking Changes
Should not, as its the same approach like in compute_config

## How Has This Been Tested?
- Create a cluster with EKS Auto Mode enabled
- Disable the EKS Auto mode
