### PR TITLE
feat: Add support for standalone Pod Identity associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | [aws_eks_addon.before_compute](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster) | resource |
+| [aws_eks_pod_identity_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_identity_provider_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_identity_provider_config) | resource |
 | [aws_iam_openid_connect_provider.oidc_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_policy.cluster_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -548,6 +549,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="input_node_security_group_use_name_prefix"></a> [node\_security\_group\_use\_name\_prefix](#input\_node\_security\_group\_use\_name\_prefix) | Determines whether node security group name (`node_security_group_name`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_openid_connect_audiences"></a> [openid\_connect\_audiences](#input\_openid\_connect\_audiences) | List of OpenID Connect audience client IDs to add to the IRSA provider | `list(string)` | `[]` | no |
 | <a name="input_outpost_config"></a> [outpost\_config](#input\_outpost\_config) | Configuration for the AWS Outpost to provision the cluster on | <pre>object({<br/>    control_plane_instance_type = optional(string)<br/>    control_plane_placement = optional(object({<br/>      group_name = string<br/>    }))<br/>    outpost_arns = list(string)<br/>  })</pre> | `null` | no |
+| <a name="input_pod_identity_associations"></a> [pod\_identity\_associations](#input\_pod\_identity\_associations) | Map of EKS Pod Identity associations to create; map key is used as a friendly identifier | <pre>map(object({<br/>    namespace            = string<br/>    service_account      = string<br/>    role_arn             = string<br/>    disable_session_tags = optional(bool)<br/>    target_role_arn      = optional(string)<br/>    tags                 = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
 | <a name="input_prefix_separator"></a> [prefix\_separator](#input\_prefix\_separator) | The separator to use between the prefix and the generated timestamp for resource names | `string` | `"-"` | no |
 | <a name="input_putin_khuylo"></a> [putin\_khuylo](#input\_putin\_khuylo) | Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo! | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration | `string` | `null` | no |
@@ -611,6 +613,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="output_node_security_group_id"></a> [node\_security\_group\_id](#output\_node\_security\_group\_id) | ID of the node shared security group |
 | <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | The OpenID Connect identity provider (issuer URL without leading `https://`) |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider if `enable_irsa = true` |
+| <a name="output_pod_identity_associations"></a> [pod\_identity\_associations](#output\_pod\_identity\_associations) | Map of Pod Identity associations created and their attributes |
 | <a name="output_self_managed_node_groups"></a> [self\_managed\_node\_groups](#output\_self\_managed\_node\_groups) | Map of attribute maps for all self managed node groups created |
 | <a name="output_self_managed_node_groups_autoscaling_group_names"></a> [self\_managed\_node\_groups\_autoscaling\_group\_names](#output\_self\_managed\_node\_groups\_autoscaling\_group\_names) | List of the autoscaling group names created by self-managed node groups |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -849,6 +849,29 @@ resource "aws_eks_addon" "before_compute" {
 }
 
 ################################################################################
+# Pod Identity Association
+################################################################################
+
+resource "aws_eks_pod_identity_association" "this" {
+  for_each = local.create ? var.pod_identity_associations : {}
+
+  region = var.region
+
+  cluster_name    = aws_eks_cluster.this[0].id
+  namespace       = each.value.namespace
+  service_account = each.value.service_account
+  role_arn        = each.value.role_arn
+
+  disable_session_tags = each.value.disable_session_tags
+  target_role_arn      = each.value.target_role_arn
+
+  tags = merge(
+    var.tags,
+    each.value.tags,
+  )
+}
+
+################################################################################
 # EKS Identity Provider
 # Note - this is different from IRSA
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -221,6 +221,15 @@ output "cluster_addons" {
 }
 
 ################################################################################
+# Pod Identity Association
+################################################################################
+
+output "pod_identity_associations" {
+  description = "Map of Pod Identity associations created and their attributes"
+  value       = aws_eks_pod_identity_association.this
+}
+
+################################################################################
 # EKS Identity Provider
 ################################################################################
 

--- a/tests/self-managed-node-group/README.md
+++ b/tests/self-managed-node-group/README.md
@@ -92,6 +92,7 @@ No inputs.
 | <a name="output_node_security_group_id"></a> [node\_security\_group\_id](#output\_node\_security\_group\_id) | ID of the node shared security group |
 | <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | The OpenID Connect identity provider (issuer URL without leading `https://`) |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | The ARN of the OIDC Provider if `enable_irsa = true` |
+| <a name="output_pod_identity_associations"></a> [pod\_identity\_associations](#output\_pod\_identity\_associations) | Map of Pod Identity associations created and their attributes |
 | <a name="output_self_managed_node_groups"></a> [self\_managed\_node\_groups](#output\_self\_managed\_node\_groups) | Map of attribute maps for all self managed node groups created |
 | <a name="output_self_managed_node_groups_autoscaling_group_names"></a> [self\_managed\_node\_groups\_autoscaling\_group\_names](#output\_self\_managed\_node\_groups\_autoscaling\_group\_names) | List of the autoscaling group names created by self-managed node groups |
 <!-- END_TF_DOCS -->

--- a/tests/self-managed-node-group/main.tf
+++ b/tests/self-managed-node-group/main.tf
@@ -54,10 +54,14 @@ module "eks" {
     vpc-cni = {
       before_compute = true
       most_recent    = true
-      pod_identity_association = [{
-        role_arn        = module.aws_vpc_cni_ipv4_pod_identity.iam_role_arn
-        service_account = "aws-node"
-      }]
+    }
+  }
+
+  pod_identity_associations = {
+    vpc_cni = {
+      namespace       = "kube-system"
+      service_account = "aws-node"
+      role_arn        = module.aws_vpc_cni_ipv4_pod_identity.iam_role_arn
     }
   }
 

--- a/tests/self-managed-node-group/outputs.tf
+++ b/tests/self-managed-node-group/outputs.tf
@@ -185,6 +185,15 @@ output "cluster_addons" {
 }
 
 ################################################################################
+# Pod Identity Association
+################################################################################
+
+output "pod_identity_associations" {
+  description = "Map of Pod Identity associations created and their attributes"
+  value       = module.eks.pod_identity_associations
+}
+
+################################################################################
 # EKS Identity Provider
 ################################################################################
 

--- a/variables.tf
+++ b/variables.tf
@@ -672,6 +672,23 @@ variable "addons_timeouts" {
 }
 
 ################################################################################
+# Pod Identity Association
+################################################################################
+
+variable "pod_identity_associations" {
+  description = "Map of EKS Pod Identity associations to create; map key is used as a friendly identifier"
+  type = map(object({
+    namespace            = string
+    service_account      = string
+    role_arn             = string
+    disable_session_tags = optional(bool)
+    target_role_arn      = optional(string)
+    tags                 = optional(map(string), {})
+  }))
+  default = {}
+}
+
+################################################################################
 # EKS Identity Provider
 ################################################################################
 


### PR DESCRIPTION
## Summary

- Add `pod_identity_associations` variable for creating standalone `aws_eks_pod_identity_association` resources directly through the module
- Currently, pod identity associations are only supported as inline blocks within addon definitions — users who need pod identity for their own workloads must manage the resources outside the module
- Supports all resource arguments: `namespace`, `service_account`, `role_arn` (required), plus `disable_session_tags` and `target_role_arn` (optional) for session tag control and role chaining
- Follows existing module patterns (`access_entries` style): conditional creation via `local.create`, per-entry tags merged with module-level tags, ternary `for_each`

### Example usage

```hcl
module "eks" {
  source = "terraform-aws-modules/eks/aws"

  # ... cluster config ...

  pod_identity_associations = {
    vpc_cni = {
      namespace       = "kube-system"
      service_account = "aws-node"
      role_arn        = "arn:aws:iam::123456789012:role/vpc-cni-role"
    }
    external_secrets = {
      namespace       = "external-secrets"
      service_account = "external-secrets-sa"
      role_arn        = "arn:aws:iam::123456789012:role/external-secrets-role"
    }
  }
}
```

## Test plan

- [x] `terraform fmt` passes on all modified files
- [x] Updated `self-managed-node-group` test fixture to exercise the new standalone path
- [x] `eks-managed-node-group` test fixture continues to cover inline addon pod identity associations
- [x] README updated with new variable and output in the TF_DOCS section