### PR TITLE
feat: Add ECR Public permissions to EKS Auto Mode node IAM role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -921,8 +921,9 @@ resource "aws_iam_role" "eks_auto" {
 # Policies attached ref https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
 resource "aws_iam_role_policy_attachment" "eks_auto" {
   for_each = { for k, v in {
-    AmazonEKSWorkerNodeMinimalPolicy   = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodeMinimalPolicy",
-    AmazonEC2ContainerRegistryPullOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly",
+    AmazonEKSWorkerNodeMinimalPolicy             = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodeMinimalPolicy",
+    AmazonEC2ContainerRegistryPullOnly           = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly",
+    AmazonElasticContainerRegistryPublicReadOnly = "${local.iam_role_policy_prefix}/AmazonElasticContainerRegistryPublicReadOnly",
   } : k => v if local.create_node_iam_role }
 
   policy_arn = each.value


### PR DESCRIPTION
## Description
Include permissions for authenticated container pulls from public ECR in the node roles used for EKS Auto clusters. 

## Motivation and Context
Without them, the pulls will still succeed, but they can be rate-limited, resulting in slow pod startup times.

## Breaking Changes
n/a

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
