### PR TITLE
fix: Allow for both `amazonaws.com.cn` and `amazonaws.com` conditions in PassRole as required for AWS CN

### DIFF
--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -195,7 +195,7 @@ data "aws_iam_policy_document" "v033" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = distinct(["ec2.${local.dns_suffix}", "ec2.amazonaws.com"])
+      values   = ["ec2.${local.dns_suffix}"]
     }
   }
 
@@ -585,7 +585,7 @@ data "aws_iam_policy_document" "v1" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["ec2.${local.dns_suffix}"]
+      values   = distinct(["ec2.${local.dns_suffix}", "ec2.amazonaws.com"])
     }
   }
 

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -195,7 +195,7 @@ data "aws_iam_policy_document" "v033" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["ec2.${local.dns_suffix}"]
+      values   = distinct(["ec2.${local.dns_suffix}", "ec2.amazonaws.com"])
     }
   }
 


### PR DESCRIPTION
## Description
AWS CN requires both service principals in the IAM policy passrole condition. Added ec2.amazonaws.com as a default principal.

## Motivation and Context
Fails to create EC2NodeClasses without this change in AWS CN

`{"level":"ERROR","time":"2025-07-17T09:48:10.169Z","logger":"controller","message":"Reconciler error","commit":"a2875e3","controller":"nodeclass.status","controllerGroup":"karpenter.k8s.aws","controllerKind":"EC2NodeClass","EC2NodeClass":{"name":"gpu"},"namespace":"","name":"gpu","reconcileID":"f6a8cdf5-e6c3-4329-bf32-fa1973febf1a","error":"creating instance profile, adding role \"staging-cn-nw-1-kpt-eks-node-group-20250716100915634200000001\" to instance profile \"staging-cn-nw-1-eks_14906149492098168839\", AccessDenied: User: arn:aws-cn:sts::XXX:assumed-role/KarpenterController-20250716132851685200000005/1752742098653173128 is not authorized to perform: iam:PassRole on resource: arn:aws-cn:iam::XXX:role/staging-cn-nw-1-kpt-eks-node-group-20250716100915634200000001 because no identity-based policy allows the iam:PassRole action\n\tstatus code: 403, request id: 0bce511a-7372-4cdb-9585-3415f44102bc"}`

Noted in issue #3389, and same fix applied in cloudformation for karpenter https://github.com/aws/karpenter-provider-aws/pull/6839


Resolves #3389

## How Has This Been Tested?
Applied to a new cluster in AWS CN cn-northwest-1 region.  
- [ ] I have executed `pre-commit run -a` on my pull request
