### PR TITLE
fix: Correct the timeouts handling for addons

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -785,9 +785,9 @@ resource "aws_eks_addon" "this" {
   service_account_role_arn    = each.value.service_account_role_arn
 
   timeouts {
-    create = try(coalesce(each.value.timeouts.create, var.addons_timeouts.create), null)
-    update = try(coalesce(each.value.timeouts.update, var.addons_timeouts.update), null)
-    delete = try(coalesce(each.value.timeouts.delete, var.addons_timeouts.delete), null)
+    create = try(each.value.timeouts.create, var.addons_timeouts.create, null)
+    update = try(each.value.timeouts.update, var.addons_timeouts.update, null)
+    delete = try(each.value.timeouts.delete, var.addons_timeouts.delete, null)
   }
 
   tags = merge(
@@ -830,9 +830,9 @@ resource "aws_eks_addon" "before_compute" {
   service_account_role_arn    = each.value.service_account_role_arn
 
   timeouts {
-    create = try(coalesce(each.value.timeouts.create, var.addons_timeouts.create), null)
-    update = try(coalesce(each.value.timeouts.update, var.addons_timeouts.update), null)
-    delete = try(coalesce(each.value.timeouts.delete, var.addons_timeouts.delete), null)
+    create = try(each.value.timeouts.create, var.addons_timeouts.create, null)
+    update = try(each.value.timeouts.update, var.addons_timeouts.update, null)
+    delete = try(each.value.timeouts.delete, var.addons_timeouts.delete, null)
   }
 
   tags = merge(


### PR DESCRIPTION
## Description
Solves the problem from #3479 by removing coalesce function

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
