### PR TITLE
fix: Ignore desired_capacity_type drift on self-managed node group ASG

### DIFF
--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -807,7 +807,8 @@ resource "aws_autoscaling_group" "this" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
-      desired_capacity
+      desired_capacity,
+      desired_capacity_type,
     ]
   }
 }


### PR DESCRIPTION
## Description

When `desired_size_type` (→ `desired_capacity_type`) is left unset, AWS populates it
server-side (e.g. after a console-driven capacity change, or when `instance_requirements`
is in use). The next apply then plans `desired_capacity_type = "units" -> null`, which the
API rejects:

    ValidationError: Value '' at 'desiredCapacityType' failed to satisfy constraint:
    Member must have length greater than or equal to 1

This adds `desired_capacity_type` to the existing `ignore_changes` on
`aws_autoscaling_group.this` in `self-managed-node-group`, matching the precedent already
set for `desired_capacity` directly above it.

Fixes #3723. The root cause is the provider bug hashicorp/terraform-provider-aws#37523;
this is a module-level mitigation that does not depend on the provider fix landing.

The issue also suggested option 2 (defaulting `desired_size_type` to "units" when unset).
This PR takes option 1 because it follows the in-module `desired_capacity` precedent and is
backward compatible. Happy to switch if you prefer option 2.

## Breaking Changes

No.

## How Has This Been Tested?

- [x] `terraform fmt` and `terraform validate` pass
- [x] `tflint` clean
