### PR TITLE
fix: Correct metadata options loop condition due to variable definition defaults

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -224,7 +224,7 @@ resource "aws_launch_template" "this" {
   }
 
   dynamic "metadata_options" {
-    for_each = var.metadata_options != null ? [var.metadata_options] : []
+    for_each = [var.metadata_options]
 
     content {
       http_endpoint               = metadata_options.value.http_endpoint

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -342,7 +342,7 @@ resource "aws_launch_template" "this" {
   }
 
   dynamic "metadata_options" {
-    for_each = var.metadata_options != null ? [var.metadata_options] : []
+    for_each = [var.metadata_options]
 
     content {
       http_endpoint               = metadata_options.value.http_endpoint


### PR DESCRIPTION
## Description
- Correct metadata options loop condition due to variable definition defaults

## Motivation and Context
- Resolves #3482

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
