### PR TITLE
fix: Ensure module created security group is included on any network interfaces created

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -360,7 +360,7 @@ resource "aws_launch_template" "this" {
 
   update_default_version = var.update_launch_template_default_version
   user_data              = module.user_data.user_data
-  vpc_security_group_ids = length(local.network_interfaces) > 0 ? [] : var.vpc_security_group_ids
+  vpc_security_group_ids = length(local.network_interfaces) > 0 ? [] : local.security_group_ids
 
   tags = merge(
     var.tags,


### PR DESCRIPTION
## Description

Wrong security groups ids usage between vpc_security_group and network_interfaces.

## Motivation and Context

Because it use `vpc_security_group` variable so we don't have any solution to sent `cluster_primary_security_group` to network_interfaces except hard coding.

## Breaking Changes

Could be if developer rely on problem behavior

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects

<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->

- [ ] I have executed `pre-commit run -a` on my pull request

<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
