### PR TITLE
fix: Allows disabling auto mode, as well as improves support for custom node pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_eks_cluster" "this" {
 
     content {
       enabled       = compute_config.value.enabled
-      node_pools    = compute_config.value.node_pools
+      node_pools    = compute_config.value.enabled ? compute_config.value.node_pools : []
       node_role_arn = compute_config.value.node_pools != null ? try(aws_iam_role.eks_auto[0].arn, compute_config.value.node_role_arn) : null
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_eks_cluster" "this" {
     content {
       enabled       = compute_config.value.enabled
       node_pools    = compute_config.value.enabled ? compute_config.value.node_pools : []
-      node_role_arn = compute_config.value.node_pools != null ? try(aws_iam_role.eks_auto[0].arn, compute_config.value.node_role_arn) : null
+      node_role_arn = compute_config.value.enabled ? (length(compute_config.value.node_pools) > 0 ? try(aws_iam_role.eks_auto[0].arn, compute_config.value.node_role_arn) : null) : null
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_eks_cluster" "this" {
   }
 
   dynamic "compute_config" {
-    for_each = var.compute_config != null ? [var.compute_config] : []
+    for_each = var.compute_config[*]
 
     content {
       enabled       = compute_config.value.enabled
@@ -81,7 +81,7 @@ resource "aws_eks_cluster" "this" {
 
     content {
       dynamic "elastic_load_balancing" {
-        for_each = local.auto_mode_enabled ? [1] : []
+        for_each = var.compute_config[*]
 
         content {
           enabled = local.auto_mode_enabled
@@ -148,7 +148,7 @@ resource "aws_eks_cluster" "this" {
   }
 
   dynamic "storage_config" {
-    for_each = local.auto_mode_enabled ? [1] : []
+    for_each = var.compute_config[*]
 
     content {
       block_storage {

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "compute_config" {
   description = "Configuration block for the cluster compute configuration"
   type = object({
     enabled       = optional(bool, false)
-    node_pools    = optional(list(string))
+    node_pools    = optional(list(string), [])
     node_role_arn = optional(string)
   })
   default = null


### PR DESCRIPTION
## Description
This change allows EKS Auto Mode to be disabled, after being enabled. It also allows the user to remove and re-add the built-in node pools, without recreating the entire cluster (this part requires aws provider v6.13.0, I can bump the module min version if desired).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Primary motivation is to be able to sucessfully disable auto mode. Currently this module can create a cluster with auto mode enabled, but cannot disable auto mode. This is because of a logic error in `elastic_load_balancing` and `storage_config`. Instead of removing the blocks entirely from the config as it currently does, the API requires that the blocks be present but set `enabled = false`.

Also, when disabling auto mode, the API requires that `compute_config.node_pools` be empty. Instead of requiring the user to set both `compute_config.enabled` and `compute_config.node_pools`, this changeset coerces the node pools to an empty list when the user sends `enabled` = false`.

And finally, when the user enables auto mode but wants to use custom node pools with the builtin node_role_arn, then `compute_config.node_role_arn` needs to be `null`.

Fixes #3273 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
