### PR TITLE
fix: Add enable_data_source_optimizations variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,8 @@ data "aws_iam_session_context" "current" {
 locals {
   create = var.create && var.putin_khuylo
 
-  account_id = try(data.aws_caller_identity.current[0].account_id, "")
-  partition  = try(data.aws_partition.current[0].partition, "")
+  account_id = var.enable_data_source_optimizations ? try(data.aws_caller_identity.current[0].account_id, "") : ""
+  partition  = var.enable_data_source_optimizations ? try(data.aws_partition.current[0].partition, "") : ""
 
   role_arn = try(aws_iam_role.this[0].arn, var.iam_role_arn)
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "enable_data_source_optimizations" {
+  description = "Enable data source optimizations to reduce API calls."
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # Cluster
 ################################################################################


### PR DESCRIPTION
## Description
This PR addresses a regression introduced in v21.0.0 where the terraform-aws-eks module became incompatible with `depends_on`, breaking existing v20 user configurations with 'Invalid count argument' errors.

Rather than force some users to refactor their working infrastructure (without a migration path) for optimization gains they may not need, it gives users the choice to reduce the number of GET requests for `partition` and `account_id` across submodules.

## Motivation and Context 
Resolves #3440

## Breaking Changes
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
Tested with `examples/eks-managed-node-group`
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
