### PR TITLE
feat: Add opt-in aws:SourceArn condition to Karpenter controller IAM role trust policy

### DIFF
--- a/modules/karpenter/README.md
+++ b/modules/karpenter/README.md
@@ -156,6 +156,7 @@ No modules.
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Path of the IAM role | `string` | `"/"` | no |
 | <a name="input_iam_role_permissions_boundary_arn"></a> [iam\_role\_permissions\_boundary\_arn](#input\_iam\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for the IAM role | `string` | `null` | no |
 | <a name="input_iam_role_policies"></a> [iam\_role\_policies](#input\_iam\_role\_policies) | Policies to attach to the IAM role in `{'static_name' = 'policy_arn'}` format | `map(string)` | `{}` | no |
+| <a name="input_iam_role_source_arn_condition"></a> [iam\_role\_source\_arn\_condition](#input\_iam\_role\_source\_arn\_condition) | Whether to add an `aws:SourceArn` condition to the Karpenter controller IAM role's trust policy, scoped to this cluster | `bool` | `false` | no |
 | <a name="input_iam_role_source_assume_policy_documents"></a> [iam\_role\_source\_assume\_policy\_documents](#input\_iam\_role\_source\_assume\_policy\_documents) | A list of IAM policy documents to use as a source for the assume role policy document for the Karpenter controller IAM role | `list(string)` | `[]` | no |
 | <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add the the IAM role | `map(string)` | `{}` | no |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the name of the IAM role (`iam_role_name`) is used as a prefix | `bool` | `true` | no |

--- a/modules/karpenter/main.tf
+++ b/modules/karpenter/main.tf
@@ -51,6 +51,19 @@ data "aws_iam_policy_document" "controller_assume_role" {
       type        = "Service"
       identifiers = ["pods.eks.amazonaws.com"]
     }
+
+    dynamic "condition" {
+      for_each = var.iam_role_source_arn_condition ? [1] : []
+
+      content {
+        test     = "ArnEquals"
+        variable = "aws:SourceArn"
+
+        values = [
+          "arn:${local.partition}:eks:${local.region}:${local.account_id}:cluster/${var.cluster_name}",
+        ]
+      }
+    }
   }
 }
 

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -110,6 +110,12 @@ variable "iam_role_override_assume_policy_documents" {
   default     = []
 }
 
+variable "iam_role_source_arn_condition" {
+  description = "Whether to add an `aws:SourceArn` condition to the Karpenter controller IAM role's trust policy, scoped to this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "iam_role_source_assume_policy_documents" {
   description = "A list of IAM policy documents to use as a source for the assume role policy document for the Karpenter controller IAM role"
   type        = list(string)


### PR DESCRIPTION
## Description

Adds a new `iam_role_source_arn_condition` variable to the `karpenter` sub-module.
When set to `true`, an `aws:SourceArn` condition scoped to this cluster is added to the Karpenter controller IAM role's Pod Identity trust statement.

## Motivation and Context

`pods.eks.amazonaws.com` names no cluster, so the controller role is assumable from any cluster in the account that can pass it. 

This is the controller-side counterpart to #3695, which added the same opt-in for the node IAM role. The ARN is built from the existing locals the same way `modules/fargate-profile` builds its `aws:SourceArn` condition (#3039).
No new inputs or data sources.

## Breaking Changes

None.
Opt-in, default `false` 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request