### PR TITLE
fix: Sync Karpenter IAM permissions with upstream

### DIFF
--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -181,6 +181,7 @@ data "aws_iam_policy_document" "controller" {
     sid       = "AllowRegionalReadActions"
     resources = ["*"]
     actions = [
+      "ec2:DescribeCapacityReservations",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeImages",
       "ec2:DescribeInstances",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Sync with Karpenter upstream IAM permissions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Missing IAM permissions

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
