### PR TITLE
docs: Fix typo in README.md regarding EKS Auto Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please note that we strive to provide a comprehensive suite of documentation for
 > }
 >```
 >
-> If you try to disable by simply removing the `compute_config` block, this will fail to disble EKS Auto Mode. Only after applying with `enabled = false` can you then remove the `compute_config` block from your configurations.
+> If you try to disable by simply removing the `compute_config` block, this will fail to disable EKS Auto Mode. Only after applying with `enabled = false` can you then remove the `compute_config` block from your configurations.
 
 ```hcl
 module "eks" {


### PR DESCRIPTION
## Description
Fix a simple typo in the README, disble into disable

## Motivation and Context
A small typo I noticed when going through the README
No open issue

## Breaking Changes
Not a breaking change

## How Has This Been Tested?
Simple typo in Readme, doesn't require running of the test suite
