### PR TITLE
fix: Eliminates depends_on in policy association using ref to access entry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -354,11 +354,7 @@ resource "aws_eks_access_policy_association" "this" {
   cluster_name = aws_eks_cluster.this[0].id
 
   policy_arn    = each.value.association_policy_arn
-  principal_arn = each.value.principal_arn
-
-  depends_on = [
-    aws_eks_access_entry.this,
-  ]
+  principal_arn = aws_eks_access_entry.this[each.value.entry_key].principal_arn
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

By using a reference to the `eks_access_entry` resource, we can eliminate the `depends_on` in the `aws_access_entry_policy_association` resource.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using `depends_on` is generally frowned on, and can cause odd errors for some terraform operations, especially resource recreating operations. In our case, we were running into problems when refactoring resulted in recreating access entries and policy associations for the same principal. Using a attribute ref helped terraform create the graph properly for more types of operations.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
