### PR TITLE
fix(eks-managed-node-group): pass launch template name when ID is not provided

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -483,6 +483,7 @@ resource "aws_eks_node_group" "this" {
 
     content {
       id      = local.launch_template_id
+      name    = local.launch_template_id == null ? local.launch_template_name : null
       version = local.launch_template_version
     }
   }


### PR DESCRIPTION
## Description

When using a custom launch template specified by `launch_template_name` (with `create_launch_template = false` and `use_custom_launch_template = true`), EKS node group creation fails with:

```
InvalidParameterException: Either a launch template ID or a launch template name must be specified in the request.
```

The `launch_template` content block in `aws_eks_node_group` only sets `id`, which is `null` when the module doesn't create the launch template and the user doesn't provide `launch_template_id`. The AWS API requires either `id` or `name`.

This fix adds `name` to the `launch_template` content block as a fallback when `id` is not available.

## Reproduction

```hcl
module "eks" {
  source = "terraform-aws-modules/eks/aws"

  # ...

  eks_managed_node_groups = {
    test = {
      create_launch_template     = false
      use_custom_launch_template = true
      launch_template_name       = "my-existing-launch-template"
    }
  }
}
```

## Breaking Changes

None. When `id` is available (the common case), `name` is set to `null` and behavior is unchanged.

## How Has This Been Tested?

- [x] I have executed `pre-commit run -a` on my pull request

Fixes #3656