### PR TITLE
feat: Add cluster_addon_vpc_cni output

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="output_access_policy_associations"></a> [access\_policy\_associations](#output\_access\_policy\_associations) | Map of eks cluster access policy associations created and their attributes |
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
+| <a name="output_cluster_addon_vpc_cni"></a> [cluster\_addon\_vpc\_cni](#output\_cluster\_addon\_vpc\_cni) | Attribute map for VPC-CNI EKS cluster addon |
 | <a name="output_cluster_addons"></a> [cluster\_addons](#output\_cluster\_addons) | Map of attribute maps for all EKS cluster addons enabled |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The Amazon Resource Name (ARN) of the cluster |
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |

--- a/outputs.tf
+++ b/outputs.tf
@@ -220,6 +220,11 @@ output "cluster_addons" {
   value       = merge(aws_eks_addon.this, aws_eks_addon.before_compute)
 }
 
+output "cluster_addon_vpc_cni" {
+  description = "Attribute map for VPC-CNI EKS cluster addon"
+  value       = try(aws_eks_addon.before_compute["vpc-cni"], null)
+}
+
 ################################################################################
 # EKS Identity Provider
 ################################################################################


### PR DESCRIPTION
to be able to use this event for creation of eniconfigs in custom networking usecases

related issues:
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3445
- https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2593

related docs:
- https://aws-ia.github.io/terraform-aws-eks-blueprints/snippets/vpc-cni-custom-networking/

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
