### PR TITLE
feat: Add recommended security group rule for port `10251` to match EKS addon for `metrics-server`

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -128,7 +128,7 @@ locals {
     }
     # metrics-server, current EKS default port
     ingress_cluster_10251_webhook = {
-      description                   = "Cluster API to node 4443/tcp webhook"
+      description                   = "Cluster API to node 10251/tcp webhook"
       protocol                      = "tcp"
       from_port                     = 10251
       to_port                       = 10251


### PR DESCRIPTION
and add TODO note to remove the metrics-server legacy port 4443 on the next breaking change

## Description
metrics-server uses port 10251 as the default nowadays with the EKS provided bundle that can be installed as an addon. Port 4443 is the legacy port used by it in the past, but not anymore in the releases of the last 3 years. Addresses #3557.

## Motivation and Context
- Resolves #3557 

## Breaking Changes
no breaking change introduced, backwards compatible and just adding another recommended port to be added as a security rule. TODO note added to be considered for the next planned breaking change version bump at v22 to remove the legacy port security group rule then.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe how you tested your changes -->
tested with default metrics-server addon added to the list of addons, without passing any configuration changes

