### PR TITLE
fix: Respect user-provided placement group name with EFA

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -328,7 +328,7 @@ resource "aws_launch_template" "this" {
     content {
       affinity                = try(placement.value.affinity, null)
       availability_zone       = try(placement.value.availability_zone, null)
-      group_name              = try(aws_placement_group.this[0].name, placement.value.group_name)
+      group_name              = try(placement.value.group_name, aws_placement_group.this[0].name)
       host_id                 = try(placement.value.host_id, null)
       host_resource_group_arn = try(placement.value.host_resource_group_arn, null)
       partition_number        = try(placement.value.partition_number, null)
@@ -698,7 +698,8 @@ resource "aws_iam_role_policy" "this" {
 ################################################################################
 
 locals {
-  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
+  # Don't create a placement group if user provides their own via var.placement.group_name
+  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group) && try(var.placement.group_name, null) == null
 }
 
 resource "aws_placement_group" "this" {


### PR DESCRIPTION
## Description

Fixes #3661

When using EFA with a pre-existing placement group (e.g., from a Capacity Reservation), the module would incorrectly:
1. Create a new placement group despite user providing an existing one
2. Ignore the user-provided `group_name` in favor of the auto-created one

## Use Case

Users with static Capacity Reservations have pre-existing placement groups that must be used. Currently, even when providing `var.placement.group_name`, the module creates a new placement group and uses that name instead.

## Changes

1. **Flip `try()` order in placement.group_name** - Prioritize user-provided `group_name` over auto-created placement group name
   ```hcl
   # Before
   group_name = try(aws_placement_group.this[0].name, placement.value.group_name)
   
   # After  
   group_name = try(placement.value.group_name, aws_placement_group.this[0].name)
   ```

2. **Don't create a placement group when user provides one** - Skip creating a new placement group when `var.placement.group_name` is provided
   ```hcl
   # Before
   create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
   
   # After
   create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group) && try(var.placement.group_name, null) == null
   ```

## Backward Compatibility

- If user doesn't provide `var.placement.group_name`, behavior is unchanged (module creates placement group if EFA enabled)
- If user provides `var.placement.group_name`, that name is used instead of creating a new placement group

## Example Usage After Fix

```hcl
module "eks_managed_node_group" {
  source = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"

  # EFA enabled
  enable_efa_support = true
  
  # Use existing placement group from Capacity Reservation
  placement = {
    group_name = "existing-capacity-reservation-pg"
  }
}
```