### PR TITLE
fix: Fix karpenter policy to set proper conditions to ec2 service in China

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -21,6 +21,7 @@ data "aws_service_principal" "ec2" {
 locals {
   account_id  = try(data.aws_caller_identity.current[0].account_id, "")
   ec2_sp_name = try(data.aws_service_principal.ec2[0].name, "")
+  dns_suffix  = data.aws_partition.current[0].dns_suffix
   partition   = try(data.aws_partition.current[0].partition, "")
   region      = try(data.aws_region.current[0].region, "")
 }

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -234,7 +234,7 @@ data "aws_iam_policy_document" "controller" {
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = distinct([local.ec2_sp_name, "ec2.amazonaws.com"])
+      values   = distinct(["ec2.${local.dns_suffix}", "ec2.amazonaws.com"])
     }
   }
 


### PR DESCRIPTION
Policy created for karpenter controller doesn't work for AWS China. The problem is inside controller's policy: https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v21.15.1/modules/karpenter/policy.tf#L237

Code contemplates adding ec2.amazonaws.com.cn when executing in China. The problem is that aws_service_principal is not working as expected. There's an open issue for it here: https://github.com/hashicorp/terraform-provider-aws/issues/46209 that I'm able to reproduce.

This PR fixes above issue.