### PR TITLE
fix: add CNI enhanced subnet discovery permissions

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -37,7 +37,9 @@ data "aws_iam_policy_document" "cni_ipv6_policy" {
       "ec2:DescribeInstances",
       "ec2:DescribeTags",
       "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribeInstanceTypes"
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Fixes #3733

## Summary
- add `ec2:DescribeSecurityGroups` to the IPv6 CNI IAM policy
- add `ec2:DescribeSubnets` for enhanced subnet discovery in newer Amazon VPC CNI releases

<!-- pr-relay-job relay-120-5045ca118a8919c9a0cd -->