### PR TITLE
fix: remove variable conflicts by making instance_type nullable

### DIFF
--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -437,7 +437,6 @@ variable "instance_type" {
   description = "The type of the instance to launch"
   type        = string
   default     = "m6i.large"
-  nullable    = false
 }
 
 variable "key_name" {


### PR DESCRIPTION
## Description
Made instance_type nullable in the self-managed-node-groups module

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3453

## Breaking Changes
N/A

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->


When making the change in this PR the following code works.
```HCL
<...>
      instance_type = null
      instance_requirements = {
        vcpu_count = {
          min = 2
        }
        memory_mib = {
          min = 8192
        }
        instance_generations = ["current", "previous"]
      }
<...>
```
