### PR TITLE
feat: Replace url in `tls_certificate` with dualstack OIDC issuer URL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -447,14 +447,14 @@ locals {
 
   oidc_root_ca_thumbprint = local.create_oidc_provider && var.include_oidc_root_ca_thumbprint ? [data.tls_certificate.this[0].certificates[0].sha1_fingerprint] : []
 
-  dualstack_oidc_issuer_url = try(replace(replace(aws_eks_cluster.this[0].identity[0].oidc[0].issuer, "https://oidc.eks.", "https://oidc-eks."), ".amazonaws.com/", ".api.aws/"), null)
+  dualstack_oidc_issuer_endpoint = try(replace(replace(aws_eks_cluster.this[0].identity[0].oidc[0].issuer, "https://oidc.eks.", "https://oidc-eks."), ".amazonaws.com/", ".api.aws/"), null)
 }
 
 data "tls_certificate" "this" {
   # Not available on outposts
   count = local.create_oidc_provider && var.include_oidc_root_ca_thumbprint ? 1 : 0
 
-  url = local.dualstack_oidc_issuer_url
+  url = var.use_dualstack_oidc_issuer_endpoint ? local.dualstack_oidc_issuer_endpoint : aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 }
 
 resource "aws_iam_openid_connect_provider" "oidc_provider" {

--- a/main.tf
+++ b/main.tf
@@ -463,7 +463,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
 
   client_id_list  = distinct(compact(concat(["sts.amazonaws.com"], var.openid_connect_audiences)))
   thumbprint_list = concat(local.oidc_root_ca_thumbprint, var.custom_oidc_thumbprints)
-  url             = local.dualstack_oidc_issuer_url
+  url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
 
   tags = merge(
     { Name = "${var.name}-eks-irsa" },

--- a/main.tf
+++ b/main.tf
@@ -446,13 +446,15 @@ locals {
   create_oidc_provider = local.create && var.enable_irsa && !local.create_outposts_local_cluster
 
   oidc_root_ca_thumbprint = local.create_oidc_provider && var.include_oidc_root_ca_thumbprint ? [data.tls_certificate.this[0].certificates[0].sha1_fingerprint] : []
+
+  dualstack_oidc_issuer_url = try(replace(replace(aws_eks_cluster.this[0].identity[0].oidc[0].issuer, "https://oidc.eks.", "https://oidc-eks."), ".amazonaws.com/", ".api.aws/"), null)
 }
 
 data "tls_certificate" "this" {
   # Not available on outposts
   count = local.create_oidc_provider && var.include_oidc_root_ca_thumbprint ? 1 : 0
 
-  url = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
+  url = local.dualstack_oidc_issuer_url
 }
 
 resource "aws_iam_openid_connect_provider" "oidc_provider" {
@@ -461,7 +463,7 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
 
   client_id_list  = distinct(compact(concat(["sts.amazonaws.com"], var.openid_connect_audiences)))
   thumbprint_list = concat(local.oidc_root_ca_thumbprint, var.custom_oidc_thumbprints)
-  url             = aws_eks_cluster.this[0].identity[0].oidc[0].issuer
+  url             = local.dualstack_oidc_issuer_url
 
   tags = merge(
     { Name = "${var.name}-eks-irsa" },

--- a/variables.tf
+++ b/variables.tf
@@ -507,6 +507,12 @@ variable "enable_irsa" {
   default     = true
 }
 
+variable "use_dualstack_oidc_issuer_endpoint" {
+  description = "Determines whether to use the dual-stack compatible OIDC issuer endpoint to fetch thumbprint for OIDC provider. Defaults to `false`"
+  type        = bool
+  default     = false
+}
+
 variable "openid_connect_audiences" {
   description = "List of OpenID Connect audience client IDs to add to the IRSA provider"
   type        = list(string)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We faced the following issue while using the eks module via atlantis deployed inside an management eks, as the eks vpc endpoints doesnt support oidc endpoint:
```
╷
│ Error: Failed to identify fetch peer certificates
│ 
│   with module.eks.data.tls_certificate.this[0],
│   on .terraform/modules/eks/main.tf line 451, in data "tls_certificate" "this":
│  451: data "tls_certificate" "this" {
│ 
│ failed to fetch certificates from URL 'https': Get
│ "https://oidc.eks.<region>.amazonaws.com:443/id/xxxxxxxxxxxxxxxxxxxx":
│ dial tcp: lookup oidc.eks.<region>.amazonaws.com on 172.20.0.10:53: no
│ such host
╵
```

Using the dual-stack url should probably fix this issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
