### PR TITLE
feat: Add ability to publish modules to oci repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
       - '**/*.tf'
       - '.github/workflows/release.yml'
 
+env:
+  RELEASE_VERSION: "25.0.0"
+
 jobs:
   release:
     name: Release
@@ -40,6 +43,50 @@ jobs:
       - name: Release
         uses: cycjimmy/semantic-release-action@v5
         with:
-          semantic_version: 25.0.0
+          semantic_version: ${{ env.RELEASE_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+
+  tofu-modules:
+    name: Release OCI artifact
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write # needed to publish oci artifact to ghcr.io
+    # Skip running release workflow on forks
+    if: github.repository_owner == 'terraform-aws-modules'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Login to registry
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install oras tool
+        uses: oras-project/setup-oras@v2.0.0
+
+      - name: Create zip file
+        run: |-
+          mkdir -p /home/runner/work/modules
+          zip -r /home/runner/work/modules/terraform-aws-eks.zip . -x "*.git*"
+
+      - name: Publish Artifact
+        working-directory: /home/runner/work/modules
+        run: |-
+          oras push ghcr.io/${{ github.repository_owner }}/opentofu-modules/eks:latest \
+            --artifact-type application/vnd.opentofu.modulepkg \
+            terraform-aws-eks.zip:archive/zip
+
+      - name: Create tagged version
+        run: |-
+
+      - name: Create manifest list and pushes
+        run: |-
+          oras tag  ghcr.io/${{ github.repository_owner }}/opentofu-modules/eks:latest ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
## Description
This PR allows for publishing the terraform module as an oci artifact to `ghcr.io`

## Motivation and Context

When working in environment that limited or no access to the internet, there is a lot of tooling around storing OCI artifacts. So this allow the EKS module to be pulled across as an OCI artiacts and allow `opentofu` to consume the artiacts

## Breaking Changes

No breaking changes

## References

- [`opentofu v1.10.0`](https://opentofu.org/blog/opentofu-1-10-0/)
- [`OneUptime/blog`](https://github.com/OneUptime/blog/blob/f0a2de477727900430d0cec6b5a1336896230225/posts/2026-03-20-oci-registry-support-opentofu-1-10/README.md)
- [`pewpewpotato/scaling-units`](https://github.com/pewpewpotato/scaling-units/blob/8866e79c3d98d71814612703a15d589bdead03c4/docs/how-to-publish-opentofu-module-to-oci.md)

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
