### PR TITLE
feat: Split Karpenter policies, align with upstream

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -120,8 +120,14 @@ No modules.
 | [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.controller_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_eks_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_iam_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_interruption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_node_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_resource_discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.controller_zonal_shift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.node_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -71,31 +71,31 @@ resource "aws_iam_role" "controller" {
 }
 
 resource "aws_iam_role_policy" "controller" {
-  count = local.create_iam_role && var.enable_inline_policy ? 1 : 0
+  for_each = local.create_iam_role && var.enable_inline_policy ? local.controller_policies : {}
 
-  name        = var.iam_policy_use_name_prefix ? null : var.iam_policy_name
-  name_prefix = var.iam_policy_use_name_prefix ? "${var.iam_policy_name}-" : null
+  name        = var.iam_policy_use_name_prefix ? null : "${var.iam_policy_name}${each.key}"
+  name_prefix = var.iam_policy_use_name_prefix ? "${var.iam_policy_name}${each.key}-" : null
   role        = aws_iam_role.controller[0].name
-  policy      = data.aws_iam_policy_document.controller[0].json
+  policy      = each.value
 }
 
 resource "aws_iam_policy" "controller" {
-  count = local.create_iam_role && !var.enable_inline_policy ? 1 : 0
+  for_each = local.create_iam_role && !var.enable_inline_policy ? local.controller_policies : {}
 
-  name        = var.iam_policy_use_name_prefix ? null : var.iam_policy_name
-  name_prefix = var.iam_policy_use_name_prefix ? "${var.iam_policy_name}-" : null
+  name        = var.iam_policy_use_name_prefix ? null : "${var.iam_policy_name}${each.key}"
+  name_prefix = var.iam_policy_use_name_prefix ? "${var.iam_policy_name}${each.key}-" : null
   path        = var.iam_policy_path
   description = var.iam_policy_description
-  policy      = data.aws_iam_policy_document.controller[0].json
+  policy      = each.value
 
   tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "controller" {
-  count = local.create_iam_role && !var.enable_inline_policy ? 1 : 0
+  for_each = aws_iam_policy.controller
 
   role       = aws_iam_role.controller[0].name
-  policy_arn = aws_iam_policy.controller[0].arn
+  policy_arn = each.value.arn
 }
 
 resource "aws_iam_role_policy_attachment" "controller_additional" {

--- a/modules/karpenter/policy.tf
+++ b/modules/karpenter/policy.tf
@@ -1,4 +1,22 @@
-data "aws_iam_policy_document" "controller" {
+locals {
+  controller_policies = local.create_iam_role ? merge(
+    {
+      EKSIntegration    = data.aws_iam_policy_document.controller_eks_integration[0].json
+      IAMIntegration    = data.aws_iam_policy_document.controller_iam_integration[0].json
+      NodeLifecycle     = data.aws_iam_policy_document.controller_node_lifecycle[0].json
+      ResourceDiscovery = data.aws_iam_policy_document.controller_resource_discovery[0].json
+      ZonalShift        = data.aws_iam_policy_document.controller_zonal_shift[0].json
+    },
+    local.enable_spot_termination ? {
+      Interruption = data.aws_iam_policy_document.controller_interruption[0].json
+    } : {},
+    var.iam_policy_statements != null ? {
+      Additional = data.aws_iam_policy_document.controller_additional[0].json
+    } : {},
+  ) : {}
+}
+
+data "aws_iam_policy_document" "controller_node_lifecycle" {
   count = local.create_iam_role ? 1 : 0
 
   statement {
@@ -51,7 +69,6 @@ data "aws_iam_policy_document" "controller" {
       "arn:${local.partition}:ec2:${local.region}:*:network-interface/*",
       "arn:${local.partition}:ec2:${local.region}:*:launch-template/*",
       "arn:${local.partition}:ec2:${local.region}:*:spot-instances-request/*",
-      "arn:${local.partition}:ec2:${local.region}:*:capacity-reservation/*"
     ]
     actions = [
       "ec2:RunInstances",
@@ -177,23 +194,26 @@ data "aws_iam_policy_document" "controller" {
       values   = ["*"]
     }
   }
+}
+
+data "aws_iam_policy_document" "controller_resource_discovery" {
+  count = local.create_iam_role ? 1 : 0
 
   statement {
     sid       = "AllowRegionalReadActions"
     resources = ["*"]
     actions = [
       "ec2:DescribeCapacityReservations",
-      "ec2:DescribeAvailabilityZones",
       "ec2:DescribeImages",
       "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
       "ec2:DescribeInstanceTypeOfferings",
       "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplates",
+      "ec2:DescribePlacementGroups",
       "ec2:DescribeSecurityGroups",
-      "ec2:DescribeInstanceStatus",
       "ec2:DescribeSpotPriceHistory",
       "ec2:DescribeSubnets",
-      "ec2:DescribePlacementGroups"
     ]
 
     condition {
@@ -216,6 +236,22 @@ data "aws_iam_policy_document" "controller" {
   }
 
   statement {
+    sid       = "AllowUnscopedInstanceProfileListAction"
+    resources = ["*"]
+    actions   = ["iam:ListInstanceProfiles"]
+  }
+
+  statement {
+    sid       = "AllowInstanceProfileReadActions"
+    resources = ["arn:${local.partition}:iam::${local.account_id}:instance-profile/*"]
+    actions   = ["iam:GetInstanceProfile"]
+  }
+}
+
+data "aws_iam_policy_document" "controller_zonal_shift" {
+  count = local.create_iam_role ? 1 : 0
+
+  statement {
     sid       = "AllowZonalShiftReadActions"
     resources = ["*"]
     actions   = ["arc-zonal-shift:GetManagedResource"]
@@ -225,20 +261,24 @@ data "aws_iam_policy_document" "controller" {
       values   = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
     }
   }
+}
 
-  dynamic "statement" {
-    for_each = local.enable_spot_termination ? [1] : []
+data "aws_iam_policy_document" "controller_interruption" {
+  count = local.create_iam_role && local.enable_spot_termination ? 1 : 0
 
-    content {
-      sid       = "AllowInterruptionQueueActions"
-      resources = [try(aws_sqs_queue.this[0].arn, null)]
-      actions = [
-        "sqs:DeleteMessage",
-        "sqs:GetQueueUrl",
-        "sqs:ReceiveMessage"
-      ]
-    }
+  statement {
+    sid       = "AllowInterruptionQueueActions"
+    resources = [try(aws_sqs_queue.this[0].arn, null)]
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage"
+    ]
   }
+}
+
+data "aws_iam_policy_document" "controller_iam_integration" {
+  count = local.create_iam_role ? 1 : 0
 
   statement {
     sid       = "AllowPassingInstanceRole"
@@ -357,24 +397,20 @@ data "aws_iam_policy_document" "controller" {
       values   = ["*"]
     }
   }
+}
 
-  statement {
-    sid       = "AllowInstanceProfileReadActions"
-    resources = ["arn:${local.partition}:iam::${local.account_id}:instance-profile/*"]
-    actions   = ["iam:GetInstanceProfile"]
-  }
-
-  statement {
-    sid       = "AllowUnscopedInstanceProfileListAction"
-    resources = ["*"]
-    actions   = ["iam:ListInstanceProfiles"]
-  }
+data "aws_iam_policy_document" "controller_eks_integration" {
+  count = local.create_iam_role ? 1 : 0
 
   statement {
     sid       = "AllowAPIServerEndpointDiscovery"
     resources = ["arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}"]
     actions   = ["eks:DescribeCluster"]
   }
+}
+
+data "aws_iam_policy_document" "controller_additional" {
+  count = local.create_iam_role && var.iam_policy_statements != null ? 1 : 0
 
   dynamic "statement" {
     for_each = var.iam_policy_statements != null ? var.iam_policy_statements : []


### PR DESCRIPTION
## Description

The current policy can easily exceed the 6144 chars limit of AWS IAM managed policies. Upstream has split the single policy in 6, to which we add an "Additional" one when using iam_policy_statements.

Align with https://github.com/aws/karpenter-provider-aws/blob/f0d0bba0a5ce845879c12c09cf9f18234dcd8c5d/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml:
- AllowScopedEC2InstanceActionsWithTags: removed capacity-reservation
- AllowRegionalReadActions: removed ec2:DescribeAvailabilityZones

## Motivation and Context

It's getting really easy to bump into the 6144 chars limit, and even if a workaround exists, it's always nicer when everything works out of the box
Fixes #3637

## Breaking Changes
Role doesn't change, but the attached policy is deleted, replaced by up to 7 policies, potentially causing temporarily denied requests. This is transparent for most users.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] manual tests (`enable_inline_policy` / `iam_policy_use_name_prefix` / `create` / `create_iam_role` / ...)
- [X] I have executed `pre-commit run -a` on my pull request

