### PR TITLE
feat: Update Karpenter sub-module to support Karpenter `v1.11`

### DIFF
--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -274,6 +274,14 @@ locals {
         detail-type = ["EC2 Instance State-change Notification"]
       }
     }
+    capacity_reservation_interruption = {
+      name        = "CRInterruption"
+      description = "Karpenter interrupt - EC2 capacity reservation instance interruption warning"
+      event_pattern = {
+        source      = ["aws.ec2"]
+        detail-type = ["EC2 Capacity Reservation Instance Interruption Warning"]
+      }
+    }
   }
 }
 

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -9,6 +9,7 @@ data "aws_iam_policy_document" "controller" {
       "arn:${local.partition}:ec2:${local.region}:*:security-group/*",
       "arn:${local.partition}:ec2:${local.region}:*:subnet/*",
       "arn:${local.partition}:ec2:${local.region}:*:capacity-reservation/*",
+      "arn:${local.partition}:ec2:${local.region}:*:placement-group/*"
     ]
 
     actions = [
@@ -190,7 +191,8 @@ data "aws_iam_policy_document" "controller" {
       "ec2:DescribeLaunchTemplates",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeSpotPriceHistory",
-      "ec2:DescribeSubnets"
+      "ec2:DescribeSubnets",
+      "ec2:DescribePlacementGroups"
     ]
 
     condition {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR update the Karpenter module to support Karpenter v1.11

1. Update IAM policy permissions
2. Add new Event rule for Capacity Reservation interruption

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
