### PR TITLE
add placement group outputs to managed node group module

### DIFF
--- a/modules/eks-managed-node-group/outputs.tf
+++ b/modules/eks-managed-node-group/outputs.tf
@@ -93,3 +93,23 @@ output "security_group_id" {
   description = "ID of the security group"
   value       = try(aws_security_group.this[0].id, null)
 }
+
+################################################################################
+# Placement Group
+################################################################################
+
+
+output "placement_group_id" {
+  description = "The ID of the created placement group"
+  value       = try(aws_placement_group.this[0].id, null)
+}
+
+output "placement_group_arn" {
+  description = "The ARN of the created placement group"
+  value       = try(aws_placement_group.this[0].arn, null)
+}
+
+output "placement_group_name" {
+  description = "The name of the created placement group"
+  value       = try(aws_placement_group.this[0].name, null)
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
add outputs for placement groups in managed node groups module.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
when creating a managed node group with efa, a placement group is created.
however when creating a capacity reservation, one wants to choose the placement group.
to do that we need to output the placement group from the managed node group modules.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
