### PR TITLE
feat(examples): Add Cilium CNI + Karpenter example with ENI native ro…

### DIFF
--- a/examples/cilium-with-karpenter/README.md
+++ b/examples/cilium-with-karpenter/README.md
@@ -1,0 +1,91 @@
+# Cilium + Karpenter Example
+
+Configuration in this directory creates an AWS EKS cluster with [Cilium](https://cilium.io/) as the CNI and [Karpenter](https://karpenter.sh/) for node provisioning.
+
+## Solving the CNI Bootstrap (Chicken-and-Egg) Problem
+
+EKS nodes will not reach `Ready` state until a CNI plugin is present on the node. Normally, `vpc-cni` handles this automatically. When replacing it with Cilium, a bootstrap ordering problem arises:
+
+- Cilium must be installed **before** nodes join, so nodes have a CNI binary on startup
+- But Helm requires a reachable API server with schedulable nodes to deploy
+
+This example solves it with three mechanisms working together:
+
+1. **Cilium is installed before any nodes join** — `helm_release.cilium` depends only on the EKS control plane (`module.eks`), not on any node group. With `wait = false`, Terraform does not block waiting for Cilium pods to be Running (there are no nodes yet to schedule them on).
+
+2. **Nodes are tainted at join time** — the managed node group applies the `node.cilium.io/agent-not-ready:NoExecute` taint via the launch template. This prevents any workload pods from being scheduled on a node until the Cilium agent DaemonSet pod is Running and removes the taint itself.
+
+3. **`nodeInit` writes the bootstrap marker** — Cilium's `nodeInit` component runs as an init container and writes `/tmp/cilium-bootstrap-time` to the node filesystem before the kubelet fully initializes, ensuring the CNI binary and config are in place before the node announces itself to the API server.
+
+The result: nodes join, find Cilium already registered in the cluster, become `Ready`, and Cilium removes the taint — all without manual intervention.
+
+## Cilium Configuration
+
+Cilium is configured in **ENI native routing mode** (`ipam.mode: eni`), which gives each pod a real AWS ENI IP address — no overlay, no tunneling. This mode requires the Cilium IAM policy attached to node instance roles.
+
+Additional features enabled in this example:
+- `kubeProxyReplacement: true` — Cilium replaces kube-proxy entirely using eBPF
+- Hubble observability with UI, relay, and metrics
+- Maglev load balancing
+- AWS prefix delegation for higher pod density
+
+## Usage
+
+```bash
+terraform init
+terraform plan
+terraform apply --auto-approve
+```
+
+Once the cluster is up:
+
+```bash
+# Update kubeconfig
+aws eks --region us-east-1 update-kubeconfig --name ex-karpenter-cilium
+
+# Verify Cilium is healthy
+kubectl -n kube-system exec ds/cilium -- cilium status
+
+# Deploy Karpenter NodeClass and NodePool
+kubectl apply -f karpenter.yaml
+
+# Deploy a test workload for Karpenter to provision nodes for
+kubectl apply -f inflate.yaml
+
+# Watch Karpenter logs
+kubectl logs -f -n kube-system -l app.kubernetes.io/name=karpenter -c controller
+```
+
+Verify Cilium is the active CNI and nodes are healthy:
+
+```bash
+kubectl get nodes -L karpenter.sh/registered
+kubectl get pods -n kube-system -l k8s-app=cilium
+```
+
+Expected output — Cilium agent Running on every node, no `aws-node` pods:
+
+```text
+NAME                                       READY   STATUS    NODE
+cilium-xxxxx                               1/1     Running   ip-10-0-x-x...
+cilium-xxxxx                               1/1     Running   ip-10-0-x-x...
+cilium-operator-xxxxx                      1/1     Running   ip-10-0-x-x...
+hubble-relay-xxxxx                         1/1     Running   ip-10-0-x-x...
+```
+
+### Tear Down & Clean-Up
+
+Remove Karpenter-provisioned nodes before destroying with Terraform:
+
+```bash
+kubectl delete deployment inflate
+# Wait for Karpenter to deprovision nodes
+kubectl get nodes --watch
+
+terraform destroy --auto-approve
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you no longer need them.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/examples/cilium-with-karpenter/cilium.tf
+++ b/examples/cilium-with-karpenter/cilium.tf
@@ -1,0 +1,69 @@
+variable "cilium_version" {
+  type    = string
+  default = "1.18.0"
+}
+
+variable "cilium_helm_repo" {
+  type    = string
+  default = "https://helm.cilium.io"
+
+}
+
+# ─── STEP 1: Cilium IAM Policy (no cluster dependency) ───────────────────────
+resource "aws_iam_policy" "aws_cilium_policy" {
+  name        = "${local.name}-cilium-policy"
+  description = "EKS Cilium policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceTypes",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:CreateNetworkInterface",
+          "ec2:AttachNetworkInterface",
+          "ec2:DetachNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:ModifyNetworkInterfaceAttribute",
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:UnassignPrivateIpAddresses",
+          "ec2:AssignIpv6Addresses",
+          "ec2:UnassignIpv6Addresses",
+          "ec2:CreateTags"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# ─── STEP 2: Cilium — installed BEFORE nodes join ────────────────────────────
+# Targets the control plane only. DaemonSet pods will be pending until
+# managed nodes join, but the CNI config is already present on the node
+# filesystem via the nodeInit bootstrap, so nodes become Ready immediately.
+resource "helm_release" "cilium" {
+  name       = "cilium"
+  namespace  = "kube-system"
+  chart      = "cilium"
+  version    = var.cilium_version
+  repository = var.cilium_helm_repo
+  wait       = false # ← CRITICAL: must be false, no nodes yet to schedule on
+
+  set = [
+    {
+      name  = "k8sServiceHost"
+      value = trimprefix(module.eks.cluster_endpoint, "https://")
+    }
+  ]
+
+  values = [file("${path.module}/cilium_values.yaml")]
+
+  # Only depends on control plane, NOT on any node group
+  depends_on = [module.eks]
+}

--- a/examples/cilium-with-karpenter/cilium_values.yaml
+++ b/examples/cilium-with-karpenter/cilium_values.yaml
@@ -1,0 +1,58 @@
+kubeProxyReplacement: true
+k8sServicePort: "443"
+agentNotReadyTaintKey: "node.cilium.io/agent-not-ready"
+
+ipam:
+  mode: eni
+
+cni:
+  install: true
+  exclusive: true
+  binPath: /opt/cni/bin
+  confPath: /etc/cni/net.d
+
+priorityClassName: system-node-critical
+
+nodeInit:
+  enabled: true
+  bootstrapFile: "/tmp/cilium-bootstrap-time"
+
+operator:
+  replicas: 1
+  awsEnablePrefixDelegation: true
+  createCiliumNodeResource: true
+  releaseExcessENIIPs: true
+  prometheus:
+    enabled: true
+
+prometheus:
+  enabled: true
+
+routingMode: native
+enableL7Proxy: true
+
+eni:
+  enabled: true
+  awsEnablePrefixDelegation: true
+
+loadBalancer:
+  algorithm: maglev
+  mode: snat
+
+hubble:
+  enabled: true
+  ringbufferSize: 32768
+  ui:
+    enabled: true
+  relay:
+    enabled: true
+  metrics:
+    enableOpenMetrics: true
+    enabled:
+      - dns
+      - drop
+      - tcp
+      - port-distribution
+      - icmp
+      - "flow:labelsContext=source_namespace,source_workload,destination_namespace,destination_workload;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"
+      - "httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction;sourceContext=workload-name|reserved-identity;destinationContext=workload-name|reserved-identity"

--- a/examples/cilium-with-karpenter/inflate.yaml
+++ b/examples/cilium-with-karpenter/inflate.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: inflate
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
+          resources:
+            requests:
+              cpu: 1

--- a/examples/cilium-with-karpenter/karpenter.tf
+++ b/examples/cilium-with-karpenter/karpenter.tf
@@ -1,0 +1,65 @@
+data "aws_ecrpublic_authorization_token" "token" {
+  region = "us-east-1"
+}
+
+module "karpenter" {
+  # source  = "terraform-aws-modules/eks/aws//modules/karpenter"
+  # version = "21.10.1"
+  source = "../../modules/karpenter"
+
+  cluster_name = module.eks.cluster_name
+
+  # Name needs to match role name passed to the EC2NodeClass
+  node_iam_role_use_name_prefix   = false
+  node_iam_role_name              = local.name
+  create_pod_identity_association = true
+  enable_inline_policy            = true
+
+  # Used to attach additional IAM policies to the Karpenter node IAM role
+  node_iam_role_additional_policies = {
+    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    CiliumPolicy                 = aws_iam_policy.aws_cilium_policy.arn
+  }
+
+  tags = local.tags
+
+  depends_on = [module.eks]
+}
+
+################################################################################
+# Karpenter Helm chart & manifests
+################################################################################
+
+resource "helm_release" "karpenter" {
+  namespace           = "kube-system"
+  name                = "karpenter"
+  repository          = "oci://public.ecr.aws/karpenter"
+  repository_username = data.aws_ecrpublic_authorization_token.token.user_name
+  repository_password = data.aws_ecrpublic_authorization_token.token.password
+  chart               = "karpenter"
+  version             = "1.6.0"
+  wait                = false
+
+  values = [
+    <<-EOT
+    nodeSelector:
+      karpenter.sh/controller: 'true'
+    dnsPolicy: Default
+    settings:
+      clusterName: ${module.eks.cluster_name}
+      clusterEndpoint: ${module.eks.cluster_endpoint}
+      interruptionQueue: ${module.karpenter.queue_name}
+      enableZonalShift: true
+    webhook:
+      enabled: false
+    EOT
+  ]
+
+  # Karpenter controller runs on managed nodes — needs both
+  depends_on = [
+    module.eks_managed_node_group,
+    module.karpenter,
+    aws_eks_addon.coredns, # needs DNS to resolve ECR
+  ]
+
+}

--- a/examples/cilium-with-karpenter/karpenter.yaml
+++ b/examples/cilium-with-karpenter/karpenter.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  amiSelectorTerms:
+    - alias: bottlerocket@latest
+  role: ex-cilium-with-karpenter
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: ex-cilium-with-karpenter
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: ex-cilium-with-karpenter
+  tags:
+    karpenter.sh/discovery: ex-cilium-with-karpenter
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      requirements:
+        - key: "karpenter.k8s.aws/instance-category"
+          operator: In
+          values: ["c", "m", "r"]
+        - key: "karpenter.k8s.aws/instance-cpu"
+          operator: In
+          values: ["4", "8", "16", "32"]
+        - key: "karpenter.k8s.aws/instance-hypervisor"
+          operator: In
+          values: ["nitro"]
+        - key: "karpenter.k8s.aws/instance-generation"
+          operator: Gt
+          values: ["2"]
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30s

--- a/examples/cilium-with-karpenter/main.tf
+++ b/examples/cilium-with-karpenter/main.tf
@@ -1,0 +1,112 @@
+data "aws_availability_zones" "available" {}
+
+locals {
+  name   = "ex-${basename(path.cwd)}"
+  region = "us-east-1"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  tags = {
+    Example    = local.name
+    GithubRepo = "terraform-aws-eks"
+    GithubOrg  = "terraform-aws-modules"
+  }
+}
+
+module "eks" {
+  # source  = "terraform-aws-modules/eks/aws"
+  # version = "21.20.0"
+  source = "../.."
+
+  name               = local.name
+  kubernetes_version = "1.35"
+
+  enable_cluster_creator_admin_permissions = true
+  endpoint_public_access                   = true
+
+  control_plane_scaling_config = {
+    tier = "standard"
+  }
+
+  enable_irsa = true
+
+  # NO addons here — coredns needs nodes, add later
+  addons = {
+    eks-pod-identity-agent = {
+      before_compute = true
+      most_recent    = true
+    }
+  }
+
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.private_subnets
+  control_plane_subnet_ids = module.vpc.intra_subnets
+
+  # NO eks_managed_node_groups here — moved below
+
+  node_security_group_tags = merge(local.tags, {
+    "karpenter.sh/discovery" = local.name
+  })
+
+  tags = local.tags
+}
+
+
+# ─── STEP 4: Managed Node Group (Karpenter controller nodes) ─────────────────
+# Nodes join AFTER Cilium is installed. The cilium taint prevents any
+# non-cilium pods from running until the DaemonSet pod is Ready on that node.
+module "eks_managed_node_group" {
+  # source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  # version = "21.10.1"
+  source = "../../modules/eks-managed-node-group"
+
+  name                 = "${local.name}-karpenter"
+  cluster_name         = module.eks.cluster_name
+  cluster_service_cidr = module.eks.cluster_service_cidr
+
+  subnet_ids = module.vpc.private_subnets
+
+  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
+  vpc_security_group_ids            = [module.eks.node_security_group_id]
+
+  ami_type       = "BOTTLEROCKET_x86_64"
+  instance_types = ["m5.large"]
+
+  min_size     = 2
+  max_size     = 6
+  desired_size = 2
+
+  labels = {
+    "karpenter.sh/controller" = "true"
+  }
+
+  taints = {
+    cilium_not_ready = {
+      key    = "node.cilium.io/agent-not-ready"
+      value  = "true"
+      effect = "NO_EXECUTE"
+    }
+  }
+
+  iam_role_use_name_prefix = false
+  iam_role_name            = "${local.name}-karpenter-ng"
+
+  iam_role_additional_policies = {
+    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    CiliumPolicy                 = aws_iam_policy.aws_cilium_policy.arn
+  }
+
+  tags = merge(local.tags, {
+  })
+
+  # Nodes join only after Cilium CNI is registered in the cluster
+  depends_on = [helm_release.cilium]
+}
+
+# ─── STEP 5: EKS Addons that require nodes ───────────────────────────────────
+resource "aws_eks_addon" "coredns" {
+  cluster_name = module.eks.cluster_name
+  addon_name   = "coredns"
+  depends_on   = [module.eks_managed_node_group]
+}

--- a/examples/cilium-with-karpenter/providers.tf
+++ b/examples/cilium-with-karpenter/providers.tf
@@ -1,0 +1,48 @@
+## providers: aws, helm, kubernetes, kubectl
+provider "aws" {
+  region = "us-east-1"
+  alias  = "virginia"
+}
+
+provider "kubectl" {
+  apply_retry_count      = 10
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  load_config_file       = false
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--region", local.region,
+      "--cluster-name", module.eks.cluster_name
+    ]
+  }
+}
+
+
+
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    command     = "aws"
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      command     = "aws"
+    }
+  }
+}

--- a/examples/cilium-with-karpenter/versions.tf
+++ b/examples/cilium-with-karpenter/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.3.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.83"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.7"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/examples/cilium-with-karpenter/vpc.tf
+++ b/examples/cilium-with-karpenter/vpc.tf
@@ -1,0 +1,27 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs             = local.azs
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
+  intra_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 52)]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+    # Tags subnets for Karpenter auto-discovery
+    "karpenter.sh/discovery" = local.name
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
## Description
Adds a new example `examples/karpenter-cilium` demonstrating how to run
Cilium as the sole CNI on an EKS cluster managed by Karpenter, solving
the CNI bootstrap ordering problem entirely within Terraform — no manual
kubectl steps required.

Cilium is configured in ENI native routing mode with kubeProxyReplacement
enabled, Hubble observability, and Maglev load balancing. Karpenter handles
node autoprovisioning with the Cilium not-ready taint applied automatically
to all nodes.

## Motivation and Context
When replacing the default vpc-cni with Cilium on EKS, there is a
well-known chicken-and-egg problem: nodes will not reach Ready state without
a CNI binary present, but Cilium cannot be scheduled without Ready nodes.
Existing workarounds require a manual kubectl patch of the aws-node DaemonSet,
breaking automated provisioning.

This example resolves the ordering entirely in Terraform using three mechanisms:
- helm_release.cilium depends only on the control plane with wait = false,
  so Cilium is registered before any node joins
- The managed node group applies node.cilium.io/agent-not-ready:NoExecute
  taint, preventing workload scheduling until the Cilium agent is ready
- Cilium nodeInit writes the CNI binary to the node filesystem at bootstrap,
  so nodes become Ready immediately after the agent starts
  
## Breaking Changes
None — additive example only.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

Tested on EKS 1.35 / Cilium 1.16.x / Karpenter 1.6.0. Full apply/destroy
cycle completed successfully. Cilium status healthy, kube-proxy replaced,
Hubble relay running, Karpenter provisioning nodes correctly.