### PR TITLE
feat: Update Karpenter sub-module to support Karpenter `v1.12`

### DIFF
--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -116,7 +116,6 @@ module "karpenter" {
   node_iam_role_use_name_prefix   = false
   node_iam_role_name              = local.name
   create_pod_identity_association = true
-  enable_zonal_shift              = true
 
   # Used to attach additional IAM policies to the Karpenter node IAM role
   node_iam_role_additional_policies = {

--- a/examples/karpenter/main.tf
+++ b/examples/karpenter/main.tf
@@ -116,6 +116,7 @@ module "karpenter" {
   node_iam_role_use_name_prefix   = false
   node_iam_role_name              = local.name
   create_pod_identity_association = true
+  enable_zonal_shift              = true
 
   # Used to attach additional IAM policies to the Karpenter node IAM role
   node_iam_role_additional_policies = {
@@ -155,6 +156,7 @@ resource "helm_release" "karpenter" {
       clusterName: ${module.eks.cluster_name}
       clusterEndpoint: ${module.eks.cluster_endpoint}
       interruptionQueue: ${module.karpenter.queue_name}
+      enableZonalShift: true
     webhook:
       enabled: false
     EOT

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -215,14 +215,10 @@ data "aws_iam_policy_document" "controller" {
     actions   = ["pricing:GetProducts"]
   }
 
-  dynamic "statement" {
-    for_each = var.enable_zonal_shift ? [1] : []
-
-    content {
-      sid       = "AllowZonalShiftReadActions"
-      resources = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
-      actions   = ["arc-zonal-shift:GetManagedResource"]
-    }
+  statement {
+    sid       = "AllowZonalShiftReadActions"
+    resources = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
+    actions   = ["arc-zonal-shift:GetManagedResource"]
   }
 
   dynamic "statement" {

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -190,6 +190,7 @@ data "aws_iam_policy_document" "controller" {
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplates",
       "ec2:DescribeSecurityGroups",
+      "ec2:DescribeInstanceStatus",
       "ec2:DescribeSpotPriceHistory",
       "ec2:DescribeSubnets",
       "ec2:DescribePlacementGroups"
@@ -212,6 +213,16 @@ data "aws_iam_policy_document" "controller" {
     sid       = "AllowPricingReadActions"
     resources = ["*"]
     actions   = ["pricing:GetProducts"]
+  }
+
+  dynamic "statement" {
+    for_each = var.enable_zonal_shift ? [1] : []
+
+    content {
+      sid       = "AllowZonalShiftReadActions"
+      resources = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
+      actions   = ["arc-zonal-shift:GetManagedResource"]
+    }
   }
 
   dynamic "statement" {

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -186,12 +186,6 @@ variable "enable_spot_termination" {
   default     = true
 }
 
-variable "enable_zonal_shift" {
-  description = "Determines whether to enable support for ARC Zonal Shift"
-  type        = bool
-  default     = false
-}
-
 variable "queue_name" {
   description = "Name of the SQS queue"
   type        = string

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -186,6 +186,12 @@ variable "enable_spot_termination" {
   default     = true
 }
 
+variable "enable_zonal_shift" {
+  description = "Determines whether to enable support for ARC Zonal Shift"
+  type        = bool
+  default     = false
+}
+
 variable "queue_name" {
   description = "Name of the SQS queue"
   type        = string


### PR DESCRIPTION
## Description

This PR updates the Karpenter module to support Karpenter v1.12.

1. Add `ec2:DescribeInstanceStatus` to the controller IAM policy (required for EC2 instance status health checks in the interruption controller)
2. Add `arc-zonal-shift:GetManagedResource` permission scoped to the EKS cluster ARN (supports ARC Zonal Shift)
3. Update Karpenter example to demonstrate zonal shift Helm configuration

## Motivation and Context

Karpenter v1.12.0 introduces two IAM-relevant changes per the [upgrade guide](https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-1120):

> **Upgrading to `1.12.0`**
>
> This version of Karpenter adds an additional IAM permission, `ec2:DescribeInstanceStatus`, for EC2 instance status health checks in the interruption controller. [...]
>
> This version also adds support for AWS Application Recovery Controller Zonal Shift. This capability is opt-in, disabled by default. You'll need to provision a new IAM permission, `arc-zonal-shift:GetManagedResource` [...] See the Zonal Shift Onboarding section of the Getting Started Guide for instructions on enabling zonal shift on new or existing clusters.

Both permissions are included unconditionally — the module provides full IAM permissions and users enable/disable features via the Karpenter controller's Helm values (`settings.enableZonalShift`). The `arc-zonal-shift:GetManagedResource` resource ARN is scoped to the specific EKS cluster, matching upstream's CloudFormation template.

## Breaking Changes

None. Both permissions are additive.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the `examples/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)