### PR TITLE
fix: Missing ec2:ModifyNetworkInterfaceAttribute permission in IPv6 CNI policy

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -37,7 +37,8 @@ data "aws_iam_policy_document" "cni_ipv6_policy" {
       "ec2:DescribeInstances",
       "ec2:DescribeTags",
       "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribeInstanceTypes"
+      "ec2:DescribeInstanceTypes",
+      "ec2:ModifyNetworkInterfaceAttribute"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Description

The current `AmazonEKS_CNI_IPv6_Policy` created by this module is missing the `ec2:ModifyNetworkInterfaceAttribute` permission, which causes the VPC CNI to log `UnauthorizedOperation` warnings during pod startup.

## Motivation and Context

The AWS-documented IPv6 CNI policy (https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy) only includes IPv6-specific permissions but omits ENI management permissions that the VPC CNI still requires even in IPv6 mode.

The VPC CNI calls `ec2:ModifyNetworkInterfaceAttribute` in two scenarios:
1. **Updating security groups on managed ENIs** - [refreshSGIDs function](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/pkg/awsutils/awsutils.go#L564-L586)
2. **Setting DeleteOnTermination flag on newly attached ENIs** - [AllocENI function](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/pkg/awsutils/awsutils.go#L873-L882)

Warning event logged on every new node:

`Unauthorized operation: failed to call ec2:ModifyNetworkInterfaceAttribute due to missing permissions. Please refer https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/iam-policy.md to attach relevant policy to IAM role`

## Breaking Changes

No breaking changes.

## How Has This Been Tested?

Tested on IPv6 EKS cluster running:
- EKS version: 1.34.1
- VPC CNI: v1.21.0
- Karpenter 1.8.2 for node provisioning

After applying the fix, the warnings disappeared and ENI attributes are properly managed.

- [x] I have executed `pre-commit run -a` on my pull request
