### PR TITLE
feat: Add enable_efa_placement_group to decouple EFA from Cluster Placement Group

### DIFF
--- a/modules/eks-managed-node-group/main.tf
+++ b/modules/eks-managed-node-group/main.tf
@@ -707,7 +707,7 @@ resource "aws_iam_role_policy" "this" {
 ################################################################################
 
 locals {
-  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
+  create_placement_group = var.create && ((local.enable_efa_support && var.enable_efa_placement_group) || var.create_placement_group)
 }
 
 resource "aws_placement_group" "this" {

--- a/modules/eks-managed-node-group/variables.tf
+++ b/modules/eks-managed-node-group/variables.tf
@@ -420,6 +420,13 @@ variable "create_placement_group" {
   nullable    = false
 }
 
+variable "enable_efa_placement_group" {
+  description = "Determines whether to automatically create a Cluster Placement Group when EFA is enabled. Set to `false` when using On-Demand Capacity Reservations (ODCRs) or Capacity Blocks that are not configured with a placement group"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
 variable "private_dns_name_options" {
   description = "The options for the instance hostname. The default values are inherited from the subnet"
   type = object({

--- a/modules/self-managed-node-group/main.tf
+++ b/modules/self-managed-node-group/main.tf
@@ -964,7 +964,7 @@ resource "aws_iam_role_policy" "this" {
 ################################################################################
 
 locals {
-  create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
+  create_placement_group = var.create && ((local.enable_efa_support && var.enable_efa_placement_group) || var.create_placement_group)
 }
 
 resource "aws_placement_group" "this" {

--- a/modules/self-managed-node-group/variables.tf
+++ b/modules/self-managed-node-group/variables.tf
@@ -347,6 +347,13 @@ variable "create_placement_group" {
   nullable    = false
 }
 
+variable "enable_efa_placement_group" {
+  description = "Determines whether to automatically create a Cluster Placement Group when EFA is enabled. Set to `false` when using On-Demand Capacity Reservations (ODCRs) or Capacity Blocks that are not configured with a placement group"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
 variable "private_dns_name_options" {
   description = "The options for the instance hostname. The default values are inherited from the subnet"
   type = object({

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -357,6 +357,7 @@ module "eks_managed_node_group" {
   enable_efa_only                    = each.value.enable_efa_only
   efa_indices                        = each.value.efa_indices
   create_placement_group             = each.value.create_placement_group
+  enable_efa_placement_group         = each.value.enable_efa_placement_group
   placement                          = each.value.placement
   network_interfaces                 = each.value.network_interfaces
   network_performance_options        = each.value.network_performance_options
@@ -432,6 +433,7 @@ module "self_managed_node_group" {
   context                 = each.value.context
 
   create_placement_group    = each.value.create_placement_group
+  enable_efa_placement_group = try(each.value.enable_efa_placement_group, true)
   placement_group           = each.value.placement_group
   health_check_type         = each.value.health_check_type
   health_check_grace_period = each.value.health_check_grace_period

--- a/variables.tf
+++ b/variables.tf
@@ -836,6 +836,7 @@ variable "self_managed_node_groups" {
     protect_from_scale_in            = optional(bool)
     context                          = optional(string)
     create_placement_group           = optional(bool)
+    enable_efa_placement_group       = optional(bool, true)
     placement_group                  = optional(string)
     health_check_type                = optional(string)
     health_check_grace_period        = optional(number)
@@ -1391,6 +1392,7 @@ variable "eks_managed_node_groups" {
     enable_efa_only        = optional(bool)
     efa_indices            = optional(list(string))
     create_placement_group = optional(bool)
+    enable_efa_placement_group = optional(bool, true)
     placement = optional(object({
       affinity                = optional(string)
       availability_zone       = optional(string)


### PR DESCRIPTION
## Description

When `enable_efa_support = true`, the module unconditionally creates a Cluster Placement Group via:

```hcl
create_placement_group = var.create && (local.enable_efa_support || var.create_placement_group)
```

This causes `InsufficientInstanceCapacity` errors when launching instances against **On-Demand Capacity Reservations (ODCRs)** or **Capacity Blocks** that were not provisioned with a matching placement group. The ODCR is active and allocated, but the RunInstances request includes a CPG constraint that doesn't match the reservation, so EC2 cannot guarantee capacity delivery.

## Problem

Customers using GPU instances (e.g., p6-b200.48xlarge) with:
- EFA enabled (for high-bandwidth networking)
- ODCR or Capacity Blocks (for guaranteed GPU capacity)

Hit ICE errors because the module forces a CPG that the reservation doesn't have.

## Solution

Add a new variable `enable_efa_placement_group` (default: `true` for backward compatibility) that allows users to enable EFA without forcing a Cluster Placement Group:

```hcl
create_placement_group = var.create && ((local.enable_efa_support && var.enable_efa_placement_group) || var.create_placement_group)
```

### Usage

```hcl
module "eks_managed_node_group" {
  # Enable EFA without Cluster Placement Group (for ODCR compatibility)
  enable_efa_support         = true
  enable_efa_placement_group = false
}
```

## Changes

- `modules/eks-managed-node-group/main.tf` — Decouple EFA from CPG creation
- `modules/eks-managed-node-group/variables.tf` — Add `enable_efa_placement_group` variable
- `modules/self-managed-node-group/main.tf` — Same fix
- `modules/self-managed-node-group/variables.tf` — Same variable
- `node_groups.tf` — Passthrough for both module types
- `variables.tf` — Add to root module type definitions

## Backward Compatibility

✅ Fully backward compatible. Default is `true`, preserving existing behavior. Only customers who explicitly set `enable_efa_placement_group = false` will see changed behavior.

## Real-World Use Case

Customer with 4x p6-b200.48xlarge ODCR in us-east-2b couldn't launch their 4th GPU instance because the EKS Terraform module automatically added a CPG that didn't match the ODCR. EC2 on-call confirmed: "User has a placement group constraint, only reservations for placement group X are guaranteed. Insufficient capacity within placement group constraint."