### PR TITLE
mention change of behavior for `encryption_config` when upgrading to v21.

### DIFF
--- a/docs/UPGRADE-21.0.md
+++ b/docs/UPGRADE-21.0.md
@@ -32,6 +32,7 @@ If you find a bug, please open an issue with supporting configuration to reprodu
 - `addons.most_recent` is now set to `true` by default (was `false`).
 - `cluster_identity_providers.issuer_url` is now required to be set by users; the prior incorrect default has been removed. See https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3055 and https://github.com/kubernetes/kubernetes/pull/123561 for more details.
 - The OIDC issuer URL for IAM roles for service accounts (IRSA) has been changed to use the new dual stack`oidc-eks` endpoint instead of `oidc.eks`. This is to align with https://github.com/aws/containers-roadmap/issues/2038#issuecomment-2278450601
+- `encryption_config` (formerly `cluster_encryption_config`) is now enabled by default.  If you are migrating a cluster from v20 that used the previously disabled default and wish to preserve this same behavior, you will need to explicitly set this variable to `null`.  If using the new behavior is preferred when migrating you will additionally need to supply a value for the `encryption_config` [key_arn](../variables.tf#L174).
 
 ## Additional changes
 


### PR DESCRIPTION
## Description

adding notes about the change in behavior for `encryption_config` (formerly `cluster_encryption_config`) in the v21 upgrade guide.  

## Motivation and Context

previously this was disabled by default and has changed to be enabled by default, which will cause `plan` failures when trying to migrate existing clusters from v20 to v21.

related issues:
- [3469](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3469)
- [3450](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3450)
- [3435](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3435)

related PR discussions:
- [3524](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3524)
- [3438](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3438)
- [3439](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3439#issuecomment-3124562754)

## Breaking Changes

none.  just adding a line to the 21 upgrade guide.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

(not trying to ignore standards but this only adds to a markdown file.)
