### PR TITLE
fix: Change partition due to dependency in terraform

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -1,13 +1,13 @@
 data "aws_partition" "current" {
-  count = var.create && var.partition == "" ? 1 : 0
+  count = var.create ? 1 : 0
 }
 data "aws_caller_identity" "current" {
-  count = var.create && var.account_id == "" ? 1 : 0
+  count = var.create ? 1 : 0
 }
 
 locals {
-  partition  = try(data.aws_partition.current[0].partition, var.partition)
-  account_id = try(data.aws_caller_identity.current[0].account_id, var.account_id)
+  partition  = try(data.aws_partition.current[0].partition, "")
+  account_id = try(data.aws_caller_identity.current[0].account_id, "")
 }
 
 ################################################################################

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -17,18 +17,6 @@ variable "region" {
   default     = null
 }
 
-variable "partition" {
-  description = "The AWS partition - pass through value to reduce number of GET requests from data sources"
-  type        = string
-  default     = ""
-}
-
-variable "account_id" {
-  description = "The AWS account ID - pass through value to reduce number of GET requests from data sources"
-  type        = string
-  default     = ""
-}
-
 ################################################################################
 # User Data
 ################################################################################

--- a/modules/fargate-profile/main.tf
+++ b/modules/fargate-profile/main.tf
@@ -4,15 +4,15 @@ data "aws_region" "current" {
   region = var.region
 }
 data "aws_partition" "current" {
-  count = var.create && var.partition == "" ? 1 : 0
+  count = var.create ? 1 : 0
 }
 data "aws_caller_identity" "current" {
-  count = var.create && var.account_id == "" ? 1 : 0
+  count = var.create ? 1 : 0
 }
 
 locals {
-  account_id = try(data.aws_caller_identity.current[0].account_id, var.account_id)
-  partition  = try(data.aws_partition.current[0].partition, var.partition)
+  account_id = try(data.aws_caller_identity.current[0].account_id, "")
+  partition  = try(data.aws_partition.current[0].partition, "")
   region     = try(data.aws_region.current[0].region, "")
 }
 

--- a/modules/fargate-profile/variables.tf
+++ b/modules/fargate-profile/variables.tf
@@ -18,18 +18,6 @@ variable "region" {
   default     = null
 }
 
-variable "partition" {
-  description = "The AWS partition - pass through value to reduce number of GET requests from data sources"
-  type        = string
-  default     = ""
-}
-
-variable "account_id" {
-  description = "The AWS account ID - pass through value to reduce number of GET requests from data sources"
-  type        = string
-  default     = ""
-}
-
 ################################################################################
 # IAM Role
 ################################################################################

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -1,13 +1,13 @@
 data "aws_partition" "current" {
-  count = var.create && var.partition == "" ? 1 : 0
+  count = var.create ? 1 : 0
 }
 data "aws_caller_identity" "current" {
-  count = var.create && var.account_id == "" ? 1 : 0
+  count = var.create ? 1 : 0
 }
 
 locals {
-  partition  = try(data.aws_partition.current[0].partition, var.partition)
-  account_id = try(data.aws_caller_identity.current[0].account_id, var.account_id)
+  partition  = try(data.aws_partition.current[0].partition, "")
+  account_id = try(data.aws_caller_identity.current[0].account_id, "")
 }
 
 ################################################################################

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -17,18 +17,6 @@ variable "region" {
   default     = null
 }
 
-variable "partition" {
-  description = "The AWS partition - pass through value to reduce number of GET requests from data sources"
-  type        = string
-  default     = ""
-}
-
-variable "account_id" {
-  description = "The AWS account ID - pass through value to reduce number of GET requests from data sources"
-  type        = string
-  default     = ""
-}
-
 ################################################################################
 # User Data
 ################################################################################

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -233,10 +233,6 @@ module "fargate_profile" {
 
   region = var.region
 
-  # Pass through values to reduce GET requests from data sources
-  partition  = local.partition
-  account_id = local.account_id
-
   # Fargate Profile
   cluster_name      = time_sleep.this[0].triggers["name"]
   cluster_ip_family = var.ip_family
@@ -277,10 +273,6 @@ module "eks_managed_node_group" {
   create = each.value.create
 
   region = var.region
-
-  # Pass through values to reduce GET requests from data sources
-  partition  = local.partition
-  account_id = local.account_id
 
   cluster_name       = time_sleep.this[0].triggers["name"]
   kubernetes_version = each.value.kubernetes_version != null ? each.value.kubernetes_version : time_sleep.this[0].triggers["kubernetes_version"]
@@ -405,10 +397,6 @@ module "self_managed_node_group" {
   create = each.value.create
 
   region = var.region
-
-  # Pass through values to reduce GET requests from data sources
-  partition  = local.partition
-  account_id = local.account_id
 
   cluster_name = time_sleep.this[0].triggers["name"]
 


### PR DESCRIPTION
## Description
Due to dependency between the terraform of eks and the managed node groups
managed node groups should be able to run on its own - while allowing running from the eks module

it seems that the change to allow this was breaking and this should allow the terraform to run correctly
this is the behavior in hybrid_node_role and karpenter submodules

## Motivation and Context
fixes this issue
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3604

## Breaking Changes
this shouldnt break anything since it uses the same partition and accunt

## How Has This Been Tested?
- [V ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ V] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request

