### PR TITLE
Add a comment to scaling_config desired_size for future readers

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -476,6 +476,8 @@ resource "aws_eks_node_group" "this" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
+      // If you are here, you may think this is strange or even a bug but it is intentional!
+      // For more context, check out https://github.com/bryantbiggs/eks-desired-size-hack
       scaling_config[0].desired_size,
     ]
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a code comment to the EKS managed node group scaling_config lifecycle policy hinting at why it exists

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Earlier this morning, I was caught out by the `desired_size` lifecycle issue. I had a skim through some issues, didn't see any immediately obvious issue titles and almost opened an issue despite thinking that surely the lifecycle ignore had to be intentional.

As a hint for future readers, I think it would be useful to leave a hint for anyone who runs into this caveat. Whether my wording is what you're after I'm happy to discuss but I think some sort of hint should be left there 🙂 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
N/A