### PR TITLE
fix: Respect static placement group for EFA nodes (#3661)

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -696,7 +696,7 @@ resource "aws_iam_role_policy" "this" {
 ################################################################################
 
 locals {
-  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
+  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group) && try(var.placement.group_name, null) == null
 }
 
 resource "aws_placement_group" "this" {

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -952,7 +952,7 @@ resource "aws_iam_role_policy" "this" {
 ################################################################################
 
 locals {
-  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
+  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group) && try(var.placement.group_name, null) == null
 }
 
 resource "aws_placement_group" "this" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
when users enable EFA on their node groups, the module sticks to any static placement group names they've provided

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #3661

EFA's automatic placement group creation was overshadowing their explicit `var.placement` configuration. This PR skips generating the automatic EFA placement group if it detects that the user has supplied their own `var.placement.group_name`. This allows the existing fallback to pick up the user's string. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
\-

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
