### PR TITLE
feat: Make kubernetes.io/cluster tag on node security group configurable

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -186,11 +186,11 @@ resource "aws_security_group" "node" {
 
   tags = merge(
     var.tags,
-    {
-      "Name"                              = local.node_sg_name
+    { "Name" = local.node_sg_name },
+    var.node_security_group_set_cluster_tag ? {
       "kubernetes.io/cluster/${var.name}" = "owned"
-    },
-    var.node_security_group_tags
+    } : {},
+    var.node_security_group_tags,
   )
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -497,6 +497,12 @@ variable "node_security_group_tags" {
   default     = {}
 }
 
+variable "node_security_group_set_cluster_tag" {
+  description = "Determines whether the `kubernetes.io/cluster/<name>` tag is applied to the node security group. The EKS-managed cluster primary security group already carries this tag; duplicating it on the node security group can cause the AWS Load Balancer Controller to refuse to manage backend SG rules in IP target mode (resulting in Target.Timeout health checks)."
+  type        = bool
+  default     = true
+}
+
 ################################################################################
 # IRSA
 ################################################################################


### PR DESCRIPTION
**Problem**

The aws_security_group.node resource in [node_groups.tf](vscode-webview://1fp99512jubrt6hh3bbkt0ksrbsddo0fn6lr2gudf7vsgncjcvdm/core-infrastructure/development-account/us-east-1/eks/.terraform/modules/eks_use1/node_groups.tf) unconditionally applies the tag kubernetes.io/cluster/<cluster_name> = "owned" to the module-created node security group. The EKS-managed cluster primary security group (created by AWS when the cluster is provisioned) already carries this exact tag. When both security groups are attached to the same ENI.

AWS Load Balancer Controller refuses to manage backend security group rules in IP target mode. Specifically, it scans the SGs attached to a target pod's ENI for kubernetes.io/cluster/<cluster_name> and bails out when it finds more than one match — because it can't tell which SG is the "true" cluster SG to mutate.

**Symptom**
End-to-end, users see ALB target groups with healthy registrations but Target.Timeout health-check failures. The ALB → pod port is never opened in any SG because the controller never edited a backend rule. There is no log line at error severity from the controller — the failure mode is a silent skip, surfaced only via target health.

**Existing workaround**
Consumers can override the tag to null via var.node_security_group_tags, which the merge at [node_groups.tf:187-194](vscode-webview://1fp99512jubrt6hh3bbkt0ksrbsddo0fn6lr2gudf7vsgncjcvdm/core-infrastructure/development-account/us-east-1/eks/.terraform/modules/eks_use1/node_groups.tf#L187-L194) honors because the user map is merged last:


node_security_group_tags = {
  "kubernetes.io/cluster/${local.eks_cluster_name}" = null
}

**Backward compatibility**
Default value preserves existing tag behavior.
No state movement, no resource replacement for existing consumers leaving the default.
Consumers who set the flag to false will see one tag removed from their node SG — a metadata-only update, no SG replacement.