### PR TITLE
fix: Prevent perpetual drift on OIDC thumbprint when root CA thumbprint is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -460,7 +460,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   count = local.create_oidc_provider ? 1 : 0
 
   client_id_list  = distinct(compact(concat(["sts.amazonaws.com"], var.openid_connect_audiences)))
-  thumbprint_list = concat(local.oidc_root_ca_thumbprint, var.custom_oidc_thumbprints)
+  thumbprint_list = length(local.oidc_root_ca_thumbprint) > 0 || length(var.custom_oidc_thumbprints) > 0 ? concat(local.oidc_root_ca_thumbprint, var.custom_oidc_thumbprints) : null
   url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 
   tags = merge(


### PR DESCRIPTION
## Description

When `include_oidc_root_ca_thumbprint` is set to `false` and no `custom_oidc_thumbprints` are provided, `thumbprint_list` resolves to an empty list `[]`. On apply, Terraform sets the empty list on the OIDC provider, but AWS auto-provisions a thumbprint for the provider. On the next `terraform plan`, Terraform detects the AWS-managed thumbprint and proposes to remove it — causing a **perpetual diff**:

```
  ~ resource "aws_iam_openid_connect_provider" "oidc_provider" {
      ~ thumbprint_list = [
          - "06b25927c42a721631c1efd9431e648fa62e1e39",
        ]
    }
```

### Fix

Set `thumbprint_list` to `null` when both `oidc_root_ca_thumbprint` and `custom_oidc_thumbprints` are empty. Per the [AWS provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider#thumbprint_list-1), when `thumbprint_list` is not set, the OIDC provider thumbprint is auto-managed by AWS and Terraform won't attempt to reconcile it.

When either source provides thumbprints, the existing `concat()` behavior is preserved.

### Reproduction

```hcl
module "eks" {
  source = "terraform-aws-modules/eks/aws"

  include_oidc_root_ca_thumbprint = false
  enable_irsa                     = true
  # ...
}
```

1. `terraform apply` — creates OIDC provider with empty thumbprint list
2. `terraform plan` — shows removal of AWS-managed thumbprint (perpetual drift)

## Breaking Changes

None. When `include_oidc_root_ca_thumbprint = true` (the default) or `custom_oidc_thumbprints` are provided, behavior is unchanged.

## How Has This Been Tested?

- [x] I have executed `pre-commit run -a` on my pull request

Fixes #3607
Related to #3586 (prior fix attempt, closed for lack of reproduction)