### PR TITLE
feat: Update Karpenter controller policy and permissions to match upstream project

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -297,7 +297,7 @@ resource "aws_iam_role_policy_attachment" "node" {
   for_each = { for k, v in merge(
     {
       AmazonEKSWorkerNodePolicy          = "${local.node_iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy"
-      AmazonEC2ContainerRegistryReadOnly = "${local.node_iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
+      AmazonEC2ContainerRegistryPullOnly = "${local.node_iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly"
     },
     local.ipv4_cni_policy,
     local.ipv6_cni_policy

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "controller" {
       "arn:${local.partition}:ec2:${local.region}:*:network-interface/*",
       "arn:${local.partition}:ec2:${local.region}:*:launch-template/*",
       "arn:${local.partition}:ec2:${local.region}:*:spot-instances-request/*",
+      "arn:${local.partition}:ec2:${local.region}:*:capacity-reservation/*"
     ]
     actions = [
       "ec2:RunInstances",
@@ -180,7 +181,6 @@ data "aws_iam_policy_document" "controller" {
     sid       = "AllowRegionalReadActions"
     resources = ["*"]
     actions = [
-      "ec2:DescribeCapacityReservations",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeImages",
       "ec2:DescribeInstances",
@@ -347,6 +347,12 @@ data "aws_iam_policy_document" "controller" {
     sid       = "AllowInstanceProfileReadActions"
     resources = ["arn:${local.partition}:iam::${local.account_id}:instance-profile/*"]
     actions   = ["iam:GetInstanceProfile"]
+  }
+
+  statement {
+    sid       = "AllowUnscopedInstanceProfileListAction"
+    resources = ["*"]
+    actions   = ["iam:ListInstanceProfiles"]
   }
 
   statement {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Karpenter supports for Capacity Reservation introduce a new IAM permissions, a previous PR resolved this but was missing the `ec2:DescribeCapacityReservations` permission.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To allow users use Karpenter with Capacity Reservation

Changes from the following upstream PRs:
- https://github.com/aws/karpenter-provider-aws/pull/7801
- https://github.com/aws/karpenter-provider-aws/pull/7963
- https://github.com/aws/karpenter-provider-aws/pull/8249


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
