### PR TITLE
Omit public access CIDRs when the public endpoint is disabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,12 +75,28 @@ resource "aws_eks_cluster" "this" {
     }
   }
 
-  vpc_config {
-    security_group_ids      = compact(distinct(concat(var.additional_security_group_ids, [local.security_group_id])))
-    subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
-    endpoint_private_access = var.endpoint_private_access
-    endpoint_public_access  = var.endpoint_public_access
-    public_access_cidrs     = var.endpoint_public_access_cidrs
+  dynamic "vpc_config" {
+    for_each = var.endpoint_public_access ? [] : ["without-public_access_cidrs"]
+
+    content {
+      security_group_ids      = compact(distinct(concat(var.additional_security_group_ids, [local.security_group_id])))
+      subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
+      endpoint_private_access = var.endpoint_private_access
+      endpoint_public_access  = var.endpoint_public_access
+      public_access_cidrs     = var.endpoint_public_access_cidrs
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.endpoint_public_access ? ["with-public_access_cidrs"] : []
+
+    content {
+      security_group_ids      = compact(distinct(concat(var.additional_security_group_ids, [local.security_group_id])))
+      subnet_ids              = coalescelist(var.control_plane_subnet_ids, var.subnet_ids)
+      endpoint_private_access = var.endpoint_private_access
+      endpoint_public_access  = var.endpoint_public_access
+      public_access_cidrs     = var.endpoint_public_access_cidrs
+    }
   }
 
   dynamic "kubernetes_network_config" {


### PR DESCRIPTION
## Description
### Current Behavior

When the public endpoint is disabled, i.e. for security, the CIDR prefixes are still delivered to the AWS API in the `VpcConfigRequest` object even though [the property VpcConfigRequest.publicAccessCidrs](https://docs.aws.amazon.com/eks/latest/APIReference/API_VpcConfigRequest.html#AmazonEKS-Type-VpcConfigRequest-publicAccessCidrs) is optional.

This results in two security group rules for randomly-selected (by AWS) ports getting created in the default security group for the cluster that permit traffic from the CIDRs, i.e. `0.0.0.0/0`.

While there might be no service running on those ports, any public entity could brute-force search for the open security group rules by looking for a connection refusal response (as opposed to a timeout due to packets getting dropped). Knowing these security group rules enables sending arbitrary network traffic to the EKS network stack (although the packets are rejected if the public interface is disabled).

Currently, the only feasible way in downstream usage around the issue is to select a public IP address belonging to a reputable entity and then pass it thru as a `/32` in `publicAccessCidrs`.

### Desired Behavior

Because the argument [VpcConfigRequest.publicAccessCidrs](https://docs.aws.amazon.com/eks/latest/APIReference/API_VpcConfigRequest.html#AmazonEKS-Type-VpcConfigRequest-publicAccessCidrs) is optional, we can omit it when the public interface is disabled, so that EKS will not automatically create the unnecessary security group rules.

## Motivation and Context

This is (in the author's opinion) a sensible choice for the sake of security hardening, because the only alternative to picking a well-known /32 is to manually delete the security group rules, basically creating drift.

If a property is both optional and not necessary for a use case, it should be omitted in that case.

## Breaking Changes

This should not be a breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
