### PR TITLE
fix: Add IAM permissions for CNI subnet discovery

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -37,7 +37,9 @@ data "aws_iam_policy_document" "cni_ipv6_policy" {
       "ec2:DescribeInstances",
       "ec2:DescribeTags",
       "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribeInstanceTypes"
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Fixes #3733\n\nAmazon VPC CNI v1.22.1 enables enhanced subnet discovery and requires\nec2:DescribeSecurityGroups and ec2:DescribeSubnets for the customer-managed\nIPv6 CNI policy. Add both actions to the policy document so aws-node can start\nafter the CNI upgrade.\n\nValidation:\n- git diff --check\n- terraform fmt could not be run locally because Terraform is not installed