### PR TITLE
fix(karpenter): silence is_enabled deprecation warning in event_rules output : v21:20:0

### DIFF
--- a/modules/karpenter/outputs.tf
+++ b/modules/karpenter/outputs.tf
@@ -42,7 +42,7 @@ output "queue_url" {
 
 output "event_rules" {
   description = "Map of the event rules created and their attributes"
-  value       = aws_cloudwatch_event_rule.this
+  value       = { for k, v in aws_cloudwatch_event_rule.this : k => { arn = v.arn, id = v.id } }
 }
 
 ################################################################################


### PR DESCRIPTION
## Summary
Silences the Terraform AWS provider deprecation warning for `is_enabled` attribute on `aws_cloudwatch_event_rule` resources. ## Details
The warning was triggered because the `event_rules` output was exporting the entire CloudWatch event rule resource object, which caused Terraform to read the deprecated `is_enabled` attribute.
Changed the output to explicitly return only `arn` and `id` attributes instead of the full resource object, avoiding access to the deprecated field:
value = { for k, v in aws_cloudwatch_event_rule.this : k => { arn = v.arn, id = v.id } }
## Related Issue
Warning message:
The deprecation originates from module.karpenter...is_enabled is_enabled is deprecated. Use state instead.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
