### PR TITLE
docs: Correct variable names in FAQ documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,13 +23,13 @@ By default, EKS creates a cluster primary security group that is created outside
 ```hcl
   create_node_security_group = false # default is true
 
-  eks_managed_node_group = {
+  eks_managed_node_groups = {
     example = {
       attach_cluster_primary_security_group = true # default is false
     }
   }
   # Or for self-managed
-  self_managed_node_group = {
+  self_managed_node_groups = {
     example = {
       attach_cluster_primary_security_group = true # default is false
     }
@@ -39,13 +39,13 @@ By default, EKS creates a cluster primary security group that is created outside
 2. By not attaching the cluster primary security group. The cluster primary security group has quite broad access and the module has instead provided a security group with the minimum amount of access to launch an empty EKS cluster successfully and users are encouraged to open up access when necessary to support their workload.
 
 ```hcl
-  eks_managed_node_group = {
+  eks_managed_node_groups = {
     example = {
       attach_cluster_primary_security_group = true # default is false
     }
   }
   # Or for self-managed
-  self_managed_node_group = {
+  self_managed_node_groups = {
     example = {
       attach_cluster_primary_security_group = true # default is false
     }


### PR DESCRIPTION
## Description

The FAQ examples for `attach_cluster_primary_security_group` use the singular `eks_managed_node_group` / `self_managed_node_group` keys, but the module variables are `eks_managed_node_groups` / `self_managed_node_groups` (plural). Copy-pasting the snippet as-is errors out with `An argument named "eks_managed_node_group" is not expected here`.

## Motivation and Context

Aligns the snippets with the actual variable names declared in `variables.tf`.

## Breaking Changes

No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request