### PR TITLE
fix: Raise min supported version of AWS provider for EKS Auto Mode corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
@@ -355,7 +355,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 

--- a/examples/eks-auto-mode/README.md
+++ b/examples/eks-auto-mode/README.md
@@ -25,13 +25,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/examples/eks-auto-mode/versions.tf
+++ b/examples/eks-auto-mode/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/examples/eks-hybrid-nodes/README.md
+++ b/examples/eks-hybrid-nodes/README.md
@@ -26,7 +26,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.4 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.5 |
@@ -36,8 +36,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
-| <a name="provider_aws.remote"></a> [aws.remote](#provider\_aws.remote) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
+| <a name="provider_aws.remote"></a> [aws.remote](#provider\_aws.remote) | >= 6.15 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | >= 3.4 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.5 |

--- a/examples/eks-hybrid-nodes/versions.tf
+++ b/examples/eks-hybrid-nodes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/eks-managed-node-group/versions.tf
+++ b/examples/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/examples/karpenter/README.md
+++ b/examples/karpenter/README.md
@@ -94,15 +94,15 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
-| <a name="provider_aws.virginia"></a> [aws.virginia](#provider\_aws.virginia) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
+| <a name="provider_aws.virginia"></a> [aws.virginia](#provider\_aws.virginia) | >= 6.15 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 3.0 |
 
 ## Modules

--- a/examples/karpenter/versions.tf
+++ b/examples/karpenter/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/self-managed-node-group/versions.tf
+++ b/examples/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/modules/eks-managed-node-group/README.md
+++ b/modules/eks-managed-node-group/README.md
@@ -64,13 +64,13 @@ module "eks_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/modules/eks-managed-node-group/versions.tf
+++ b/modules/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/modules/fargate-profile/README.md
+++ b/modules/fargate-profile/README.md
@@ -29,13 +29,13 @@ module "fargate_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/modules/fargate-profile/versions.tf
+++ b/modules/fargate-profile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/modules/hybrid-node-role/README.md
+++ b/modules/hybrid-node-role/README.md
@@ -75,13 +75,13 @@ module "eks_hybrid_node_role" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/modules/hybrid-node-role/versions.tf
+++ b/modules/hybrid-node-role/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -86,13 +86,13 @@ module "karpenter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/modules/karpenter/versions.tf
+++ b/modules/karpenter/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/modules/self-managed-node-group/README.md
+++ b/modules/self-managed-node-group/README.md
@@ -43,13 +43,13 @@ module "self_managed_node_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/modules/self-managed-node-group/versions.tf
+++ b/modules/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/tests/eks-fargate-profile/README.md
+++ b/tests/eks-fargate-profile/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/tests/eks-fargate-profile/versions.tf
+++ b/tests/eks-fargate-profile/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/tests/eks-hybrid-nodes/README.md
+++ b/tests/eks-hybrid-nodes/README.md
@@ -18,7 +18,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers

--- a/tests/eks-hybrid-nodes/versions.tf
+++ b/tests/eks-hybrid-nodes/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/tests/eks-managed-node-group/README.md
+++ b/tests/eks-managed-node-group/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/tests/eks-managed-node-group/versions.tf
+++ b/tests/eks-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/tests/self-managed-node-group/README.md
+++ b/tests/self-managed-node-group/README.md
@@ -18,13 +18,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.15 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.15 |
 
 ## Modules
 

--- a/tests/self-managed-node-group/versions.tf
+++ b/tests/self-managed-node-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13"
+      version = ">= 6.15"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Description
- Raise min supported version of AWS provider for EKS Auto Mode corrections

## Motivation and Context
- Resolves #3273
- Resolves #3516
- Relates #3514

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
