### PR TITLE
fix: Nullpointer in capability module if iam_role_policies is not set

### DIFF
--- a/modules/capability/main.tf
+++ b/modules/capability/main.tf
@@ -215,7 +215,7 @@ resource "aws_iam_role_policy_attachment" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional" {
-  for_each = { for k, v in var.iam_role_policies : k => v if local.create_iam_role_policy }
+  for_each = local.create_iam_role_policy ? var.iam_role_policies : {}
 
   role       = aws_iam_role.this[0].name
   policy_arn = each.value


### PR DESCRIPTION
## Description
If the optional variable `iam_role_policies` isn't set, none of the policy resources are supposed to be created. But there is a bug in the additional policy attachments resource (`aws_iam_role_policy_attachment.additional`) that produces a nullpointer if `iam_role_policies` is `null`. This PR updates the conditional in the `for_each` to use the same check as the other policy resources. It also removes the comprehension, as it is unnecessary.

## Motivation and Context
Without this fix, you can't create an EKS capability without providing `iam_role_policies`.
Several of the [existing examples](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/examples/eks-capabilities/main.tf) fails to plan due to this issue. I've tested all the examples using this branch instead, and the plan succeeds.

## Breaking Changes
This is not a breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
