### PR TITLE
fix(typo): node_iam_role_name description fix

### DIFF
--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -253,7 +253,7 @@ variable "cluster_ip_family" {
 }
 
 variable "node_iam_role_arn" {
-  description = "Existing IAM role ARN for the IAM instance profile. Required if `create_iam_role` is set to `false`"
+  description = "Existing IAM role ARN for the IAM instance profile. Required if `create_node_iam_role` is set to `false`"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description
typo fix - the description of the `node_iam_role_arn` var is wrong

## Motivation and Context
renders wrong documentation

## Breaking Changes
N/A

## How Has This Been Tested?
N/A