### PR TITLE
fix: Ensure addons with before_compute are created before compute resources

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -382,6 +382,10 @@ module "eks_managed_node_group" {
     var.tags,
     each.value.tags,
   )
+
+  depends_on = [
+    aws_eks_addon.before_compute,
+  ]
 }
 
 ################################################################################
@@ -533,4 +537,8 @@ module "self_managed_node_group" {
     var.tags,
     each.value.tags,
   )
+
+  depends_on = [
+    aws_eks_addon.before_compute,
+  ]
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix issue described here: https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3525

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Addons with before_compute = true should be applied before any compute resources.

The modules module.eks_managed_node_group and module.self_managed_node_group should include a depends_on on the aws_eks_addon.before_compute resources.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
