### PR TITLE
feat: Expose before_compute addons as a separate output

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ We are grateful to the community for contributing bugfixes and improvements! Ple
 | <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
 | <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
 | <a name="output_cluster_addons"></a> [cluster\_addons](#output\_cluster\_addons) | Map of attribute maps for all EKS cluster addons enabled |
+| <a name="output_cluster_addons_before_compute"></a> [cluster\_addons\_before\_compute](#output\_cluster\_addons\_before\_compute) | Map of attribute maps for all EKS cluster addons created before the data plane compute resources (e.g. vpc-cni) |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The Amazon Resource Name (ARN) of the cluster |
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |
 | <a name="output_cluster_control_plane_scaling_tier"></a> [cluster\_control\_plane\_scaling\_tier](#output\_cluster\_control\_plane\_scaling\_tier) | The EKS Provisioned Control Plane scaling tier for the cluster |

--- a/outputs.tf
+++ b/outputs.tf
@@ -220,6 +220,11 @@ output "cluster_addons" {
   value       = merge(aws_eks_addon.this, aws_eks_addon.before_compute)
 }
 
+output "cluster_addons_before_compute" {
+  description = "Map of attribute maps for all EKS cluster addons created before the data plane compute resources (e.g. vpc-cni)"
+  value       = aws_eks_addon.before_compute
+}
+
 ################################################################################
 # EKS Identity Provider
 ################################################################################


### PR DESCRIPTION
## Description
Add `cluster_addons_before_compute` output exposing `aws_eks_addon.before_compute` on its own.

## Motivation and Context
The only addon output today is `cluster_addons`, which merges the before-compute and post-compute addons. Consumers running VPC CNI custom networking need to anchor ENIConfig creation on vpc-cni readiness, but referencing the merged output pulls in the post-compute addons, which depend on the node groups, which under custom networking cannot become Ready until ENIConfig exists, creating a dependency cycle.

## Breaking Changes
Purely additive; no behavior change, no new resources
