### PR TITLE
fix: Local enable_encryption_config still reads true even when toggled off

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ locals {
   role_arn = try(aws_iam_role.this[0].arn, var.iam_role_arn)
 
   create_outposts_local_cluster = var.outpost_config != null
-  enable_encryption_config      = length(var.encryption_config) > 0 && !local.create_outposts_local_cluster
+  enable_encryption_config      = var.encryption_config != {} && !local.create_outposts_local_cluster
 
   auto_mode_enabled = try(var.compute_config.enabled, false)
 }


### PR DESCRIPTION
Because encryption_config is now strictly defined as an object, count will never be <1 even if empty.

## Description
Addendum to previous PR... Changes enable_encryption_config to react to actual value of encryption_config rather than count since strict type object will always be >0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows enable_encryption_config to become false when encryption_config is {} as in previous versions.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No, restores backwards compatibility.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
