### PR TITLE
fix: Update karpenter zonal-shift policy

### DIFF
--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -217,8 +217,13 @@ data "aws_iam_policy_document" "controller" {
 
   statement {
     sid       = "AllowZonalShiftReadActions"
-    resources = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
+    resources = ["*"]
     actions   = ["arc-zonal-shift:GetManagedResource"]
+    condition {
+      test     = "StringEquals"
+      variable = "arc-zonal-shift:ResourceIdentifier"
+      values   = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
+    }
   }
 
   dynamic "statement" {


### PR DESCRIPTION
## Description

This PR updates the karpenter module to fix an IAM rights which was not working

https://github.com/terraform-aws-modules/terraform-aws-eks/pull/3690#issuecomment-4335178005

## Motivation and Context

As stated in AWS docs, an EKS cluster ARN is not supported. So I used the condition key `arc-zonal-shift:ResourceIdentifier`

https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonapplicationrecoverycontroller-zonalshift.html

## Breaking Changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
