### PR TITLE
fix(eks-managed-node-group): respect user-provided placement group name

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -328,7 +328,7 @@ resource "aws_launch_template" "this" {
     content {
       affinity                = try(placement.value.affinity, null)
       availability_zone       = try(placement.value.availability_zone, null)
-      group_name              = try(aws_placement_group.this[0].name, placement.value.group_name)
+      group_name              = try(placement.value.group_name, aws_placement_group.this[0].name, null)
       host_id                 = try(placement.value.host_id, null)
       host_resource_group_arn = try(placement.value.host_resource_group_arn, null)
       partition_number        = try(placement.value.partition_number, null)
@@ -698,7 +698,7 @@ resource "aws_iam_role_policy" "this" {
 ################################################################################
 
 locals {
-  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
+  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group) && try(var.placement.group_name, null) == null
 }
 
 resource "aws_placement_group" "this" {


### PR DESCRIPTION
## Description

When a user provides a static `placement.group_name` (e.g., from an existing Capacity Reservation), the module ignores it because the `try()` order in the placement block prefers the auto-created placement group over the user-provided value.

This causes failures when using EFA with pre-existing placement groups tied to Capacity Reservations — the user cannot reference their static placement group.

### Changes

1. **Flip `try()` order** in the placement block (line 331): `try(placement.value.group_name, aws_placement_group.this[0].name, null)` — user-provided `group_name` now takes priority over the auto-created one.

2. **Skip auto-creating placement group** when user provides their own `group_name` via the `placement` variable: `create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group) && try(var.placement.group_name, null) == null`

### Reproduction

```hcl
module "eks" {
  source = "terraform-aws-modules/eks/aws"

  eks_managed_node_groups = {
    gpu = {
      enable_efa_support = true
      placement = {
        group_name = "my-existing-capacity-reservation-pg"
      }
      # ...
    }
  }
}
```

Previously, the user's `group_name` was silently overridden by the auto-created placement group.

## Breaking Changes

None. Existing configurations that don't provide `placement.group_name` are unaffected — auto-creation and the fallback still work.

## How Has This Been Tested?

- [x] I have executed `pre-commit run -a` on my pull request

Fixes #3661