### PR TITLE
docs: Fix FAQ example for not attaching the cluster primary security group

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,13 +41,13 @@ By default, EKS creates a cluster primary security group that is created outside
 ```hcl
   eks_managed_node_groups = {
     example = {
-      attach_cluster_primary_security_group = true # default is false
+      attach_cluster_primary_security_group = false # default is false
     }
   }
   # Or for self-managed
   self_managed_node_groups = {
     example = {
-      attach_cluster_primary_security_group = true # default is false
+      attach_cluster_primary_security_group = false # default is false
     }
   }
 ```


### PR DESCRIPTION
## Description

Fixes the FAQ entry [_I received an error: `expect exactly one securityGroup tagged with kubernetes.io/cluster/<CLUSTER_NAME> ...`_](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#i-received-an-error-expect-exactly-one-securitygroup-tagged-with-kubernetesioclustercluster_name-).

The entry lists two opposite approaches for resolving the error, but both showed the **same** example. The second case — "By not attaching the cluster primary security group" — still set `attach_cluster_primary_security_group = true`, which is the *attaching* behavior described in the first case. This corrects the second example to `attach_cluster_primary_security_group = false` so it actually demonstrates *not* attaching the cluster primary security group (matching the `# default is false` comment already present).

Closes #3724

## Motivation and Context

The contradictory example is confusing for users hitting the `expect exactly one securityGroup ...` error — the "not attaching" remedy showed code that attaches.

## Breaking Changes

None — documentation only.

## How Has This Been Tested?

- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

Documentation-only change (`docs/faq.md`); no Terraform code paths are affected.