### PR TITLE
feat: Add Public ECR perms in aws partition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -920,10 +920,16 @@ resource "aws_iam_role" "eks_auto" {
 
 # Policies attached ref https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
 resource "aws_iam_role_policy_attachment" "eks_auto" {
-  for_each = { for k, v in {
-    AmazonEKSWorkerNodeMinimalPolicy   = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodeMinimalPolicy",
-    AmazonEC2ContainerRegistryPullOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly",
-  } : k => v if local.create_node_iam_role }
+  for_each = { for k, v in merge(
+    {
+      AmazonEKSWorkerNodeMinimalPolicy   = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodeMinimalPolicy",
+      AmazonEC2ContainerRegistryPullOnly = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryPullOnly",
+    },
+    # ECR Public is only available in the commercial partition
+    local.partition == "aws" ? {
+      AmazonElasticContainerRegistryPublicReadOnly = "${local.iam_role_policy_prefix}/AmazonElasticContainerRegistryPublicReadOnly",
+    } : {}
+  ) : k => v if local.create_node_iam_role }
 
   policy_arn = each.value
   role       = aws_iam_role.eks_auto[0].name


### PR DESCRIPTION
## Description
Update EKS Auto NodeRole configuration to also include ECR Public read permissions. These permissions are only applied in aws partition, since this policy (and ECR Public) are not available elsewhere.

## Motivation and Context
Without these permissions, the pulls will still succeed, but they can be rate-limited, resulting in slow pod startup times.

## Breaking Changes
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - ran `tofu plan` for eks-auto-mode example, validated: `arn:aws:iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly` was added. 
  - ran `tofu plan` for eks-auto-mode in region `us-gov-west-1`, validated corresponding policy was not added.
- [X] I have executed `pre-commit run -a` on my pull request