### PR TITLE
docs: add minimal EKS managed node group example

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,33 @@ module "eks" {
 }
 ```
 
+### Minimal Managed Node Group Example
+
+> This is a simple, beginner-friendly example of defining a managed node group with minimal configuration.
+
+```hcl
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.0"
+
+  name               = "my-eks-cluster"
+  kubernetes_version = "1.28"
+
+  vpc_id     = "vpc-xxxxxx"
+  subnet_ids = ["subnet-xxxxxx", "subnet-yyyyyy"]
+
+  eks_managed_node_groups = {
+    example = {
+      instance_types = ["t3.medium"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+  }
+}
+```
+
 ### Cluster Access Entry
 
 When enabling `authentication_mode = "API_AND_CONFIG_MAP"`, EKS will automatically create an access entry for the IAM role(s) used by managed node group(s) and Fargate profile(s). There are no additional actions required by users. For self-managed node groups and the Karpenter sub-module, this project automatically adds the access entry on behalf of users so there are no additional actions required by users.


### PR DESCRIPTION
## Description
Adds a minimal, beginner-friendly example of an EKS managed node group under the Node Groups section in README.md.  
This example shows only the required fields (min/max/desired size, instance type, subnets, cluster name) to help beginners get started quickly.


## Motivation and Context
The existing Node Groups example is comprehensive but can be overwhelming for beginners.  
This minimal example helps users understand the absolute essentials to create a managed node group.  
No issue linked; this is a documentation improvement.


## Breaking Changes
No breaking changes. Documentation only.


## How Has This Been Tested?
- [x] Documentation-only change. No module logic affected.
- [ ] N/A for examples/testing as this is README update.