### PR TITLE
fix: Add missing IAM permissions to IPv6 CNI policy

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -35,6 +35,8 @@ data "aws_iam_policy_document" "cni_ipv6_policy" {
     actions = [
       "ec2:AssignIpv6Addresses",
       "ec2:DescribeInstances",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
       "ec2:DescribeTags",
       "ec2:DescribeNetworkInterfaces",
       "ec2:DescribeInstanceTypes"


### PR DESCRIPTION
## Description

Amazon VPC CNI v1.22.1 introduced enhanced subnet discovery, which requires `ec2:DescribeSecurityGroups` and `ec2:DescribeSubnets`. Without these permissions, the CNI add-on can fail to start and report as unhealthy.

## Motivation and Context

The module-managed `AmazonEKS_CNI_IPv6_Policy` (`node_groups.tf`) was missing both actions. The current upstream IPv6 IAM policy documented in [aws/amazon-vpc-cni-k8s docs/iam-policy.md](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/iam-policy.md#ipv6-mode) already includes `ec2:DescribeSecurityGroups` and `ec2:DescribeSubnets` alongside the other actions in this statement:

```json
"Action": [
    "ec2:AssignIpv6Addresses",
    "ec2:DescribeInstances",
    "ec2:DescribeSecurityGroups",
    "ec2:DescribeSubnets",
    "ec2:DescribeTags",
    "ec2:DescribeNetworkInterfaces",
    "ec2:DescribeInstanceTypes"
]
```

This PR brings the module's policy in sync with that upstream definition. Note that Security Group Discovery itself was reverted in v1.22.2, but both actions remain part of the current upstream IPv6 policy document, so syncing against the current upstream policy (rather than only the v1.22.1 release note) is the more durable justification here.

Fixes #3733

## Breaking Changes

No. This only appends two read-only `Describe*` actions to an existing policy statement.

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `terraform fmt` and `terraform validate` on the changed file
- [ ] I have executed `pre-commit run -a` on my pull request