### PR TITLE
Improve upgrade docs v21.0

### DIFF
--- a/docs/UPGRADE-21.0.md
+++ b/docs/UPGRADE-21.0.md
@@ -120,6 +120,7 @@ If you find a bug, please open an issue with supporting configuration to reprodu
         - `cluster_addons` -> `addons`
         - `cluster_addons_timeouts` -> `addons_timeouts`
         - `cluster_identity_providers` -> `identity_providers`
+        - `fargate_profile_defaults` -> `fargate_profiles` - iam_role_additional_policies sub value was moved to same level as selectors under fargate_profiles
     - `eks-managed-node-group` sub-module
         - `cluster_version` -> `kubernetes_version`
     - `self-managed-node-group` sub-module


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add missing moved variable to the upgrade docs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensure that users have a simple time migrating to v21 by addressing why fargate_profile_defaults is reported as an invalid variable in v21.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
