### PR TITLE
fix: Allow `instance_requirements` to be set in self-managed node groups

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -321,7 +321,7 @@ resource "aws_launch_template" "this" {
     }
   }
 
-  instance_type = var.instance_type
+  instance_type = var.instance_requirements != null ? null : var.instance_type
   kernel_id     = var.kernel_id
   key_name      = var.key_name
 

--- a/tests/self-managed-node-group/main.tf
+++ b/tests/self-managed-node-group/main.tf
@@ -164,7 +164,79 @@ module "eks" {
       }
     }
 
-    # Complete
+    instance_attributes = {
+      name = "instance-attributes"
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+
+      cloudinit_pre_nodeadm = [{
+        content      = <<-EOT
+          ---
+          apiVersion: node.eks.aws/v1alpha1
+          kind: NodeConfig
+          spec:
+            kubelet:
+              config:
+                shutdownGracePeriod: 30s
+        EOT
+        content_type = "application/node.eks.aws"
+      }]
+
+      instance_type = null
+
+      # launch template configuration
+      instance_requirements = {
+        cpu_manufacturers                           = ["intel"]
+        instance_generations                        = ["current", "previous"]
+        spot_max_price_percentage_over_lowest_price = 100
+
+        memory_mib = {
+          min = 8192
+        }
+
+        vcpu_count = {
+          min = 1
+        }
+
+        allowed_instance_types = ["t*", "m*"]
+      }
+
+      use_mixed_instances_policy = true
+      mixed_instances_policy = {
+        instances_distribution = {
+          on_demand_base_capacity                  = 0
+          on_demand_percentage_above_base_capacity = 0
+          on_demand_allocation_strategy            = "lowest-price"
+          spot_allocation_strategy                 = "price-capacity-optimized"
+        }
+
+        # ASG configuration
+        launch_template = {
+          override = [
+            {
+              instance_requirements = {
+                cpu_manufacturers                           = ["intel"]
+                instance_generations                        = ["current", "previous"]
+                spot_max_price_percentage_over_lowest_price = 100
+
+                memory_mib = {
+                  min = 8192
+                }
+
+                vcpu_count = {
+                  min = 1
+                }
+
+                allowed_instance_types = ["t*", "m*"]
+              }
+            }
+          ]
+        }
+      }
+    }
+
     complete = {
       name            = "complete-self-mng"
       use_name_prefix = false
@@ -208,73 +280,6 @@ module "eks" {
             encrypted             = true
             kms_key_id            = module.ebs_kms_key.key_arn
             delete_on_termination = true
-          }
-        }
-      }
-
-      instance_attributes = {
-        name = "instance-attributes"
-
-        min_size     = 1
-        max_size     = 2
-        desired_size = 1
-
-        bootstrap_extra_args = "--kubelet-extra-args '--node-labels=node.kubernetes.io/lifecycle=spot'"
-
-        cloudinit_pre_nodeadm = [{
-          content      = <<-EOT
-          ---
-          apiVersion: node.eks.aws/v1alpha1
-          kind: NodeConfig
-          spec:
-            kubelet:
-              config:
-                shutdownGracePeriod: 30s
-        EOT
-          content_type = "application/node.eks.aws"
-        }]
-
-        instance_type = null
-
-        # launch template configuration
-        instance_requirements = {
-          cpu_manufacturers                           = ["intel"]
-          instance_generations                        = ["current", "previous"]
-          spot_max_price_percentage_over_lowest_price = 100
-
-          vcpu_count = {
-            min = 1
-          }
-
-          allowed_instance_types = ["t*", "m*"]
-        }
-
-        use_mixed_instances_policy = true
-        mixed_instances_policy = {
-          instances_distribution = {
-            on_demand_base_capacity                  = 0
-            on_demand_percentage_above_base_capacity = 0
-            on_demand_allocation_strategy            = "lowest-price"
-            spot_allocation_strategy                 = "price-capacity-optimized"
-          }
-
-          # ASG configuration
-          launch_template = {
-            override = [
-              {
-                instance_requirements = {
-                  cpu_manufacturers                           = ["intel"]
-                  instance_generations                        = ["current", "previous"]
-                  spot_max_price_percentage_over_lowest_price = 100
-
-                  vcpu_count = {
-                    min = 1
-                  }
-
-                  allowed_instance_types = ["t*", "m*"]
-                }
-              }
-            ]
           }
         }
       }


### PR DESCRIPTION
## Description
- Allow `instance_requirements` to be set in self-managed node groups
- Correct self-managed node group test case for `instance_requirements`; this was incorrectly indented under another node group in the example for a few years now 😅 

## Motivation and Context
- Resolves #3453
- Closes #3454

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
