### PR TITLE
fix: Revert "feat: Add ECR Public permissions to EKS Auto Mode node IAM role"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -921,9 +921,8 @@ resource "aws_iam_role" "eks_auto" {
 # Policies attached ref https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
 resource "aws_iam_role_policy_attachment" "eks_auto" {
   for_each = { for k, v in {
-    AmazonEKSWorkerNodeMinimalPolicy             = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodeMinimalPolicy",
-    AmazonEC2ContainerRegistryPullOnly           = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly",
-    AmazonElasticContainerRegistryPublicReadOnly = "${local.iam_role_policy_prefix}/AmazonElasticContainerRegistryPublicReadOnly",
+    AmazonEKSWorkerNodeMinimalPolicy   = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodeMinimalPolicy",
+    AmazonEC2ContainerRegistryPullOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly",
   } : k => v if local.create_node_iam_role }
 
   policy_arn = each.value


### PR DESCRIPTION
Reverts terraform-aws-modules/terraform-aws-eks#3665

This policy is not available in Govcloud partition and possibly others, roll this back for now.

Resolves #3666 