### PR TITLE
fix: Correct aws:RequestTag/eks:kubernetes-cni-node-name test

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -699,7 +699,7 @@ data "aws_iam_policy_document" "custom" {
       }
 
       condition {
-        test     = "StringEquals"
+        test     = "StringLike"
         variable = "aws:RequestTag/eks:kubernetes-cni-node-name"
         values   = ["*"]
       }


### PR DESCRIPTION
## Description
The `StringEquals` test looks for a literal match, but we need `StringLike` as per the reference policy in the EKS docs: https://docs.aws.amazon.com/eks/latest/userguide/auto-cluster-iam-role.html#tag-prop

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
NO

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
