### PR TITLE
fix: Avoid attempting to retrieve the AMI ID from SSM parameter if a custom AMI ID is provided

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -43,7 +43,7 @@ locals {
 
 data "aws_ssm_parameter" "ami" {
   # only pull the ami if we're creating the resource AND we're not already using a custom ami
-  count = var.create && length(var.ami_id) == 0 ? 1 : 0
+  count = var.create && var.ami_id == "" ? 1 : 0
 
   region = var.region
 
@@ -220,7 +220,7 @@ resource "aws_launch_template" "this" {
     arn = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].arn : var.iam_instance_profile_arn
   }
 
-  image_id                             = coalesce(var.ami_id, nonsensitive(try(data.aws_ssm_parameter.ami[0].value, "")))
+  image_id                             = var.ami_id == "" ? nonsensitive(data.aws_ssm_parameter.ami[0].value) : var.ami_id
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
 
   dynamic "instance_market_options" {

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -42,7 +42,8 @@ locals {
 }
 
 data "aws_ssm_parameter" "ami" {
-  count = var.create ? 1 : 0
+  # only pull the ami if we're creating the resource AND we're not already using a custom ami
+  count = var.create && length(var.ami_id) == 0 ? 1 : 0
 
   region = var.region
 
@@ -219,7 +220,7 @@ resource "aws_launch_template" "this" {
     arn = var.create_iam_instance_profile ? aws_iam_instance_profile.this[0].arn : var.iam_instance_profile_arn
   }
 
-  image_id                             = coalesce(var.ami_id, nonsensitive(data.aws_ssm_parameter.ami[0].value))
+  image_id                             = coalesce(var.ami_id, nonsensitive(try(data.aws_ssm_parameter.ami[0].value, "")))
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
 
   dynamic "instance_market_options" {


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

The ssm param for the recommended ami is not used if a custom ami is used. Also, if one wishes to use a custom ami with the older AL2 ami_type (uses bootstrap.sh for user_data in launch templates), retrieving the ssm param fails with k8s >= 1.33 due to the AL2 images being removed:

    Error: reading SSM Parameter (/aws/service/eks/optimized-ami/1.34/amazon-linux-2/recommended/image_id): couldn't find resource

Private-ref: https://tasks.opencraft.com/browse/BB-10631

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes using self managed node groups with Ubuntu AMIs.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

I don't believe this breaks backward compatibility.

## How Has This Been Tested?

I've tested this patch based on v20.37.2. Ideally we would backport it to the v20 release series, since we're using that at the moment and cannot update right now.



- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
